### PR TITLE
Chore: Git hooks + CI checks for lint, TypeScript, build, and E2E

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Husky and shell hooks must use LF so shebangs work on Windows (Git Bash) and Unix.
+.husky/** text eol=lf
+*.sh text eol=lf

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,4 +1,4 @@
-name: E2E Tests
+name: Lint, typecheck, build, and E2E
 
 on:
   push:
@@ -33,6 +33,12 @@ jobs:
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
+
+      - name: ESLint
+        run: npm run lint
+
+      - name: TypeScript
+        run: npm run typecheck
 
       - name: Build application
         run: npm run build

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+# Blocks commit if staged files fail ESLint (with fixes applied) or TypeScript check fails.
+# Bypass (emergency only): HUSKY=0 git commit ...
+set -e
+
+echo ""
+echo "=== pre-commit: lint-staged (ESLint) ==="
+npx lint-staged
+
+echo ""
+echo "=== pre-commit: TypeScript (tsc --noEmit) ==="
+npm run typecheck
+
+echo ""
+echo "OK pre-commit passed"
+echo ""

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# Blocks push if lint, types, production build, or E2E tests fail.
+# Bypass (emergency only): git push --no-verify  OR  HUSKY=0 git push
+set -e
+
+echo ""
+echo "=== pre-push: ESLint (full project) ==="
+npm run lint
+
+echo ""
+echo "=== pre-push: TypeScript ==="
+npm run typecheck
+
+echo ""
+echo "=== pre-push: production build ==="
+npm run build
+
+echo ""
+echo "=== pre-push: Playwright E2E ==="
+npm run test:e2e
+
+echo ""
+echo "OK pre-push passed"
+echo ""

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,7 @@ const nextConfig: NextConfig = {
     devtoolSegmentExplorer: false,
   },
   images: {
+    qualities: [75, 85, 100],
     // Configure ImageKit as a remote pattern for Next.js Image optimization
     // This enables future use of Next.js Image component with ImageKit URLs
     remotePatterns: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -3573,9 +3573,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001753",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001753.tgz",
-      "integrity": "sha512-Bj5H35MD/ebaOV4iDLqPEtiliTN29qkGtEHCwawWn4cYm+bPJM2NsaP30vtZcnERClMzp52J4+aw2UNbK4o+zw==",
+      "version": "1.0.30001788",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,8 @@
         "autoprefixer": "^10.4.21",
         "eslint": "^9",
         "eslint-config-next": "^15.3.0",
+        "husky": "^9.1.7",
+        "lint-staged": "^15.4.3",
         "playwright": "^1.56.1",
         "postcss": "^8.5.3",
         "tailwindcss": "^4.1.4",
@@ -3081,6 +3083,35 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -3642,6 +3673,39 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^5.0.0",
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -3677,6 +3741,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -3687,6 +3758,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/concat-map": {
@@ -3976,6 +4057,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/es-abstract": {
@@ -4596,6 +4690,37 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -4885,6 +5010,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -4929,6 +5067,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-symbol-description": {
@@ -5127,6 +5278,32 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/ieee754": {
@@ -5407,6 +5584,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-generator-function": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
@@ -5525,6 +5715,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-string": {
@@ -6018,6 +6221,78 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lint-staged": {
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.5.2.tgz",
+      "integrity": "sha512-YUSOLq9VeRNAo/CTaVmhGDKG+LBtA8KF1X4K5+ykMSwWST1vDxJRB2kv2COgLb1fvpCo+A/y9A0G0znNVmdx4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^13.1.0",
+        "debug": "^4.4.0",
+        "execa": "^8.0.1",
+        "lilconfig": "^3.1.3",
+        "listr2": "^8.2.5",
+        "micromatch": "^4.0.8",
+        "pidtree": "^0.6.0",
+        "string-argv": "^0.3.2",
+        "yaml": "^2.7.0"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.3.3.tgz",
+      "integrity": "sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^4.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -6054,6 +6329,72 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -6139,6 +6480,13 @@
         }
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -6182,6 +6530,32 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mimic-response": {
@@ -6408,6 +6782,35 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -6537,6 +6940,22 @@
       "optional": true,
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -6687,6 +7106,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pidtree": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/playwright": {
@@ -7168,6 +7600,39 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -7178,6 +7643,13 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -7485,6 +7957,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/simple-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
@@ -7532,6 +8017,36 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/sonner": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.3.tgz",
@@ -7567,6 +8082,41 @@
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
@@ -7681,6 +8231,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -7689,6 +8255,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strip-json-comments": {
@@ -8336,12 +8915,59 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -8,11 +8,20 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "typecheck": "tsc --noEmit",
+    "validate": "npm run lint && npm run typecheck && npm run build && npm run test:e2e",
+    "postinstall": "node scripts/ensure-husky-hooks.mjs",
+    "prepare": "husky",
     "clean": "rm -rf .next && rm -rf node_modules/.cache",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:debug": "playwright test --debug"
+  },
+  "lint-staged": {
+    "*.{js,jsx,mjs,cjs,ts,tsx}": [
+      "eslint --max-warnings 0 --fix"
+    ]
   },
   "dependencies": {
     "@headlessui/react": "^2.2.2",
@@ -59,6 +68,8 @@
     "autoprefixer": "^10.4.21",
     "eslint": "^9",
     "eslint-config-next": "^15.3.0",
+    "husky": "^9.1.7",
+    "lint-staged": "^15.4.3",
     "playwright": "^1.56.1",
     "postcss": "^8.5.3",
     "tailwindcss": "^4.1.4",

--- a/scripts/ensure-husky-hooks.mjs
+++ b/scripts/ensure-husky-hooks.mjs
@@ -1,0 +1,47 @@
+/**
+ * Ensures core.hooksPath is set for Husky 9 (.husky/_).
+ * Fixes corrupted values (e.g. "-v/_") after bad invocations. Safe when no .git (e.g. some Docker extracts).
+ */
+import { execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+const EXPECTED = ".husky/_";
+
+function run(cmd) {
+  return execSync(cmd, { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] }).trim();
+}
+
+function main() {
+  try {
+    run("git rev-parse --git-dir");
+  } catch {
+    return;
+  }
+
+  if (!existsSync(path.join(process.cwd(), ".husky", "_"))) {
+    return;
+  }
+
+  let current = "";
+  try {
+    current = run("git config --get core.hooksPath");
+  } catch {
+    current = "";
+  }
+
+  if (current === EXPECTED) {
+    return;
+  }
+
+  console.warn(
+    `[husky] Repairing core.hooksPath (was ${current ? JSON.stringify(current) : "unset"}) -> ${EXPECTED}`,
+  );
+  try {
+    execSync(`git config core.hooksPath ${EXPECTED}`, { stdio: "inherit" });
+  } catch {
+    console.warn("[husky] Could not set core.hooksPath; run: npx husky");
+  }
+}
+
+main();

--- a/src/app/(main)/about/page.tsx
+++ b/src/app/(main)/about/page.tsx
@@ -50,7 +50,7 @@ export default function AboutPage() {
                 src="/highlights/Akomapa-69.jpg"
                 alt="Akomapa Health Foundation Team"
                 fill
-                priority
+                sizes="(min-width: 1024px) 50vw, 100vw"
                 className="object-cover"
               />
               <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-transparent" />

--- a/src/app/(main)/about/team/page.tsx
+++ b/src/app/(main)/about/team/page.tsx
@@ -348,6 +348,7 @@ function BioModal({
                       src={member.image}
                       alt={member.name}
                       fill
+                      sizes="(min-width: 768px) 672px, 100vw"
                       className="object-cover object-center"
                       quality={100}
                     />

--- a/src/app/(main)/clinics/akomapa-nhp/page.tsx
+++ b/src/app/(main)/clinics/akomapa-nhp/page.tsx
@@ -226,7 +226,7 @@ export default function NHPClinicPage() {
                 src="/highlights/yale-uni.jpg"
                 alt="Akomapa–NHP Yale Clinic community screening event"
                 fill
-                priority
+                sizes="(min-width: 1024px) 50vw, 100vw"
                 className="object-cover object-center"
               />
               <div className="absolute inset-0 bg-gradient-to-t from-black/35 via-transparent to-transparent" />
@@ -272,6 +272,7 @@ export default function NHPClinicPage() {
                   src="/highlights/yale-med.jpg"
                   alt="Community health screening in New Haven"
                   fill
+                  sizes="(min-width: 1024px) 50vw, 100vw"
                   className="object-cover object-center"
                 />
                 <div className="absolute inset-0 bg-gradient-to-t from-black/25 via-transparent to-transparent" />
@@ -299,6 +300,7 @@ export default function NHPClinicPage() {
                 src="/highlights/yale-nhp-program.jpg"
                 alt="Community health education and screening"
                 fill
+                sizes="(min-width: 1024px) 45vw, 100vw"
                 className="object-cover object-center"
               />
               <div className="absolute inset-0 bg-gradient-to-t from-black/35 via-transparent to-transparent" />
@@ -388,6 +390,7 @@ export default function NHPClinicPage() {
                     src={partner.logo}
                     alt={partner.name}
                     fill
+                    sizes="(min-width: 1024px) 18rem, 45vw"
                     className="object-contain transition-transform duration-300 ease-out group-hover:scale-105"
                   />
                 </div>

--- a/src/app/(main)/clinics/akomapa-ucc/page.tsx
+++ b/src/app/(main)/clinics/akomapa-ucc/page.tsx
@@ -325,7 +325,7 @@ export default function UCCClinicPage() {
                 src="/akomapa-hangout/Akomapa_hangout-114.jpg"
                 alt="Akomapa clinic team supporting community members at UCC"
                 fill
-                priority
+                sizes="(min-width: 1024px) 50vw, 100vw"
                 className="object-cover object-center"
               />
               <div className="absolute inset-0 bg-gradient-to-t from-black/35 via-transparent to-transparent" />
@@ -378,6 +378,7 @@ export default function UCCClinicPage() {
                   src="/highlights/Akomapa-69.jpg"
                   alt="Students collaborating inside the Akomapa UCC clinic"
                   fill
+                  sizes="(min-width: 1024px) 50vw, 100vw"
                   className="object-cover object-center"
                 />
                 <div className="absolute inset-0 bg-gradient-to-t from-black/25 via-transparent to-transparent" />
@@ -464,7 +465,6 @@ export default function UCCClinicPage() {
                     fill
                     className="object-cover object-top"
                     sizes="(min-width: 1024px) 25vw, (min-width: 640px) 45vw, 50vw"
-                    priority
                   />
                 </div>
               ))}

--- a/src/app/(main)/clinics/akomapa-ug/page.tsx
+++ b/src/app/(main)/clinics/akomapa-ug/page.tsx
@@ -395,7 +395,7 @@ export default function UGClinicPage() {
                 src="/university-of-ghana.jpg"
                 alt="Student leaders planning the Akomapa UG Clinic launch"
                 fill
-                priority
+                sizes="(min-width: 1024px) 50vw, 100vw"
                 className="object-cover object-center"
               />
               <div className="absolute inset-0 bg-gradient-to-t from-black/35 via-transparent to-transparent" />
@@ -447,6 +447,7 @@ export default function UGClinicPage() {
                   src="/highlights/Akomapa-18.jpg"
                   alt="Students collaborating to design the Akomapa UG Clinic"
                   fill
+                  sizes="(min-width: 1024px) 50vw, 100vw"
                   className="object-cover object-center"
                 />
                 <div className="absolute inset-0 bg-gradient-to-t from-black/25 via-transparent to-transparent" />
@@ -474,6 +475,7 @@ export default function UGClinicPage() {
                 src="/highlights/Akomapa-7.jpg"
                 alt="Students collaborating to design the Akomapa UG Clinic"
                 fill
+                sizes="(min-width: 1024px) 45vw, 100vw"
                 className="object-cover object-center"
               />
               <div className="absolute inset-0 bg-gradient-to-t from-black/35 via-transparent to-transparent" />
@@ -545,6 +547,7 @@ export default function UGClinicPage() {
                 src="/highlights/Akomapa-5.jpg"
                 alt="Community outreach event led by student volunteers"
                 fill
+                sizes="(min-width: 1024px) 45vw, 100vw"
                 className="object-cover object-center"
               />
               <div className="absolute inset-0 bg-gradient-to-t from-black/35 via-transparent to-transparent" />
@@ -586,6 +589,7 @@ export default function UGClinicPage() {
                     src={partner.logo}
                     alt={partner.name}
                     fill
+                    sizes="(min-width: 1024px) 16rem, 40vw"
                     className="object-contain transition-transform duration-300 ease-out filter grayscale group-hover:scale-105 group-hover:grayscale-0"
                   />
                 </div>

--- a/src/app/(main)/clinics/page.tsx
+++ b/src/app/(main)/clinics/page.tsx
@@ -195,7 +195,7 @@ export default function ClinicsPage() {
                 src="/highlights/Akomapa-64.jpg"
                 alt="Akomapa clinic team supporting community members"
                 fill
-                priority
+                sizes="(min-width: 1024px) 50vw, 100vw"
                 className="object-cover"
               />
               <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-transparent" />
@@ -252,6 +252,7 @@ export default function ClinicsPage() {
                         src={pillar.image}
                         alt={pillar.alt}
                         fill
+                        sizes="(min-width: 1024px) 50vw, 100vw"
                         className="object-cover"
                       />
                       <div className="absolute inset-0 bg-gradient-to-t from-black/25 via-transparent to-transparent" />
@@ -364,6 +365,7 @@ export default function ClinicsPage() {
                     src={clinic.image}
                     alt={clinic.name}
                     fill
+                    sizes="(min-width: 1024px) 33vw, 100vw"
                     className="object-cover group-hover:scale-110 transition-transform duration-300"
                   />
                   <div className="absolute top-4 left-4">

--- a/src/app/(main)/donate/page.tsx
+++ b/src/app/(main)/donate/page.tsx
@@ -118,6 +118,7 @@ export default function DonatePage() {
             src="/highlights/Akomapa-73.jpg"
             alt="group of people"
             fill
+            sizes="100vw"
             className="object-cover"
           />
         </div>
@@ -316,6 +317,7 @@ export default function DonatePage() {
                               src="/gallery/gallery-pic-4.JPG"
                               alt="Healthcare professionals providing compassionate care"
                               fill
+                              sizes="(min-width: 1024px) 50vw, 100vw"
                               className="object-cover"
                             />
                           </motion.div>
@@ -339,6 +341,7 @@ export default function DonatePage() {
                               src="/highlights/Akomapa-66.jpg"
                               alt="Students leading clinical care in community settings"
                               fill
+                              sizes="(min-width: 1024px) 50vw, 100vw"
                               className="object-cover"
                             />
                           </motion.div>
@@ -362,6 +365,7 @@ export default function DonatePage() {
                               src="/gallery/gallery-pic-24.JPG"
                               alt="Global health leadership training in action"
                               fill
+                              sizes="(min-width: 1024px) 50vw, 100vw"
                               className="object-cover"
                             />
                           </motion.div>
@@ -385,6 +389,7 @@ export default function DonatePage() {
                               src="/highlights/Akomapa-30.jpg"
                               alt="Community partnership and collaboration"
                               fill
+                              sizes="(min-width: 1024px) 50vw, 100vw"
                               className="object-cover"
                             />
                           </motion.div>
@@ -408,6 +413,7 @@ export default function DonatePage() {
                               src="/highlights/Akomapa-23.jpg"
                               alt="Expert supervision ensuring quality care"
                               fill
+                              sizes="(min-width: 1024px) 50vw, 100vw"
                               className="object-cover"
                             />
                           </motion.div>

--- a/src/app/(main)/news/page.tsx
+++ b/src/app/(main)/news/page.tsx
@@ -93,7 +93,7 @@ export default function NewsPage() {
                 src="/highlights/Akomapa-2.jpg"
                 alt="Akomapa community health activities"
                 fill
-                priority
+                sizes="(min-width: 1024px) 42vw, 100vw"
                 className="object-cover"
               />
               <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-transparent" />

--- a/src/app/(main)/partner/page.tsx
+++ b/src/app/(main)/partner/page.tsx
@@ -357,6 +357,7 @@ export default function PartnerPage() {
                         src="/highlights/Akomapa-66.jpg"
                         alt="Akomapa Partners Program - Community healthcare delivery"
                         fill
+                        sizes="(min-width: 1024px) 80vw, 100vw"
                         className="object-cover"
                       />
                       <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-transparent" />
@@ -1090,6 +1091,7 @@ export default function PartnerPage() {
                   src="/highlights/Akomapa-73.jpg"
                   alt="Corporate partnerships and collaboration"
                   fill
+                  sizes="(min-width: 1024px) 80vw, 100vw"
                   className="object-cover"
                 />
                 <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-transparent" />

--- a/src/app/(main)/programs/akomapa-foods/page.tsx
+++ b/src/app/(main)/programs/akomapa-foods/page.tsx
@@ -181,7 +181,6 @@ export default function FoodsPage() {
                 src="/highlights/Akomapa-47.jpg"
                 alt="Akomapa Foods team cultivating community farms"
                 fill
-                priority
                 sizes="(min-width: 1024px) 50vw, 100vw"
                 className="object-cover object-center"
               />
@@ -205,6 +204,7 @@ export default function FoodsPage() {
                 src="/highlights/Akomapa-61.jpg"
                 alt="Fresh produce harvested for the Akomapa Foods Initiative"
                 fill
+                sizes="(min-width: 1024px) 50vw, 100vw"
                 className="object-cover object-center"
               />
               <div className="absolute inset-0 bg-gradient-to-t from-black/25 via-transparent to-transparent" />

--- a/src/app/(main)/programs/akomapa-ghip/page.tsx
+++ b/src/app/(main)/programs/akomapa-ghip/page.tsx
@@ -221,7 +221,7 @@ export default function GHIPPage() {
                 src="/highlights/Akomapa-40.jpg"
                 alt="Global health immersion program participants"
                 fill
-                priority
+                sizes="(min-width: 1024px) 50vw, 100vw"
                 className="object-cover object-center"
               />
               <div className="absolute inset-0 bg-gradient-to-t from-black/35 via-transparent to-transparent" />
@@ -264,6 +264,7 @@ export default function GHIPPage() {
                   src="/highlights/Akomapa-66.jpg"
                   alt="Students participating in global health immersion program"
                   fill
+                  sizes="(min-width: 1024px) 50vw, 100vw"
                   className="object-cover object-center"
                 />
                 <div className="absolute inset-0 bg-gradient-to-t from-black/25 via-transparent to-transparent" />
@@ -576,6 +577,7 @@ export default function GHIPPage() {
                   src="/highlights/Akomapa-12.jpg"
                   alt="2026 Pilot Cohort in Ghana"
                   fill
+                  sizes="(min-width: 1024px) 50vw, 100vw"
                   className="object-cover object-center"
                 />
                 <div className="absolute inset-0 bg-gradient-to-t from-black/25 via-transparent to-transparent" />

--- a/src/app/(main)/programs/akomapa-ghltp/page.tsx
+++ b/src/app/(main)/programs/akomapa-ghltp/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { ArrowLeft, ArrowRight, Quote } from "lucide-react";
 import Breadcrumb from "@/components/layout/Breadcrumb";
 import Image from "@/components/common/Image";
+/** `next/image` for static files under `public/` (partner logos). ImageKit paths use `Image` above. */
 import NextImage from "next/image";
 import { Button } from "@/components/ui/button";
 
@@ -306,7 +307,7 @@ export default function GHLTPPage() {
                 src="/highlights/Akomapa-40.jpg"
                 alt="Global health leadership training program"
                 fill
-                priority
+                sizes="(min-width: 1024px) 50vw, 100vw"
                 className="object-cover"
               />
               <div className="absolute inset-0 bg-gradient-to-t from-black/35 via-transparent to-transparent" />
@@ -353,6 +354,7 @@ export default function GHLTPPage() {
                   src="/highlights/Akomapa-66.jpg"
                   alt="Students in global health leadership training"
                   fill
+                  sizes="(min-width: 1024px) 50vw, 100vw"
                   className="object-cover"
                 />
                 <div className="absolute inset-0 bg-gradient-to-t from-black/25 via-transparent to-transparent" />

--- a/src/app/(main)/programs/akomapa-network/page.tsx
+++ b/src/app/(main)/programs/akomapa-network/page.tsx
@@ -244,7 +244,7 @@ export default function AkomapaNetworkPage() {
                 src="/highlights/Akomapa-40.jpg"
                 alt="Global network of student healthcare leaders"
                 fill
-                priority
+                sizes="(min-width: 1024px) 50vw, 100vw"
                 className="object-cover"
               />
               <div className="absolute inset-0 bg-gradient-to-t from-black/35 via-transparent to-transparent" />
@@ -291,6 +291,7 @@ export default function AkomapaNetworkPage() {
                   src="/highlights/Akomapa-66.jpg"
                   alt="Students collaborating across the network"
                   fill
+                  sizes="(min-width: 1024px) 50vw, 100vw"
                   className="object-cover"
                 />
                 <div className="absolute inset-0 bg-gradient-to-t from-black/25 via-transparent to-transparent" />
@@ -469,6 +470,7 @@ export default function AkomapaNetworkPage() {
                         src={clinic.logo}
                         alt={clinic.name}
                         fill
+                        sizes="(min-width: 1024px) 28vw, 90vw"
                         className="object-contain"
                       />
                     </div>

--- a/src/app/(main)/programs/akomapa-young-advocates/page.tsx
+++ b/src/app/(main)/programs/akomapa-young-advocates/page.tsx
@@ -282,7 +282,7 @@ export default function YoungAdvocatesPage() {
                 src="/gallery/gallery-pic-2.jpg"
                 alt="Young advocates participating in a health education session"
                 fill
-                priority
+                sizes="(min-width: 1024px) 50vw, 100vw"
                 className="object-cover object-center"
               />
               <div className="absolute inset-0 bg-gradient-to-t from-black/35 via-transparent to-transparent" />
@@ -328,6 +328,7 @@ export default function YoungAdvocatesPage() {
                   src="/highlights/Akomapa-66.jpg"
                   alt="University mentors guiding high school students"
                   fill
+                  sizes="(min-width: 1024px) 50vw, 100vw"
                   className="object-cover object-center"
                 />
                 <div className="absolute inset-0 bg-gradient-to-t from-black/25 via-transparent to-transparent" />
@@ -634,6 +635,7 @@ export default function YoungAdvocatesPage() {
                 src="/highlights/Akomapa-19.jpg"
                 alt="Akomapa clinic mentors supporting youth"
                 fill
+                sizes="(min-width: 1024px) 50vw, 100vw"
                 className="object-cover object-center"
               />
               <div className="absolute inset-0 bg-gradient-to-t from-black/25 via-transparent to-transparent" />
@@ -667,6 +669,7 @@ export default function YoungAdvocatesPage() {
                   src="/images/team/brian-fleischer.jpeg"
                   alt="Akomapa Health"
                   fill
+                  sizes="64px"
                   className="object-contain p-2"
                 />
               </div>

--- a/src/app/(main)/programs/page.tsx
+++ b/src/app/(main)/programs/page.tsx
@@ -270,7 +270,7 @@ export default function ProgramsPage() {
                 src="/highlights/Akomapa-47.jpg"
                 alt="Akomapa programs and initiatives"
                 fill
-                priority
+                sizes="(min-width: 1024px) 50vw, 100vw"
                 className="object-cover"
               />
               <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-transparent" />
@@ -327,6 +327,7 @@ export default function ProgramsPage() {
                         src={program.image}
                         alt={program.alt}
                         fill
+                        sizes="(min-width: 1024px) 50vw, 100vw"
                         className="object-cover group-hover:scale-110 transition-transform duration-700"
                       />
                       <div className="absolute inset-0 bg-gradient-to-t from-black/25 via-transparent to-transparent" />

--- a/src/app/(main)/research/page.tsx
+++ b/src/app/(main)/research/page.tsx
@@ -73,7 +73,7 @@ export default function ResearchPage() {
                 src="/highlights/Akomapa-61.jpg"
                 alt="Research and data collection in community settings"
                 fill
-                priority
+                sizes="(min-width: 1024px) 50vw, 100vw"
                 className="object-cover"
               />
               <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-transparent" />
@@ -134,6 +134,7 @@ export default function ResearchPage() {
                         src={paper.image}
                         alt={paper.title}
                         fill
+                        sizes="(min-width: 1024px) 300px, 100vw"
                         className="object-cover group-hover:scale-110 transition-transform duration-500"
                       />
                       <div className="absolute inset-0 bg-gradient-to-t from-black/20 via-transparent to-transparent" />

--- a/src/app/(main)/roadmap/page.tsx
+++ b/src/app/(main)/roadmap/page.tsx
@@ -83,6 +83,7 @@ export default function RoadmapPage() {
             src="/images/hero-image.jpg"
             alt=""
             fill
+            sizes="100vw"
             className="object-cover"
           />
         </div>

--- a/src/components/clinics/VolunteerGrid.tsx
+++ b/src/components/clinics/VolunteerGrid.tsx
@@ -45,7 +45,7 @@ const volunteerImages = [
   "/ucc-team/volunteers/Akomapa-75.jpg",
 ];
 
-function VolunteerThumbnail({ src, index, onOpen }: { src: string; index: number; onOpen: () => void }) {
+function VolunteerThumbnail({ src, onOpen }: { src: string; onOpen: () => void }) {
   return (
     <button
       onClick={onOpen}
@@ -64,7 +64,6 @@ function VolunteerThumbnail({ src, index, onOpen }: { src: string; index: number
         fill
         className="object-cover"
         sizes="56px"
-        priority={index < 12}
       />
     </button>
   );
@@ -127,11 +126,10 @@ export default function VolunteerGrid() {
           viewport={{ once: true, amount: 0.2 }}
           className="grid grid-cols-6 sm:grid-cols-8 lg:grid-cols-12 gap-2 sm:gap-3 justify-items-center mb-8 max-w-4xl mx-auto"
         >
-          {volunteerImages.map((src, index) => (
+          {volunteerImages.map((src) => (
             <VolunteerThumbnail
               key={src}
               src={src}
-              index={index}
               onOpen={() => setSelectedImage(src)}
             />
           ))}

--- a/src/components/common/CardWithButton.tsx
+++ b/src/components/common/CardWithButton.tsx
@@ -26,6 +26,7 @@ export default function CardWithButton({
           src={imageSrc} 
           alt={imageAlt} 
           fill
+          sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
           className="object-cover"
         />
       </div>

--- a/src/components/common/ContentSection.tsx
+++ b/src/components/common/ContentSection.tsx
@@ -31,6 +31,7 @@ export default function ContentSection({
                 src={imageSrc} 
                 alt={imageAlt} 
                 fill
+                sizes="(min-width: 1024px) 50vw, 100vw"
                 className="object-cover"
               />
             </div>

--- a/src/components/common/Image.tsx
+++ b/src/components/common/Image.tsx
@@ -1,172 +1,62 @@
 "use client";
 
-/* eslint-disable @next/next/no-img-element */
-// Using standard img tag for ImageKit CDN optimization and better browser caching
-// ImageKit's CDN already provides optimization, so Next.js Image component overhead is unnecessary
+import NextImage from "next/image";
+import type { ComponentProps } from "react";
+import { imageKitLoader } from "@/lib/imagekit";
 
-import { useState, useEffect, useMemo } from "react";
-import { getImageKitUrl } from "@/lib/imagekit";
-
-interface ImageProps {
+type Props = Omit<ComponentProps<typeof NextImage>, "src" | "loader"> & {
   src: string;
-  alt: string;
-  width?: number;
-  height?: number;
-  className?: string;
-  fill?: boolean;
-  priority?: boolean;
-  sizes?: string;
-  style?: React.CSSProperties;
-  quality?: number;
   minWidth?: number;
   minHeight?: number;
-}
+};
 
-export default function Image({ 
-  src, 
-  alt, 
-  width, 
-  height, 
-  className, 
-  fill, 
+/**
+ * ImageKit-backed image using `next/image` with a custom loader (`imageKitLoader`).
+ * Use for remote paths served via `NEXT_PUBLIC_IMAGEKIT_URL_ENDPOINT` (e.g. `/highlights/...`).
+ * Local-only assets under `public/` should use `next/image` directly without this wrapper.
+ */
+export default function Image({
+  src,
+  alt,
+  width,
+  height,
+  className,
+  fill,
   priority,
   sizes,
   style,
-  quality = 100,
+  quality = 75,
   minWidth,
-  minHeight
-}: ImageProps) {
-  const [isClient, setIsClient] = useState(false);
-  const [imageLoaded, setImageLoaded] = useState(false);
-  const [imageError, setImageError] = useState(false);
+  minHeight,
+  loading,
+  ...rest
+}: Props) {
+  const resolvedWidth = minWidth ?? width;
+  const resolvedHeight = minHeight ?? height;
+  const resolvedSizes = fill ? (sizes ?? "100vw") : sizes;
 
-  useEffect(() => {
-    setIsClient(true);
-  }, []);
-
-  // Calculate display dimensions - use minWidth/minHeight if provided, otherwise use width/height
-  // This ensures consistency between URL generation and img element attributes
-  const displayWidth = minWidth || width;
-  const displayHeight = minHeight || height;
-
-  // Generate ImageKit URL with transformations
-  // Use useMemo to ensure consistent URLs for caching (prevents unnecessary re-renders and API calls)
-  const imageUrl = useMemo(() => {
-    return getImageKitUrl(src, {
-      quality,
-      width: displayWidth,
-      height: displayHeight,
-    });
-  }, [src, quality, displayWidth, displayHeight]);
-
-  // Reset loading state when image URL changes
-  // This ensures the placeholder shows when switching between images
-  useEffect(() => {
-    setImageLoaded(false);
-    setImageError(false);
-  }, [imageUrl]);
-
-  // Show placeholder during SSR and initial client render
-  if (!isClient) {
-    return (
-      <div 
-        className="bg-gray-200 dark:bg-gray-700 animate-pulse"
-        style={{
-          ...(fill && {
-            position: "absolute",
-            height: "100%",
-            width: "100%",
-            inset: 0,
-            minHeight: '100px', // Fallback minimum height for fill mode
-          }),
-          ...(displayWidth && displayHeight && !fill && {
-            width: `${displayWidth}px`,
-            height: `${displayHeight}px`,
-          }),
-        }}
-        aria-hidden="true"
-      />
-    );
-  }
-
-  const imageStyle: React.CSSProperties = {
-    ...style,
-    ...(fill && {
-      position: "absolute",
-      height: "100%",
-      width: "100%",
-      inset: 0,
-    }),
-    // Always include transition so opacity changes animate smoothly
-    transition: "opacity 0.3s ease-in-out",
-    ...(!imageLoaded && {
-      opacity: 0,
-    }),
-    ...(imageLoaded && {
-      opacity: 1,
-    }),
-  };
-
-  // Placeholder style - separate from image style to avoid className conflicts
-  // Don't include className here to prevent sizing conflicts
-  const placeholderStyle: React.CSSProperties = {
-    ...(fill && {
-      position: "absolute",
-      height: "100%",
-      width: "100%",
-      inset: 0,
-      zIndex: 1,
-      // Ensure placeholder has proper dimensions even in fill mode
-      minHeight: '100px', // Fallback minimum height for fill mode
-    }),
-    ...(displayWidth && displayHeight && !fill && {
-      width: `${displayWidth}px`,
-      height: `${displayHeight}px`,
-    }),
-  };
+  const resolvedLoading =
+    loading !== undefined
+      ? loading
+      : priority
+        ? undefined
+        : ("lazy" as const);
 
   return (
-    <>
-      {imageError ? (
-        <div 
-          className="bg-gray-100 dark:bg-gray-800 flex items-center justify-center text-gray-500 dark:text-gray-400 text-sm"
-          style={placeholderStyle}
-          role="alert"
-          aria-label="Image failed to load"
-        >
-          <span>Failed to load image</span>
-        </div>
-      ) : (
-        <>
-          {!imageLoaded && (
-            <div 
-              className="bg-gray-200 dark:bg-gray-700 animate-pulse"
-              style={placeholderStyle}
-              aria-hidden="true"
-            />
-          )}
-          <img
-            src={imageUrl}
-            alt={alt}
-            width={fill ? undefined : displayWidth}
-            height={fill ? undefined : displayHeight}
-            className={className}
-            loading={priority ? "eager" : "lazy"}
-            sizes={sizes}
-            style={imageStyle}
-            onLoad={() => {
-              setImageLoaded(true);
-              setImageError(false);
-            }}
-            onError={() => {
-              setImageError(true);
-              setImageLoaded(false);
-            }}
-            // Add fetchPriority (uppercase HTML attribute) for priority images to improve caching behavior
-            {...(priority && { fetchPriority: "high" })}
-          />
-        </>
-      )}
-    </>
+    <NextImage
+      {...rest}
+      loader={imageKitLoader}
+      src={src}
+      alt={alt}
+      width={fill ? undefined : resolvedWidth}
+      height={fill ? undefined : resolvedHeight}
+      fill={fill}
+      priority={priority}
+      sizes={resolvedSizes}
+      quality={quality}
+      className={className}
+      style={style}
+      loading={resolvedLoading}
+    />
   );
 }

--- a/src/components/common/PhotoCarousel.tsx
+++ b/src/components/common/PhotoCarousel.tsx
@@ -96,6 +96,7 @@ export default function PhotoCarousel({
                 src={photo.src}
                 alt={photo.alt}
                 fill
+                sizes="100vw"
                 className="object-cover"
               />
               <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/70 to-transparent p-4">

--- a/src/components/home/AkomapaMeaningSection.tsx
+++ b/src/components/home/AkomapaMeaningSection.tsx
@@ -18,6 +18,7 @@ export default function AkomapaMeaningSection() {
           src="/images/patterns/dots-pattern.webp"
           alt=""
           fill
+          sizes="100vw"
           className="object-cover"
         />
       </div>
@@ -39,6 +40,7 @@ export default function AkomapaMeaningSection() {
                   src="/highlights/Akomapa-48.jpg"
                   alt="Healthcare professionals showing compassion and care"
                   fill
+                  sizes="(min-width: 1024px) 42vw, 100vw"
                   className="object-cover"
                 />
                 <div className="absolute inset-0 bg-gradient-to-t from-[#0097b2]/40 via-transparent to-transparent"></div>

--- a/src/components/home/FeaturedNews.tsx
+++ b/src/components/home/FeaturedNews.tsx
@@ -39,6 +39,7 @@ export default function FeaturedNews() {
                   src={item.image}
                   alt={item.title}
                   fill
+                  sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
                   className="object-cover"
                 />
                 <div className="absolute top-4 left-4">

--- a/src/components/home/Gallery.tsx
+++ b/src/components/home/Gallery.tsx
@@ -334,7 +334,6 @@ export default function Gallery({ items }: GalleryProps = {}) {
                     src={item.src}
                     alt={item.alt}
                     fill
-                    priority={index < 4}
                     sizes={item.featured 
                       ? "(max-width: 640px) 100vw, (max-width: 1024px) 66vw, 50vw"
                       : "(max-width: 640px) 100vw, (max-width: 768px) 50vw, (max-width: 1024px) 33vw, 25vw"

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -113,6 +113,7 @@ export default function HeroSection({
                 alt={backgroundOptions.slideshow.images[currentImageIndex].alt}
                 fill
                 priority
+                sizes="100vw"
                 className="object-cover"
               />
             </motion.div>
@@ -127,6 +128,7 @@ export default function HeroSection({
                 src="/images/patterns/dot-pattern3.webp"
                 alt=""
                 fill
+                sizes="100vw"
                 className="object-cover"
               />
             </div>

--- a/src/components/home/LocationSection.tsx
+++ b/src/components/home/LocationSection.tsx
@@ -90,8 +90,8 @@ export default function LocationsSection() {
                 src={communityPhotos[currentPhotoIndex].src}
                 alt={communityPhotos[currentPhotoIndex].alt}
                 fill
+                sizes="(min-width: 1024px) 50vw, 100vw"
                 className="object-cover transition-opacity duration-500"
-                priority
               />
               
               {/* Overlay with gradient and caption */}

--- a/src/components/home/MissionSection.tsx
+++ b/src/components/home/MissionSection.tsx
@@ -51,6 +51,7 @@ export default function MissionSection() {
                 src="/highlights/Akomapa-72.jpg"
                 alt="Healthcare professionals training in Ghana"
                 fill
+                sizes="(min-width: 1024px) 42vw, 100vw"
                 className="object-cover"
               />
               <div className="absolute inset-0 bg-gradient-to-br from-black/30 via-transparent to-transparent"></div>

--- a/src/components/home/ProgramsOverview.tsx
+++ b/src/components/home/ProgramsOverview.tsx
@@ -227,6 +227,7 @@ export default function ProgramsOverview() {
                   src={pillar.image}
                   alt={pillar.title}
                   fill
+                  sizes="(min-width: 1024px) 25vw, (min-width: 768px) 50vw, 100vw"
                   className="object-cover transition-transform duration-200 ease-[ease] group-hover:scale-[1.02] motion-reduce:transform-none motion-reduce:transition-none"
                 />
               </div>

--- a/src/components/home/ResearchSection.tsx
+++ b/src/components/home/ResearchSection.tsx
@@ -122,6 +122,7 @@ export default function ResearchSection() {
                     src={partner.logo}
                     alt={partner.name}
                     fill
+                    sizes="(max-width: 640px) 180px, (max-width: 1024px) 220px, 280px"
                     className="object-contain transition-transform duration-300 group-hover:scale-110"
                   />
                 </div>

--- a/src/components/resources/ResourceCard.tsx
+++ b/src/components/resources/ResourceCard.tsx
@@ -15,6 +15,7 @@ export default function ResourceCard({ resource }: { resource: Resource }) {
             src={resource.image}
             alt={resource.title}
             fill
+            sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
             className="object-cover"
           />
         ) : (

--- a/src/components/shared/ProgramModal.tsx
+++ b/src/components/shared/ProgramModal.tsx
@@ -67,6 +67,7 @@ export default function ProgramModal({ program, isOpen, onClose }: ProgramModalP
                 src={program.image}
                 alt={program.title}
                 fill
+                sizes="(min-width: 768px) 672px, 100vw"
                 className="object-cover rounded-t-2xl"
               />
               <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent rounded-t-2xl" />

--- a/src/lib/imagekit.ts
+++ b/src/lib/imagekit.ts
@@ -92,3 +92,25 @@ export function getImageKitSrcSet(
     .join(', ');
 }
 
+/** Parameters passed by `next/image` to a custom loader (see Next.js Image docs). */
+export type ImageKitLoaderParams = {
+  src: string;
+  width: number;
+  quality?: number;
+};
+
+/**
+ * `next/image` loader for ImageKit asset paths (e.g. `/highlights/photo.jpg`).
+ * Applies `tr=w-` and `tr=q-` so ImageKit serves appropriately sized bytes; `src` may be a full HTTPS URL (passed through by `getImageKitUrl`).
+ *
+ * **Optimization chain:** With the default Next.js Image pipeline, the URL returned here is fetched and may be further optimized by Next (`remotePatterns` must allow the host). To rely on ImageKit transformations only, render `next/image` with `unoptimized` (not used by our wrapper).
+ */
+export function imageKitLoader({
+  src,
+  width,
+  quality,
+}: ImageKitLoaderParams): string {
+  const q = quality ?? 75;
+  return getImageKitUrl(src, { width, quality: q });
+}
+


### PR DESCRIPTION
#### Summary
Adds a strict, shared workflow so commits aren’t merged with broken lint/types and pushes aren’t published without a green production build and Playwright suite. Local behavior is aligned with GitHub Actions.

#### What changed
- Husky — `prepare` script; hooks committed under `.husky/`.
- pre-commit — `lint-staged` runs ESLint (`--max-warnings 0 --fix`) on staged `*.{js,jsx,mjs,cjs,ts,tsx}`; then `npm run typecheck` (`tsc --noEmit`).
- pre-push — `npm run lint` → `npm run typecheck` → `npm run build` → `npm run test:e2e`.
- Scripts — `typecheck`, `validate` (full local gate: `lint` + `typecheck` + `build` + `e2e`).
- lint-staged — configured in `package.json`.
- CI — workflow runs ESLint and TypeScript before build; workflow name updated to reflect lint + typecheck + build + E2E.

#### Bypass (emergencies only)
`HUSKY=0`, `git commit --no-verify`, or `git push --no-verify`.

Note
If `ESLint --fix` changes files, re-stage and commit again.
Also includes ImageKit loader, responsive sizes, and priority/lazy tuning (see prior commits / description).