### PR TITLE
[AK-156] feat(motion): add sitewide motion system with a11y and shared primitive

### DIFF
--- a/src/app/(main)/clinics/page.tsx
+++ b/src/app/(main)/clinics/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import { motion, useInView, useMotionValue, useSpring } from "framer-motion";
+import { motion } from "framer-motion";
+import { AnimatedMetric } from "@/components/motion/AnimatedMetric";
 import Link from "next/link";
 import { ArrowRight, MapPin, ChevronsDown } from "lucide-react";
 import Breadcrumb from "@/components/layout/Breadcrumb";
@@ -88,39 +88,6 @@ const impactMetrics = [
     color: "#eeba2b"
   }
 ];
-
-function ImpactCounter({ value, suffix = "", color }: { value: number; suffix?: string; color: string }) {
-  const ref = useRef<HTMLSpanElement | null>(null);
-  const isInView = useInView(ref, { once: true, amount: 0.6 });
-  const motionValue = useMotionValue(0);
-  const springValue = useSpring(motionValue, { stiffness: 120, damping: 20, mass: 0.8 });
-  const [displayValue, setDisplayValue] = useState(0);
-
-  useEffect(() => {
-    if (isInView) {
-      motionValue.set(value);
-    }
-  }, [isInView, value, motionValue]);
-
-  useEffect(() => {
-    const unsubscribe = springValue.on("change", (latest) => {
-      setDisplayValue(latest);
-    });
-    return () => unsubscribe();
-  }, [springValue]);
-
-  const formatted = `${Math.round(displayValue).toLocaleString()}${suffix}`;
-
-  return (
-    <span
-      ref={ref}
-      className="text-4xl font-semibold tracking-tight"
-      style={{ color }}
-    >
-      {formatted}
-    </span>
-  );
-}
 
 const clinicSites = [
   {
@@ -314,7 +281,12 @@ export default function ClinicsPage() {
               >
                 <div className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300 bg-gradient-to-br from-[#0097b2]/10 via-transparent to-[#F5C94D]/15" />
                 <div className="relative flex flex-col h-full">
-                  <ImpactCounter value={metric.value} suffix={metric.suffix} color={metric.color} />
+                  <AnimatedMetric
+                    value={metric.value}
+                    suffix={metric.suffix ?? ""}
+                    className="text-4xl font-semibold tracking-tight"
+                    style={{ color: metric.color }}
+                  />
                   <h3 className="mt-4 text-xl font-semibold uppercase tracking-[0.3em] text-[#1C1F1E] mb-3">
                     {metric.label}
                   </h3>

--- a/src/app/(main)/privacy/page.tsx
+++ b/src/app/(main)/privacy/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { motion } from "framer-motion";
+import { FadeIn } from "@/components/animations";
+import { HeroEntranceH1, HeroEntranceP } from "@/components/motion/HeroEntrance";
 import Breadcrumb from "@/components/layout/Breadcrumb";
 import Link from "next/link";
 
@@ -18,22 +19,15 @@ export default function PrivacyPage() {
         
         <div className="container mx-auto px-4 sm:px-6 relative z-10">
           <div className="max-w-5xl pt-4 sm:pt-8">
-            <motion.h1 
-              initial={{ opacity: 0, y: 40 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.8, ease: "easeOut" }}
-              className="text-3xl sm:text-4xl md:text-6xl lg:text-7xl font-light text-[#FCFAEF] mb-6 leading-tight"
-            >
+            <HeroEntranceH1 className="text-3xl sm:text-4xl md:text-6xl lg:text-7xl font-light text-[#FCFAEF] mb-6 leading-tight">
               Privacy Policy
-            </motion.h1>
-            <motion.p 
-              initial={{ opacity: 0, y: 40 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.15, duration: 0.8, ease: "easeOut" }}
+            </HeroEntranceH1>
+            <HeroEntranceP
+              delay={0.1}
               className="text-base sm:text-lg md:text-2xl text-[#FCFAEF]/80 font-light max-w-3xl"
             >
               Your privacy is important to us. Learn how we collect, use, and protect your information.
-            </motion.p>
+            </HeroEntranceP>
           </div>
         </div>
       </section>
@@ -42,13 +36,7 @@ export default function PrivacyPage() {
       <section className="py-16 md:py-24 bg-[#FCFAEF] dark:bg-[#1C1F1E]">
         <div className="container mx-auto px-4 sm:px-6">
           <div className="max-w-4xl mx-auto">
-            <motion.div 
-              initial={{ opacity: 0, y: 20 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6 }}
-              viewport={{ once: true }}
-              className="bg-white dark:bg-[#2F3332] rounded-2xl shadow-xl p-6 sm:p-8 md:p-10 space-y-8 sm:space-y-10"
-            >
+            <FadeIn className="bg-white dark:bg-[#2F3332] rounded-2xl shadow-xl p-6 sm:p-8 md:p-10 space-y-8 sm:space-y-10">
               <div className="space-y-4 sm:space-y-6">
                 <div className="flex items-center gap-2 mb-4">
                   <div className="h-1 w-8 bg-[#0097b2] rounded-full" />
@@ -242,7 +230,7 @@ export default function PrivacyPage() {
                   Last updated: {new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
                 </p>
               </div>
-            </motion.div>
+            </FadeIn>
           </div>
         </div>
       </section>

--- a/src/app/(main)/programs/akomapa-ghltp/page.tsx
+++ b/src/app/(main)/programs/akomapa-ghltp/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
-import { motion, useInView, useMotionValue, useSpring, AnimatePresence } from "framer-motion";
+import { useState, useEffect } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { AnimatedMetric } from "@/components/motion/AnimatedMetric";
 import Link from "next/link";
 import { ArrowLeft, ArrowRight, Quote } from "lucide-react";
 import Breadcrumb from "@/components/layout/Breadcrumb";
@@ -163,39 +164,6 @@ const testimonials = [
     image: "/avatar-2.jpg"
   }
 ];
-
-function ImpactCounter({ value, suffix = "", color }: { value: number; suffix?: string; color: string }) {
-  const ref = useRef<HTMLSpanElement | null>(null);
-  const isInView = useInView(ref, { once: true, amount: 0.6 });
-  const motionValue = useMotionValue(0);
-  const springValue = useSpring(motionValue, { stiffness: 120, damping: 20, mass: 0.8 });
-  const [displayValue, setDisplayValue] = useState(0);
-
-  useEffect(() => {
-    if (isInView) {
-      motionValue.set(value);
-    }
-  }, [isInView, value, motionValue]);
-
-  useEffect(() => {
-    const unsubscribe = springValue.on("change", (latest) => {
-      setDisplayValue(latest);
-    });
-    return () => unsubscribe();
-  }, [springValue]);
-
-  const formatted = `${Math.round(displayValue).toLocaleString()}${suffix}`;
-
-  return (
-    <span
-      ref={ref}
-      className="text-4xl md:text-5xl lg:text-6xl font-semibold tracking-tight"
-      style={{ color }}
-    >
-      {formatted}
-    </span>
-  );
-}
 
 const ctaBaseClass =
   "group inline-flex items-center justify-center gap-2 rounded-half px-8 py-6 h-auto text-base sm:text-lg font-medium transition-all duration-300 transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2";
@@ -640,7 +608,12 @@ export default function GHLTPPage() {
                   style={{ backgroundColor: "#0097b2" }}
                 />
                 <div className="mb-4">
-                  <ImpactCounter value={1000} suffix="+" color="#0097b2" />
+                  <AnimatedMetric
+                    value={1000}
+                    suffix="+"
+                    className="text-4xl md:text-5xl lg:text-6xl font-semibold tracking-tight"
+                    style={{ color: "#0097b2" }}
+                  />
                 </div>
                 <p className="text-base md:text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed flex-1">
                   Train students and young professionals in ethical, community-driven leadership
@@ -658,7 +631,12 @@ export default function GHLTPPage() {
                   style={{ backgroundColor: "#eeba2b" }}
                 />
                 <div className="mb-4">
-                  <ImpactCounter value={5} suffix="+" color="#eeba2b" />
+                  <AnimatedMetric
+                    value={5}
+                    suffix="+"
+                    className="text-4xl md:text-5xl lg:text-6xl font-semibold tracking-tight"
+                    style={{ color: "#eeba2b" }}
+                  />
                 </div>
                 <p className="text-base md:text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed flex-1">
                   Build a sustainable pipeline of interprofessional global health leaders across countries
@@ -676,7 +654,11 @@ export default function GHLTPPage() {
                   style={{ backgroundColor: "#0097b2" }}
                 />
                 <div className="mb-4">
-                  <ImpactCounter value={1} suffix="" color="#0097b2" />
+                  <AnimatedMetric
+                    value={1}
+                    className="text-4xl md:text-5xl lg:text-6xl font-semibold tracking-tight"
+                    style={{ color: "#0097b2" }}
+                  />
                 </div>
                 <p className="text-base md:text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed flex-1">
                   Strengthen links between academic learning and real-world systems change through the Akomapa Network

--- a/src/app/(main)/programs/akomapa-network/page.tsx
+++ b/src/app/(main)/programs/akomapa-network/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
-import { motion, useInView, useMotionValue, useSpring } from "framer-motion";
+import { motion } from "framer-motion";
+import { AnimatedMetric } from "@/components/motion/AnimatedMetric";
 import Link from "next/link";
 import { ArrowLeft, ArrowRight, Quote } from "lucide-react";
 import Breadcrumb from "@/components/layout/Breadcrumb";
@@ -122,39 +122,6 @@ const partnerClinics = [
     accentColor: "#0097b2"
   }
 ];
-
-function GoalCounter({ value, suffix = "", color }: { value: number; suffix?: string; color: string }) {
-  const ref = useRef<HTMLSpanElement | null>(null);
-  const isInView = useInView(ref, { once: true, amount: 0.6 });
-  const motionValue = useMotionValue(0);
-  const springValue = useSpring(motionValue, { stiffness: 120, damping: 20, mass: 0.8 });
-  const [displayValue, setDisplayValue] = useState(0);
-
-  useEffect(() => {
-    if (isInView) {
-      motionValue.set(value);
-    }
-  }, [isInView, value, motionValue]);
-
-  useEffect(() => {
-    const unsubscribe = springValue.on("change", (latest) => {
-      setDisplayValue(latest);
-    });
-    return () => unsubscribe();
-  }, [springValue]);
-
-  const formatted = `${Math.round(displayValue).toLocaleString()}${suffix}`;
-
-  return (
-    <span
-      ref={ref}
-      className="text-4xl md:text-5xl lg:text-6xl font-semibold tracking-tight"
-      style={{ color }}
-    >
-      {formatted}
-    </span>
-  );
-}
 
 const ctaBaseClass =
   "group inline-flex items-center justify-center gap-2 rounded-half px-8 py-6 h-auto text-base sm:text-lg font-medium transition-all duration-300 transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2";
@@ -415,7 +382,12 @@ export default function AkomapaNetworkPage() {
                 />
                 {goal.value !== null && (
                   <div className="mb-4">
-                    <GoalCounter value={goal.value} suffix={goal.suffix || ""} color={goal.color} />
+                    <AnimatedMetric
+                      value={goal.value}
+                      suffix={goal.suffix ?? ""}
+                      className="text-4xl md:text-5xl lg:text-6xl font-semibold tracking-tight"
+                      style={{ color: goal.color }}
+                    />
                     {goal.label && (
                       <p className="mt-2 text-sm font-semibold uppercase tracking-[0.2em] text-[#1C1F1E]/70">
                         {goal.label}

--- a/src/app/(main)/programs/akomapa-young-advocates/page.tsx
+++ b/src/app/(main)/programs/akomapa-young-advocates/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import { motion, useInView, useMotionValue, useSpring } from "framer-motion";
+import { motion } from "framer-motion";
+import { AnimatedMetric } from "@/components/motion/AnimatedMetric";
 import Link from "next/link";
 import { ArrowLeft, ArrowRight } from "lucide-react";
 import Breadcrumb from "@/components/layout/Breadcrumb";
@@ -171,39 +171,6 @@ const primaryCtaClass =
 
 const secondaryCtaClass =
   `${ctaBaseClass} bg-[#eeba2b] hover:bg-[#eeba2b]/80 text-[#FCFAEF] shadow-lg hover:shadow-xl focus-visible:ring-[#F5C94D]`;
-
-function ImpactCounter({ value, suffix = "", color }: { value: number; suffix?: string; color: string }) {
-  const ref = useRef<HTMLSpanElement | null>(null);
-  const isInView = useInView(ref, { once: true, amount: 0.6 });
-  const motionValue = useMotionValue(0);
-  const springValue = useSpring(motionValue, { stiffness: 120, damping: 20, mass: 0.8 });
-  const [displayValue, setDisplayValue] = useState(0);
-
-  useEffect(() => {
-    if (isInView) {
-      motionValue.set(value);
-    }
-  }, [isInView, value, motionValue]);
-
-  useEffect(() => {
-    const unsubscribe = springValue.on("change", (latest) => {
-      setDisplayValue(latest);
-    });
-    return () => unsubscribe();
-  }, [springValue]);
-
-  const formatted = `${Math.round(displayValue).toLocaleString()}${suffix}`;
-
-  return (
-    <span
-      ref={ref}
-      className="text-5xl md:text-6xl lg:text-7xl font-semibold tracking-tight leading-none"
-      style={{ color }}
-    >
-      {formatted}
-    </span>
-  );
-}
 
 export default function YoungAdvocatesPage() {
   return (
@@ -588,7 +555,12 @@ export default function YoungAdvocatesPage() {
                     {metric.eyebrow}
                   </p>
                   <div className="space-y-3">
-                    <ImpactCounter value={metric.value} suffix={metric.suffix} color={metric.color} />
+                    <AnimatedMetric
+                      value={metric.value}
+                      suffix={metric.suffix ?? ""}
+                      className="text-5xl md:text-6xl lg:text-7xl font-semibold tracking-tight leading-none"
+                      style={{ color: metric.color }}
+                    />
                     <h3 className="text-2xl md:text-[1.75rem] font-semibold leading-tight text-[#1C1F1E]">
                       {metric.label}
                     </h3>

--- a/src/app/(main)/programs/page.tsx
+++ b/src/app/(main)/programs/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
-import { motion, useInView, useMotionValue, useSpring } from "framer-motion";
+import { motion } from "framer-motion";
+import { AnimatedMetric } from "@/components/motion/AnimatedMetric";
 import Image from "@/components/common/Image";
 import { ArrowRight, Globe, GraduationCap, Users, Building, ChevronsDown, Sparkles, Sprout } from "lucide-react";
 import Link from "next/link";
@@ -193,39 +193,6 @@ const impactMetrics = [
     color: "#eeba2b"
   }
 ];
-
-function ImpactCounter({ value, suffix = "", color }: { value: number; suffix?: string; color: string }) {
-  const ref = useRef<HTMLSpanElement | null>(null);
-  const isInView = useInView(ref, { once: true, amount: 0.6 });
-  const motionValue = useMotionValue(0);
-  const springValue = useSpring(motionValue, { stiffness: 120, damping: 20, mass: 0.8 });
-  const [displayValue, setDisplayValue] = useState(0);
-
-  useEffect(() => {
-    if (isInView) {
-      motionValue.set(value);
-    }
-  }, [isInView, value, motionValue]);
-
-  useEffect(() => {
-    const unsubscribe = springValue.on("change", (latest) => {
-      setDisplayValue(latest);
-    });
-    return () => unsubscribe();
-  }, [springValue]);
-
-  const formatted = `${Math.round(displayValue).toLocaleString()}${suffix}`;
-
-  return (
-    <span
-      ref={ref}
-      className="text-4xl md:text-5xl font-semibold tracking-tight"
-      style={{ color }}
-    >
-      {formatted}
-    </span>
-  );
-}
 
 export default function ProgramsPage() {
   return (
@@ -423,7 +390,12 @@ export default function ProgramsPage() {
               >
                 <div className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300 bg-gradient-to-br from-[#0097b2]/10 via-transparent to-[#F5C94D]/15" />
                 <div className="relative flex flex-col h-full">
-                  <ImpactCounter value={metric.value} suffix={metric.suffix} color={metric.color} />
+                  <AnimatedMetric
+                  value={metric.value}
+                  suffix={metric.suffix ?? ""}
+                  className="text-4xl md:text-5xl font-semibold tracking-tight"
+                  style={{ color: metric.color }}
+                />
                   <h3 className="mt-4 text-xl font-semibold uppercase tracking-[0.3em] text-[#1C1F1E] mb-3">
                     {metric.label}
                   </h3>

--- a/src/app/(main)/resources/page.tsx
+++ b/src/app/(main)/resources/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
+import { FadeIn } from "@/components/animations";
 import Breadcrumb from "@/components/layout/Breadcrumb";
 import PageHeader from "@/components/shared/PageHeader";
 import ResourceGrid from "@/components/resources/ResourceGrid";
@@ -51,27 +52,29 @@ function ResourcesContent() {
       <div className="flex flex-col gap-y-section-mobile md:gap-y-section-tablet lg:gap-y-section-desktop">
         <section className="bg-blue-50 py-16 md:py-24">
           <div className="container mx-auto px-4">
-            <PageHeader
-              title="Healthcare Resources"
-              description="Access educational materials, research publications, and tools to support healthcare knowledge and practices."
-            />
+            <FadeIn>
+              <PageHeader
+                title="Healthcare Resources"
+                description="Access educational materials, research publications, and tools to support healthcare knowledge and practices."
+              />
+            </FadeIn>
           </div>
         </section>
         
         <section className="py-16">
           <div className="container mx-auto px-4">
             <div className="flex flex-col lg:flex-row gap-8">
-              <div className="w-full lg:w-1/4">
+              <FadeIn className="w-full lg:w-1/4" delay={0.05}>
                 <ResourceFilter 
                   filters={filters} 
                   setFilters={setFilters} 
                   totalResources={filteredResources.length}
                 />
-              </div>
+              </FadeIn>
               
-              <div className="w-full lg:w-3/4">
+              <FadeIn className="w-full lg:w-3/4" delay={0.1}>
                 <ResourceGrid resources={filteredResources} />
-              </div>
+              </FadeIn>
             </div>
           </div>
         </section>

--- a/src/app/(main)/template.tsx
+++ b/src/app/(main)/template.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { motionDurations } from "@/lib/motion/tokens";
+
+export default function MainTemplate({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <motion.div
+      className="flex-grow"
+      initial={{ opacity: 0.97 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: motionDurations.enter * 0.75, ease: [0.25, 0.4, 0.25, 1] }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/src/app/(main)/terms/page.tsx
+++ b/src/app/(main)/terms/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { motion } from "framer-motion";
+import { FadeIn } from "@/components/animations";
+import { HeroEntranceH1, HeroEntranceP } from "@/components/motion/HeroEntrance";
 import Breadcrumb from "@/components/layout/Breadcrumb";
 import Link from "next/link";
 
@@ -18,22 +19,15 @@ export default function TermsPage() {
         
         <div className="container mx-auto px-4 sm:px-6 relative z-10">
           <div className="max-w-5xl pt-4 sm:pt-8">
-            <motion.h1 
-              initial={{ opacity: 0, y: 40 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.8, ease: "easeOut" }}
-              className="text-3xl sm:text-4xl md:text-6xl lg:text-7xl font-light text-[#FCFAEF] mb-6 leading-tight"
-            >
+            <HeroEntranceH1 className="text-3xl sm:text-4xl md:text-6xl lg:text-7xl font-light text-[#FCFAEF] mb-6 leading-tight">
               Terms of Service
-            </motion.h1>
-            <motion.p 
-              initial={{ opacity: 0, y: 40 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.15, duration: 0.8, ease: "easeOut" }}
+            </HeroEntranceH1>
+            <HeroEntranceP
+              delay={0.1}
               className="text-base sm:text-lg md:text-2xl text-[#FCFAEF]/80 font-light max-w-3xl"
             >
               Please read these terms carefully before using our services or participating in our programs.
-            </motion.p>
+            </HeroEntranceP>
           </div>
         </div>
       </section>
@@ -42,13 +36,7 @@ export default function TermsPage() {
       <section className="py-16 md:py-24 bg-[#FCFAEF] dark:bg-[#1C1F1E]">
         <div className="container mx-auto px-4 sm:px-6">
           <div className="max-w-4xl mx-auto">
-            <motion.div 
-              initial={{ opacity: 0, y: 20 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6 }}
-              viewport={{ once: true }}
-              className="bg-white dark:bg-[#2F3332] rounded-2xl shadow-xl p-6 sm:p-8 md:p-10 space-y-8 sm:space-y-10"
-            >
+            <FadeIn className="bg-white dark:bg-[#2F3332] rounded-2xl shadow-xl p-6 sm:p-8 md:p-10 space-y-8 sm:space-y-10">
               <div className="space-y-4 sm:space-y-6">
                 <div className="flex items-center gap-2 mb-4">
                   <div className="h-1 w-8 bg-[#0097b2] rounded-full" />
@@ -201,7 +189,7 @@ export default function TermsPage() {
                   Last updated: {new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
                 </p>
               </div>
-            </motion.div>
+            </FadeIn>
           </div>
         </div>
       </section>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -211,6 +211,10 @@ html.dark {
   .homepage-hover-panel:hover {
     transform: none;
   }
+
+  .akomapa-btn-interaction {
+    transform: none !important;
+  }
 }
 
 .partner-carousel-fade {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import './globals.css';
 import { Metadata } from 'next';
 import { cn } from "@/lib/utils";
 import { ThemeProvider } from '@/components/theme/ThemeProvider';
+import { MotionConfigProvider } from '@/components/motion/MotionConfigProvider';
 
 const chillax = localFont({
   src: [
@@ -79,7 +80,9 @@ export default function RootLayout({
         plusJakartaSans.variable
       )}>
         <ThemeProvider defaultTheme="system" storageKey="akomapa-theme">
-          {children}
+          <MotionConfigProvider>
+            {children}
+          </MotionConfigProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/src/components/animations/FadeIn.tsx
+++ b/src/components/animations/FadeIn.tsx
@@ -2,8 +2,16 @@
 
 import { motion, type Variants } from "framer-motion";
 import { ReactNode, type ElementType } from "react";
+import {
+  defaultScrollViewport,
+  fadeUpStaggerContainerVariants,
+  fadeUpStaggerItemVariants,
+  fadeUpVariants,
+  motionDurations,
+  type FadeDirection,
+} from "@/lib/motion/tokens";
 
-type FadeInDirection = "up" | "down" | "left" | "right" | "none";
+type FadeInDirection = FadeDirection;
 
 type FadeInProps = {
   children: ReactNode;
@@ -16,51 +24,17 @@ type FadeInProps = {
   as?: ElementType;
 };
 
-const getDirectionOffset = (direction: FadeInDirection) => {
-  switch (direction) {
-    case "up":
-      return { y: 40, x: 0 };
-    case "down":
-      return { y: -40, x: 0 };
-    case "left":
-      return { x: 40, y: 0 };
-    case "right":
-      return { x: -40, y: 0 };
-    case "none":
-    default:
-      return { x: 0, y: 0 };
-  }
-};
-
 export function FadeIn({
   children,
   className = "",
   direction = "up",
   delay = 0,
-  duration = 0.5,
+  duration = motionDurations.enter,
   once = true,
-  amount = 0.2,
+  amount = defaultScrollViewport.amount,
   as = "div",
 }: FadeInProps) {
-  const offset = getDirectionOffset(direction);
-
-  const variants: Variants = {
-    hidden: {
-      opacity: 0,
-      x: offset.x,
-      y: offset.y,
-    },
-    visible: {
-      opacity: 1,
-      x: 0,
-      y: 0,
-      transition: {
-        duration,
-        delay,
-        ease: [0.25, 0.4, 0.25, 1],
-      },
-    },
-  };
+  const variants: Variants = fadeUpVariants({ direction, duration, delay });
 
   const MotionComponent = motion(as);
 
@@ -77,6 +51,9 @@ export function FadeIn({
   );
 }
 
+/** Alias for semantic clarity — same behavior as {@link FadeIn}. */
+export const SectionReveal = FadeIn;
+
 type FadeInStaggerProps = {
   children: ReactNode;
   className?: string;
@@ -88,19 +65,12 @@ type FadeInStaggerProps = {
 export function FadeInStagger({
   children,
   className = "",
-  staggerDelay = 0.1,
+  staggerDelay = motionDurations.staggerContainer,
   once = true,
-  amount = 0.2,
+  amount = defaultScrollViewport.amount,
 }: FadeInStaggerProps) {
-  const containerVariants: Variants = {
-    hidden: { opacity: 0 },
-    visible: {
-      opacity: 1,
-      transition: {
-        staggerChildren: staggerDelay,
-      },
-    },
-  };
+  const containerVariants: Variants =
+    fadeUpStaggerContainerVariants(staggerDelay);
 
   return (
     <motion.div
@@ -126,26 +96,12 @@ export function FadeInStaggerItem({
   children,
   className = "",
   direction = "up",
-  duration = 0.5,
+  duration = motionDurations.enter,
 }: FadeInStaggerItemProps) {
-  const offset = getDirectionOffset(direction);
-
-  const itemVariants: Variants = {
-    hidden: {
-      opacity: 0,
-      x: offset.x,
-      y: offset.y,
-    },
-    visible: {
-      opacity: 1,
-      x: 0,
-      y: 0,
-      transition: {
-        duration,
-        ease: [0.25, 0.4, 0.25, 1],
-      },
-    },
-  };
+  const itemVariants: Variants = fadeUpStaggerItemVariants({
+    direction,
+    duration,
+  });
 
   return (
     <motion.div variants={itemVariants} className={className}>
@@ -153,4 +109,3 @@ export function FadeInStaggerItem({
     </motion.div>
   );
 }
-

--- a/src/components/animations/index.ts
+++ b/src/components/animations/index.ts
@@ -1,2 +1,10 @@
-export { FadeIn, FadeInStagger, FadeInStaggerItem } from "./FadeIn";
-
+export { FadeIn, FadeInStagger, FadeInStaggerItem, SectionReveal } from "./FadeIn";
+export {
+  fadeUpVariants,
+  fadeUpStaggerContainerVariants,
+  fadeUpStaggerItemVariants,
+  getScrollRevealOffset,
+  motionDurations,
+  MOTION_EASE,
+  defaultScrollViewport,
+} from "@/lib/motion/tokens";

--- a/src/components/home/ImpactMetrics.tsx
+++ b/src/components/home/ImpactMetrics.tsx
@@ -1,9 +1,12 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import { motion, useInView } from "framer-motion";
+import { useRef } from "react";
+import { useInView } from "framer-motion";
+import { FadeIn } from "@/components/animations";
+import { useAnimatedMetricValues } from "@/lib/motion/useAnimatedInteger";
 import { BentoMetricsGroup, type BentoMetricItem } from "@/components/ui/feature-section-with-bento-grid";
 import { Target } from "lucide-react";
+import { motionDurations } from "@/lib/motion/tokens";
 
 type Metric = {
   id: number;
@@ -76,33 +79,6 @@ const futureMetrics: Metric[] = [
   }
 ];
 
-function useAnimatedCounters(metrics: Metric[], isInView: boolean, duration = 2000) {
-  const [counts, setCounts] = useState(metrics.map(() => 0));
-
-  useEffect(() => {
-    if (!isInView) return;
-
-    const start = performance.now();
-    const animate = (time: number) => {
-      const elapsed = time - start;
-      const progress = Math.min(elapsed / duration, 1);
-      const eased = 1 - Math.pow(1 - progress, 3);
-
-      setCounts(metrics.map(metric => Math.round(metric.value * eased)));
-
-      if (progress < 1) {
-        requestAnimationFrame(animate);
-      }
-    };
-
-    const animationFrame = requestAnimationFrame(animate);
-
-    return () => cancelAnimationFrame(animationFrame);
-  }, [isInView, metrics, duration]);
-
-  return counts;
-}
-
 export default function ImpactMetrics() {
   const currentRef = useRef<HTMLDivElement | null>(null);
   const futureRef = useRef<HTMLDivElement | null>(null);
@@ -116,8 +92,8 @@ export default function ImpactMetrics() {
     margin: "-20% 0px -20% 0px"
   });
 
-  const currentCounts = useAnimatedCounters(currentMetrics, currentInView, 2000);
-  const futureCounts = useAnimatedCounters(futureMetrics, futureInView, 2200);
+  const currentCounts = useAnimatedMetricValues(currentMetrics, currentInView, 2000);
+  const futureCounts = useAnimatedMetricValues(futureMetrics, futureInView, 2200);
 
   const formatMetricValue = (metric: Metric, count: number) =>
     `${metric.prefix || ""}${count.toLocaleString()}${metric.suffix || ""}`;
@@ -132,12 +108,9 @@ export default function ImpactMetrics() {
   return (
     <section className="py-16 md:py-24 bg-[#FCFAEF] dark:bg-[#1C1F1E] text-[#1C1F1E] dark:text-[#FCFAEF] relative">
       <div className="container mx-auto px-4">
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true }}
-          transition={{ duration: 0.6 }}
+        <FadeIn
           className="text-center max-w-3xl mx-auto mb-16"
+          duration={motionDurations.enter}
         >
           <h2 className="text-[#F5C94D] font-bold text-lg mb-2">
             OUR IMPACT
@@ -148,14 +121,10 @@ export default function ImpactMetrics() {
           <p className="text-lg text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
             Since our launch in October 2025, we&apos;re building a student-powered, community-rooted health movement.
           </p>
-        </motion.div>
+        </FadeIn>
 
         <div ref={currentRef} className="space-y-8">
-          <motion.div
-            initial={{ opacity: 0, y: 24 }}
-            animate={currentInView ? { opacity: 1, y: 0 } : {}}
-            transition={{ duration: 0.6 }}
-          >
+          <FadeIn duration={motionDurations.enter}>
             <BentoMetricsGroup
               badge="Today"
               title="What our first chapter already makes possible"
@@ -166,15 +135,14 @@ export default function ImpactMetrics() {
               supportingCopy="Every milestone here represents capacity that can be replicated, studied, and expanded with community partners."
               items={buildMetricItems(currentMetrics, currentCounts)}
             />
-          </motion.div>
+          </FadeIn>
         </div>
 
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true, amount: 0.6 }}
-          transition={{ duration: 0.6, delay: 0.2 }}
+        <FadeIn
           className="mt-12 md:mt-14"
+          delay={0.1}
+          amount={0.6}
+          duration={motionDurations.enter}
         >
           <div className="rounded-[28px] border border-[#0097b2]/15 bg-gradient-to-r from-[#0097b2]/[0.06] via-white/80 to-[#F5C94D]/[0.08] px-6 py-8 text-center shadow-sm backdrop-blur md:px-8 md:py-10 dark:border-[#2F3332] dark:from-[#2F3332] dark:via-[#1C1F1E] dark:to-[#2F3332]">
             <div className="inline-flex items-center justify-center rounded-full bg-[#0097b2]/10 px-4 py-2 text-sm font-medium text-[#0097b2] dark:bg-[#66C4DC]/10 dark:text-[#66C4DC]">
@@ -185,14 +153,10 @@ export default function ImpactMetrics() {
               By 2028, we aim to scale this impact across borders and disciplines, translating early momentum into a much larger network of care, training, and research.
             </p>
           </div>
-        </motion.div>
+        </FadeIn>
 
         <div ref={futureRef} className="mt-12 space-y-8">
-          <motion.div
-            initial={{ opacity: 0, y: 24 }}
-            animate={futureInView ? { opacity: 1, y: 0 } : {}}
-            transition={{ duration: 0.6 }}
-          >
+          <FadeIn duration={motionDurations.enter}>
             <BentoMetricsGroup
               badge="By 2028"
               title="Where this model is designed to go next"
@@ -203,7 +167,7 @@ export default function ImpactMetrics() {
               supportingCopy="The goal is not just growth in numbers, but stronger systems, deeper training pipelines, and broader community access."
               items={buildMetricItems(futureMetrics, futureCounts)}
             />
-          </motion.div>
+          </FadeIn>
         </div>
       </div>
     </section>

--- a/src/components/motion/AnimatedMetric.tsx
+++ b/src/components/motion/AnimatedMetric.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useInView } from "framer-motion";
+import { useRef, type CSSProperties } from "react";
+import { useAnimatedInteger } from "@/lib/motion/useAnimatedInteger";
+import { cn } from "@/lib/utils";
+
+export type AnimatedMetricProps = {
+  value: number;
+  suffix?: string;
+  prefix?: string;
+  className?: string;
+  style?: CSSProperties;
+  durationMs?: number;
+  viewport?: { once?: boolean; amount?: number | "some" | "all" };
+};
+
+export function AnimatedMetric({
+  value,
+  suffix = "",
+  prefix = "",
+  className,
+  style,
+  durationMs = 2000,
+  viewport = { once: true, amount: 0.6 },
+}: AnimatedMetricProps) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const isInView = useInView(ref, viewport);
+  const display = useAnimatedInteger(value, isInView, durationMs);
+  const formatted = `${prefix}${display.toLocaleString()}${suffix}`;
+
+  return (
+    <span ref={ref} className={cn(className)} style={style}>
+      {formatted}
+    </span>
+  );
+}

--- a/src/components/motion/HeroEntrance.tsx
+++ b/src/components/motion/HeroEntrance.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { motion } from "framer-motion";
+import type { ReactNode } from "react";
+import { fadeUpVariants, motionDurations } from "@/lib/motion/tokens";
+
+type HeroLineProps = {
+  delay?: number;
+  className?: string;
+  children: ReactNode;
+};
+
+/**
+ * Mount-time fade-up for hero headings (respects MotionConfig / reduced motion).
+ */
+export function HeroEntranceH1({ delay = 0, className, children }: HeroLineProps) {
+  return (
+    <motion.h1
+      variants={fadeUpVariants({ duration: motionDurations.enter, delay })}
+      initial="hidden"
+      animate="visible"
+      className={className}
+    >
+      {children}
+    </motion.h1>
+  );
+}
+
+export function HeroEntranceP({
+  delay = 0,
+  className,
+  children,
+}: HeroLineProps) {
+  return (
+    <motion.p
+      variants={fadeUpVariants({ duration: motionDurations.enter, delay })}
+      initial="hidden"
+      animate="visible"
+      className={className}
+    >
+      {children}
+    </motion.p>
+  );
+}

--- a/src/components/motion/MotionConfigProvider.tsx
+++ b/src/components/motion/MotionConfigProvider.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { MotionConfig } from "framer-motion";
+import type { ReactNode } from "react";
+
+type MotionConfigProviderProps = {
+  children: ReactNode;
+};
+
+/**
+ * Respects prefers-reduced-motion for all Framer Motion components in the tree.
+ */
+export function MotionConfigProvider({ children }: MotionConfigProviderProps) {
+  return (
+    <MotionConfig reducedMotion="user">{children}</MotionConfig>
+  );
+}

--- a/src/components/resources/ResourceCard.tsx
+++ b/src/components/resources/ResourceCard.tsx
@@ -8,7 +8,7 @@ export default function ResourceCard({ resource }: { resource: Resource }) {
   const isExternal = resource.url.startsWith('http');
   
   return (
-    <div className="bg-white rounded-xl overflow-hidden border border-gray-200 shadow-sm hover:shadow-md transition-shadow">
+    <div className="homepage-hover-card flex flex-col overflow-hidden rounded-xl border border-[#E6E7E7] bg-white shadow-sm [--homepage-hover-border-color:rgba(0,151,178,0.18)] dark:border-[#2F3332] dark:bg-[#4F5554] dark:[--homepage-hover-border-color:rgba(102,196,220,0.22)]">
       <div className="relative h-48">
         {resource.image ? (
           <Image

--- a/src/components/resources/ResourceGrid.tsx
+++ b/src/components/resources/ResourceGrid.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { FadeInStagger, FadeInStaggerItem } from "@/components/animations";
 import ResourceCard from "./ResourceCard";
 import { Resource } from "@/lib/types";
 
@@ -19,11 +22,16 @@ export default function ResourceGrid({ resources }: { resources: Resource[] }) {
         Showing {resources.length} resource{resources.length !== 1 ? "s" : ""}
       </div>
       
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      <FadeInStagger
+        className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
+        staggerDelay={0.08}
+      >
         {resources.map((resource) => (
-          <ResourceCard key={resource.id} resource={resource} />
+          <FadeInStaggerItem key={resource.id}>
+            <ResourceCard resource={resource} />
+          </FadeInStaggerItem>
         ))}
-      </div>
+      </FadeInStagger>
     </div>
   );
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md font-subheading text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "akomapa-btn-interaction inline-flex items-center justify-center whitespace-nowrap rounded-md font-subheading text-sm font-medium ring-offset-background transition-[color,background-color,border-color,box-shadow,transform] duration-200 ease-out hover:-translate-y-px active:scale-[0.99] motion-reduce:hover:translate-y-0 motion-reduce:active:scale-100 motion-reduce:transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {

--- a/src/lib/motion/tokens.ts
+++ b/src/lib/motion/tokens.ts
@@ -1,0 +1,106 @@
+import type { Variants } from "framer-motion";
+
+/** Primary ease curve — refined, fast deceleration */
+export const MOTION_EASE = [0.25, 0.4, 0.25, 1] as const;
+
+export const motionDurations = {
+  enter: 0.4,
+  stagger: 0.08,
+  staggerContainer: 0.1,
+} as const;
+
+export type FadeDirection = "up" | "down" | "left" | "right" | "none";
+
+const ENTER_OFFSET = 20;
+
+export function getScrollRevealOffset(direction: FadeDirection) {
+  switch (direction) {
+    case "up":
+      return { y: ENTER_OFFSET, x: 0 };
+    case "down":
+      return { y: -ENTER_OFFSET, x: 0 };
+    case "left":
+      return { x: ENTER_OFFSET, y: 0 };
+    case "right":
+      return { x: -ENTER_OFFSET, y: 0 };
+    case "none":
+    default:
+      return { x: 0, y: 0 };
+  }
+}
+
+export const defaultScrollViewport = {
+  once: true,
+  amount: 0.2,
+} as const;
+
+export type FadeUpOptions = {
+  direction?: FadeDirection;
+  duration?: number;
+  delay?: number;
+};
+
+export function fadeUpVariants(options: FadeUpOptions = {}): Variants {
+  const {
+    direction = "up",
+    duration = motionDurations.enter,
+    delay = 0,
+  } = options;
+  const offset = getScrollRevealOffset(direction);
+
+  return {
+    hidden: {
+      opacity: 0,
+      x: offset.x,
+      y: offset.y,
+    },
+    visible: {
+      opacity: 1,
+      x: 0,
+      y: 0,
+      transition: {
+        duration,
+        delay,
+        ease: [...MOTION_EASE],
+      },
+    },
+  };
+}
+
+export function fadeUpStaggerContainerVariants(
+  staggerDelay: number = motionDurations.staggerContainer
+): Variants {
+  return {
+    hidden: { opacity: 0 },
+    visible: {
+      opacity: 1,
+      transition: {
+        staggerChildren: staggerDelay,
+      },
+    },
+  };
+}
+
+export function fadeUpStaggerItemVariants(
+  options: Omit<FadeUpOptions, "delay"> = {}
+): Variants {
+  const { direction = "up", duration = motionDurations.enter } = options;
+  const offset = getScrollRevealOffset(direction);
+
+  return {
+    hidden: {
+      opacity: 0,
+      x: offset.x,
+      y: offset.y,
+    },
+    visible: {
+      opacity: 1,
+      x: 0,
+      y: 0,
+      transition: {
+        duration,
+        ease: [...MOTION_EASE],
+      },
+    },
+  };
+}

--- a/src/lib/motion/useAnimatedInteger.ts
+++ b/src/lib/motion/useAnimatedInteger.ts
@@ -1,0 +1,89 @@
+"use client";
+
+import { useReducedMotion } from "framer-motion";
+import { useEffect, useState } from "react";
+
+function easeOutCubic(t: number) {
+  return 1 - Math.pow(1 - t, 3);
+}
+
+/**
+ * Animates from 0 to `target` while `isActive` is true.
+ * Respects `prefers-reduced-motion`: jumps to `target` immediately when active.
+ */
+export function useAnimatedInteger(
+  target: number,
+  isActive: boolean,
+  durationMs = 2000
+): number {
+  const reducedMotion = useReducedMotion();
+  const [value, setValue] = useState(0);
+
+  useEffect(() => {
+    if (!isActive) return;
+
+    if (reducedMotion) {
+      setValue(target);
+      return;
+    }
+
+    const start = performance.now();
+    let raf = 0;
+
+    const tick = (time: number) => {
+      const elapsed = time - start;
+      const progress = Math.min(elapsed / durationMs, 1);
+      const eased = easeOutCubic(progress);
+      setValue(Math.round(target * eased));
+      if (progress < 1) {
+        raf = requestAnimationFrame(tick);
+      }
+    };
+
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [isActive, target, durationMs, reducedMotion]);
+
+  return value;
+}
+
+type MetricLike = { value: number };
+
+/**
+ * Parallel count-up for multiple metrics (single rAF loop).
+ */
+export function useAnimatedMetricValues<T extends MetricLike>(
+  metrics: T[],
+  isInView: boolean,
+  durationMs = 2000
+): number[] {
+  const reducedMotion = useReducedMotion();
+  const [counts, setCounts] = useState(() => metrics.map(() => 0));
+
+  useEffect(() => {
+    if (!isInView) return;
+
+    if (reducedMotion) {
+      setCounts(metrics.map((m) => m.value));
+      return;
+    }
+
+    const start = performance.now();
+    let raf = 0;
+
+    const tick = (time: number) => {
+      const elapsed = time - start;
+      const progress = Math.min(elapsed / durationMs, 1);
+      const eased = easeOutCubic(progress);
+      setCounts(metrics.map((m) => Math.round(m.value * eased)));
+      if (progress < 1) {
+        raf = requestAnimationFrame(tick);
+      }
+    };
+
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [isInView, metrics, durationMs, reducedMotion]);
+
+  return counts;
+}


### PR DESCRIPTION
### Summary

Introduces a consistent, lightweight motion layer across the site: shared Framer Motion config for accessibility, motion tokens, reusable scroll/hero primitives, unified animated metrics, and aligned button/card interactions.

### What changed

- **Global**: `MotionConfigProvider` with `reducedMotion="user"` so animations respect system “reduce motion”.
- **Tokens & UI**: `src/lib/motion/tokens.ts` (durations, ease, 20px reveal, `fadeUpVariants`, stagger helpers); `FadeIn` / `SectionReveal` / stagger updated to match.
- **Metrics**: `AnimatedMetric`, `useAnimatedInteger`, `useAnimatedMetricValues` — count-up defers to final values when reduced motion is preferred; refactors home impact + clinics/programs pages that duplicated spring counters.
- **Chrome**: Subtle button hover/active motion + `globals.css` guard for reduced motion; `ResourceCard` uses `homepage-hover-card` elevation pattern.
- **Routes**: Resources page uses `FadeIn` + grid stagger; Terms/Privacy use `HeroEntranceH1`/`HeroEntranceP`; `(main)/template.tsx` adds a short segment enter fade.

### How to test

- `npm run validate` (lint, typecheck, build, e2e)
- Toggle OS/browser **Reduce motion**: scroll reveals and counters should snap; card hover lift should not translate.
- Spot-check mobile vs desktop on home, resources, terms, and a program page with metrics.