### PR TITLE
[Rebrand] Define TypeScript types for rebrand data models

### DIFF
--- a/src/components/home/ProgramsOverview.tsx
+++ b/src/components/home/ProgramsOverview.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, KeyboardEvent } from "react";
+import { useState } from "react";
+import type { KeyboardEvent } from "react";
 import { motion } from "framer-motion";
 import Link from "next/link";
 import Image from "@/components/common/Image";
@@ -8,9 +9,9 @@ import { ArrowRight, Stethoscope, Network, GraduationCap, Globe2 } from "lucide-
 import type { LucideIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import ProgramModal from "@/components/shared/ProgramModal";
-import { Program } from "@/lib/types";
+import type { Program } from "@/lib/types";
 
-type Pillar = {
+type HomepagePillar = {
   id: number;
   title: string;
   shortDescription: string;
@@ -28,7 +29,7 @@ type Pillar = {
   ctaLabel: string;
 };
 
-const pillars: Pillar[] = [
+const pillars: HomepagePillar[] = [
   {
     id: 1,
     title: "Akomapa Clinics",
@@ -159,7 +160,7 @@ export default function ProgramsOverview() {
   const [selectedProgram, setSelectedProgram] = useState<Program | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const openProgramModal = (pillar: Pillar) => {
+  const openProgramModal = (pillar: HomepagePillar) => {
     const program: Program = {
       id: pillar.id.toString(),
       title: pillar.title,
@@ -184,7 +185,7 @@ export default function ProgramsOverview() {
     setSelectedProgram(null);
   };
 
-  const handleCardKeyDown = (event: KeyboardEvent<HTMLDivElement>, pillar: Pillar) => {
+  const handleCardKeyDown = (event: KeyboardEvent<HTMLDivElement>, pillar: HomepagePillar) => {
     if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
       openProgramModal(pillar);

--- a/src/data/team.ts
+++ b/src/data/team.ts
@@ -1,9 +1,10 @@
-import { TeamMember } from "@/lib/types";
+import type { TeamMember } from "@/lib/types";
 
 export const teamMembers: TeamMember[] = [
   // Global Executive Team Members
   {
     id: "1",
+    roleCategory: "executive",
     name: "Brian Fleischer, MD",
     title: "Founder and President",
     bio: "Brian Fleischer is the Founder and President of Akomapa Health Foundation. He holds an MD from Yale University and has extensive experience in global health initiatives across Africa.",
@@ -15,6 +16,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "2",
+    roleCategory: "executive",
     name: "Esi Bon Berkoh",
     title: "Co-founder and Vice President",
     bio: "Esi Bon Berkoh is the Co-founder and Vice President of Akomapa Health Foundation. She brings her expertise from the University of Cape Coast to drive our mission forward.",
@@ -26,6 +28,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "3",
+    roleCategory: "executive",
     name: "Afriyie Badu, MD",
     title: "Co-founder and Chief Financial Officer",
     bio: "Afriyie Badu serves as Co-founder and Chief Financial Officer. He holds an MD from the University of Ghana and oversees our financial operations and strategic planning.",
@@ -37,6 +40,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "4",
+    roleCategory: "executive",
     name: "Bismark Amoh",
     title: "Co-founder and Head of Research",
     bio: "Bismark Amoh is Co-founder and Head of Research at Akomapa Health Foundation. He brings his expertise from DGSOM UCLA to lead our research initiatives and evidence-based programs.",
@@ -48,6 +52,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "5",
+    roleCategory: "executive",
     name: "Dzifianu Ai Edoh-Torgah",
     title: "Head of Branding and Public Relations",
     bio: "Dzifianu Ai Edoh-Torgah leads our branding and public relations efforts, ensuring Akomapa Health Foundation maintains a strong presence and positive reputation in the global health community.",
@@ -59,6 +64,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "6",
+    roleCategory: "executive",
     name: "Prince Agyei Tuffour",
     title: "Head of IT Services",
     bio: "Prince Agyei Tuffour oversees our technology infrastructure and digital solutions, ensuring our IT systems support our mission effectively and securely.",
@@ -70,6 +76,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "7",
+    roleCategory: "executive",
     name: "Mighty Doffoe",
     title: "Asst Head of IT Services",
     bio: "Mighty Doffoe serves as Assistant Head of IT Services, supporting our technology initiatives and ensuring smooth digital operations across all our programs.",
@@ -81,6 +88,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "8",
+    roleCategory: "executive",
     name: "Samuel Kumi",
     title: "Head of Legal Services",
     bio: "Samuel Kumi leads our legal services, ensuring compliance with international regulations and providing legal guidance for our global health initiatives.",
@@ -92,6 +100,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "9",
+    roleCategory: "executive",
     name: "Sedem Dankwa",
     title: "Team Lead, Akomapa Health Foundation U.S",
     bio: "Sedem Dankwa serves as Team Lead for Akomapa Health Foundation U.S, coordinating our operations and partnerships in the United States.",
@@ -105,6 +114,7 @@ export const teamMembers: TeamMember[] = [
   // USA Team Members
   {
     id: "10",
+    roleCategory: "executive",
     name: "Sedem Dankwa",
     title: "Team Lead/ Head of International Partnerships",
     bio: "Sedem Dankwa from Yale University serves as Team Lead and Head of International Partnerships, driving our global collaborations and strategic partnerships.",
@@ -116,6 +126,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "11",
+    roleCategory: "executive",
     name: "Brian Fleischer",
     title: "Team Lead",
     bio: "Brian Fleischer serves as Team Lead for our USA operations, bringing his leadership and expertise to drive our mission forward in the United States.",
@@ -127,6 +138,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "12",
+    roleCategory: "executive",
     name: "Adwoa Danso-Dodoo",
     title: "Finance and Compliance Officer",
     bio: "Adwoa Danso-Dodoo from Yale University serves as Finance and Compliance Officer, ensuring financial integrity and regulatory compliance across our operations.",
@@ -138,6 +150,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "13",
+    roleCategory: "executive",
     name: "Nana Ama Ocran",
     title: "Head of the Akomapa Global Health Leadership Training program",
     bio: "Nana Ama Ocran from Yale University leads our Global Health Leadership Training program, developing the next generation of healthcare leaders.",
@@ -149,6 +162,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "14",
+    roleCategory: "executive",
     name: "Amma Buckman",
     title: "Team Member",
     bio: "Amma Buckman from David Geffen School of Medicine at UCLA contributes her expertise to our USA team, supporting our mission to improve global health outcomes.",
@@ -160,6 +174,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "15",
+    roleCategory: "executive",
     name: "Bismark Amoh",
     title: "Team Member",
     bio: "Bismark Amoh from David Geffen School of Medicine at UCLA brings his research expertise to our USA operations, supporting evidence-based healthcare initiatives.",
@@ -173,6 +188,7 @@ export const teamMembers: TeamMember[] = [
   // UCC Chapter Leadership Team
   {
     id: "16",
+    roleCategory: "community-leader",
     name: "David Ofosu",
     title: "Co-Director",
     bio: "David Ofosu serves as Co-Director of our UCC Chapter, leading local initiatives and coordinating student engagement in healthcare programs.",
@@ -184,6 +200,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "17",
+    roleCategory: "community-leader",
     name: "Hafiz Shaban",
     title: "Co-Director",
     bio: "Hafiz Shaban serves as Co-Director of our UCC Chapter, working alongside David to lead our local healthcare initiatives and student programs.",
@@ -195,6 +212,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "18",
+    roleCategory: "community-leader",
     name: "Getwell Essuman",
     title: "Volunteer Recruitment Lead",
     bio: "Getwell Essuman leads our volunteer recruitment efforts, ensuring we have dedicated volunteers to support our healthcare programs and community initiatives.",
@@ -206,6 +224,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "19",
+    roleCategory: "community-leader",
     name: "David Konadu Kombate",
     title: "Volunteer Recruitment Lead",
     bio: "David Konadu Kombate serves as Volunteer Recruitment Lead, working to expand our volunteer network and support our mission through community engagement.",
@@ -217,6 +236,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "20",
+    roleCategory: "community-leader",
     name: "Wilfred Obeng",
     title: "Training and Standards Co-ordinator",
     bio: "Wilfred Obeng coordinates our training programs and maintains high standards across all our healthcare initiatives and educational programs.",
@@ -228,6 +248,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "21",
+    roleCategory: "community-leader",
     name: "Belinda Odoom",
     title: "Training and Standards Co-ordinator",
     bio: "Belinda Odoom serves as Training and Standards Co-ordinator, ensuring quality training programs and maintaining high standards in our healthcare delivery.",
@@ -239,6 +260,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "22",
+    roleCategory: "community-leader",
     name: "Geraldine-Cristal Apeadua Agyapong",
     title: "Financial Officer",
     bio: "Geraldine-Cristal Apeadua Agyapong manages our financial operations, ensuring transparency and accountability in all our financial activities.",
@@ -250,6 +272,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "23",
+    roleCategory: "community-leader",
     name: "Frederick Baffour",
     title: "Financial Officer",
     bio: "Frederick Baffour serves as Financial Officer, supporting our financial management and ensuring proper allocation of resources for our programs.",
@@ -261,6 +284,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "24",
+    roleCategory: "community-leader",
     name: "Gloria Tawiah Blay",
     title: "Community Engagement Liaison",
     bio: "Gloria Tawiah Blay serves as Community Engagement Liaison, building strong relationships with local communities and stakeholders.",
@@ -272,6 +296,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "25",
+    roleCategory: "community-leader",
     name: "Prince Nyarkoh",
     title: "Community Engagement Liaison",
     bio: "Prince Nyarkoh serves as Community Engagement Liaison, working to strengthen our community partnerships and local healthcare initiatives.",
@@ -283,6 +308,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "26",
+    roleCategory: "community-leader",
     name: "Queenstar Aduse Opoku",
     title: "Supplies and Logistics Manager",
     bio: "Queenstar Aduse Opoku manages our supplies and logistics, ensuring efficient distribution of medical supplies and resources to support our programs.",
@@ -294,6 +320,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "27",
+    roleCategory: "community-leader",
     name: "Martha Bawa",
     title: "Supplies and Logistics Manager",
     bio: "Martha Bawa serves as Supplies and Logistics Manager, coordinating the distribution of medical supplies and ensuring proper resource management.",
@@ -307,6 +334,7 @@ export const teamMembers: TeamMember[] = [
   // Advisory Board Members
   {
     id: "28",
+    roleCategory: "advisor",
     name: "Dr. Derek Anamaale Tuoyire",
     title: "Head of Community Medicine - University of Cape Coast",
     bio: "Dr. Derek Anamaale Tuoyire serves on our Advisory Board, bringing his expertise in community medicine from the University of Cape Coast to guide our community health initiatives.",
@@ -318,6 +346,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "29",
+    roleCategory: "advisor",
     name: "Prof. Martins Ekor",
     title: "Provost, College of Health and Allied Sciences, University of Cape Coast",
     bio: "Prof. Martins Ekor serves on our Advisory Board, providing strategic guidance from his position as Provost of the College of Health and Allied Sciences at the University of Cape Coast.",
@@ -329,6 +358,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "30",
+    roleCategory: "advisor",
     name: "Emily Sheldon",
     title: "Co-Founder, African Health Innovation Center",
     bio: "Emily Sheldon serves on our Advisory Board, bringing her expertise in public health and healthcare leadership to support our healthcare programs and initiatives.",
@@ -340,6 +370,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "31",
+    roleCategory: "advisor",
     name: "Dr. Jeremy Schwartz",
     title: "Head of Chronic Care Access Lab - Yale University",
     bio: "Dr. Jeremy Schwartz serves on our Advisory Board, providing expertise in chronic care access and healthcare delivery from his position at Yale University.",
@@ -351,6 +382,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "32",
+    roleCategory: "advisor",
     name: "Dr. Adrian Mayo",
     title: "Assistant Clinical Professor - David Geffen School of Medicine, UCLA",
     bio: "Dr. Adrian Mayo serves on our Advisory Board, bringing clinical expertise and research insights from his position at the David Geffen School of Medicine at UCLA.",
@@ -362,6 +394,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "33",
+    roleCategory: "advisor",
     name: "Dr. Elijah Paintsil",
     title: "Chief and Chair of Pediatrics, Boston Medical Center",
     bio: "Dr. Elijah Paintsil serves on our Advisory Board, providing pediatric expertise and healthcare leadership from his position as Chief and Chair of Pediatrics at Boston Medical Center.",
@@ -373,6 +406,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "34",
+    roleCategory: "advisor",
     name: "Prof. Alfred Yawson",
     title: "Provost, University of Ghana College of Health Sciences",
     bio: "Prof. Alfred Yamoah serves on our Advisory Board, providing public health expertise and healthcare leadership from his position as Provost of the University of Ghana College of Health Sciences.",
@@ -384,6 +418,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "35",
+    roleCategory: "advisor",
     name: "Freda Yawson",
     title: "Founder, Innovate Ghana and Innovate Labs",
     bio: "Freda Yawson serves on our Advisory Board, providing public health expertise and healthcare leadership from her position as Founder of Innovate Ghana and Innovate Labs.",

--- a/src/lib/__tests__/types.test.ts
+++ b/src/lib/__tests__/types.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import { teamMembers } from "@/data/team";
+import type {
+  AcademyCurriculum,
+  AcademyModule,
+  BlogPost,
+  CommunityHub,
+  FacultyMember,
+  HubMetrics,
+  HubMission,
+  ImpactCategory,
+  ImpactMetric,
+  InnovationItem,
+  MapLocation,
+  MentorshipInfo,
+  Partner,
+  PhilosophySection,
+  Pillar,
+  ResearchItem,
+  Story,
+  TeamMember,
+  TimelineEvent,
+} from "@/lib/types";
+
+type OptionalKeys<T> = {
+  [Key in keyof T]-?: undefined extends T[Key] ? Key : never;
+}[keyof T];
+
+describe("rebrand data model contracts", () => {
+  it("defines the pillar, academy, and faculty models", () => {
+    const pillar: Pillar = {
+      id: "academy",
+      title: "Akomapa Academy",
+      description: "Developing ethical global health leaders.",
+      icon: "GraduationCap",
+      color: "cyan",
+      features: ["Leadership curriculum", "Faculty mentorship"],
+      link: "/academy",
+    };
+
+    const academyModule: AcademyModule = {
+      id: "ethical-leadership",
+      title: "Ethical Leadership",
+      description: "Foundations for equitable global health leadership.",
+      learningObjectives: ["Apply ethical frameworks to community health"],
+      facultyContributors: ["faculty-1"],
+      order: 1,
+    };
+
+    const curriculum: AcademyCurriculum = {
+      modules: [academyModule],
+      totalDuration: "12 weeks",
+      certificationName: "Akomapa Global Health Leadership Certificate",
+      certificationDescription: "Recognizes completion of the Academy curriculum.",
+    };
+
+    const facultyMember: FacultyMember = {
+      id: "faculty-1",
+      name: "Dr. Akomapa",
+      title: "Faculty Mentor",
+      institution: "Akomapa Academy",
+      bio: "Supports emerging global health leaders.",
+      image: "/images/team/faculty.jpg",
+      specialties: ["Global health", "Mentorship"],
+    };
+
+    expectTypeOf(pillar).toEqualTypeOf<Pillar>();
+    expectTypeOf(academyModule).toEqualTypeOf<AcademyModule>();
+    expectTypeOf(curriculum).toEqualTypeOf<AcademyCurriculum>();
+    expectTypeOf(facultyMember).toEqualTypeOf<FacultyMember>();
+    expectTypeOf<OptionalKeys<AcademyModule>>().toEqualTypeOf<"duration">();
+    expectTypeOf<OptionalKeys<FacultyMember>>().toEqualTypeOf<"socialLinks">();
+  });
+
+  it("supports a fully nested community hub model", () => {
+    const mission: HubMission = {
+      id: 1,
+      title: "Improve Community Health",
+      description: "Expand access to preventative care.",
+    };
+
+    const story: Story = {
+      id: "story-1",
+      title: "Community-led care",
+      excerpt: "A local leader reflects on the hub.",
+      content: "The community shaped the model from the beginning.",
+      author: "Community Leader",
+      role: "community-leader",
+      date: "2026-06-21",
+    };
+
+    const mentorship: MentorshipInfo = {
+      model: "Faculty-supervised, student-led care",
+      mentors: ["faculty-1"],
+    };
+
+    const research: ResearchItem = {
+      id: "research-1",
+      title: "Community hypertension outcomes",
+      description: "Measures longitudinal outcomes from hub screenings.",
+      status: "ongoing",
+    };
+
+    const innovation: InnovationItem = {
+      id: "innovation-1",
+      title: "Nkwapa EMR",
+      description: "A community health record platform.",
+      category: "nkwapa",
+    };
+
+    const metrics: HubMetrics = {
+      patientsServed: 100,
+      studentsTrained: 25,
+      communitiesReached: 6,
+      partnersEngaged: 4,
+    };
+
+    const hub: CommunityHub = {
+      id: "hub-ucc",
+      slug: "ucc",
+      name: "Akomapa UCC Community Hub",
+      location: "Cape Coast",
+      country: "Ghana",
+      description: "A student-led community health hub.",
+      image: "/images/hubs/ucc.jpg",
+      color: "cyan",
+      status: "active",
+      missions: [mission],
+      communityStories: [story],
+      studentStories: [story],
+      facultyMentorship: mentorship,
+      research: [research],
+      innovations: [innovation],
+      metrics,
+    };
+
+    expectTypeOf(hub).toEqualTypeOf<CommunityHub>();
+    expectTypeOf(hub.missions).toEqualTypeOf<HubMission[]>();
+    expectTypeOf(hub.communityStories).toEqualTypeOf<Story[] | undefined>();
+    expectTypeOf(hub.facultyMentorship).toEqualTypeOf<MentorshipInfo | undefined>();
+    expectTypeOf(hub.research).toEqualTypeOf<ResearchItem[] | undefined>();
+    expectTypeOf(hub.innovations).toEqualTypeOf<InnovationItem[] | undefined>();
+    expectTypeOf(hub.metrics).toEqualTypeOf<HubMetrics>();
+    expectTypeOf<CommunityHub["status"]>().toEqualTypeOf<
+      "active" | "in-development" | "planned"
+    >();
+    expectTypeOf<ResearchItem["status"]>().toEqualTypeOf<
+      "ongoing" | "completed" | "published"
+    >();
+    expectTypeOf<InnovationItem["category"]>().toEqualTypeOf<
+      "nkwapa" | "quality-improvement" | "technology"
+    >();
+  });
+
+  it("defines partnership, philosophy, timeline, impact, map, and blog models", () => {
+    const partner: Partner = {
+      id: "partner-1",
+      name: "Partner University",
+      logo: "/images/partners/university.svg",
+      description: "An academic partner.",
+      category: "university",
+      country: "Ghana",
+    };
+
+    const philosophySection: PhilosophySection = {
+      id: "good-heart",
+      title: "A Good Heart",
+      content: "Health leadership begins with service.",
+      order: 1,
+    };
+
+    const timelineEvent: TimelineEvent = {
+      id: "launch",
+      year: "2025",
+      title: "Akomapa launches",
+      description: "The first community clinic opens.",
+      milestone: true,
+    };
+
+    const impactMetric: ImpactMetric = {
+      id: "patients-served",
+      label: "Patients served",
+      currentValue: "100+",
+    };
+
+    const impactCategory: ImpactCategory = {
+      id: "community-health",
+      title: "Community Health",
+      metrics: [impactMetric],
+    };
+
+    const mapLocation: MapLocation = {
+      id: "ucc",
+      name: "Akomapa UCC",
+      coordinates: { lat: 5.1036, lng: -1.2825 },
+      type: "active-hub",
+      description: "Akomapa's Cape Coast community hub.",
+    };
+
+    const blogPost: BlogPost = {
+      id: "post-1",
+      slug: "leading-with-a-good-heart",
+      title: "Leading with a Good Heart",
+      excerpt: "A reflection on ethical global health leadership.",
+      content: "Leadership is rooted in service.",
+      author: "Akomapa Faculty",
+      authorRole: "Faculty Mentor",
+      category: "faculty-reflection",
+      tags: ["leadership", "global-health"],
+      date: "2026-06-21",
+      featured: true,
+    };
+
+    expectTypeOf(partner).toEqualTypeOf<Partner>();
+    expectTypeOf(philosophySection).toEqualTypeOf<PhilosophySection>();
+    expectTypeOf(timelineEvent).toEqualTypeOf<TimelineEvent>();
+    expectTypeOf(impactMetric).toEqualTypeOf<ImpactMetric>();
+    expectTypeOf(impactCategory).toEqualTypeOf<ImpactCategory>();
+    expectTypeOf(mapLocation).toEqualTypeOf<MapLocation>();
+    expectTypeOf(blogPost).toEqualTypeOf<BlogPost>();
+    expectTypeOf<Partner["category"]>().toEqualTypeOf<
+      "university" | "community" | "government" | "global"
+    >();
+    expectTypeOf<MapLocation["type"]>().toEqualTypeOf<
+      "active-hub" | "planned-hub" | "partner"
+    >();
+    expectTypeOf<BlogPost["category"]>().toEqualTypeOf<
+      | "student-essay"
+      | "faculty-reflection"
+      | "article"
+      | "community-voice"
+      | "recorded-talk"
+      | "conference-session"
+    >();
+  });
+
+  it("keeps optional properties optional", () => {
+    expectTypeOf<OptionalKeys<Story>>().toEqualTypeOf<"image">();
+    expectTypeOf<OptionalKeys<ResearchItem>>().toEqualTypeOf<"link">();
+    expectTypeOf<OptionalKeys<Partner>>().toEqualTypeOf<"website">();
+    expectTypeOf<OptionalKeys<PhilosophySection>>().toEqualTypeOf<
+      "image" | "quote"
+    >();
+    expectTypeOf<OptionalKeys<TimelineEvent>>().toEqualTypeOf<"icon">();
+    expectTypeOf<OptionalKeys<ImpactMetric>>().toEqualTypeOf<
+      "futureValue" | "futureYear" | "icon"
+    >();
+    expectTypeOf<OptionalKeys<BlogPost>>().toEqualTypeOf<
+      "authorImage" | "image" | "videoUrl"
+    >();
+  });
+
+  it("requires a supported role category for every team member", () => {
+    expectTypeOf<TeamMember["roleCategory"]>().toEqualTypeOf<
+      | "executive"
+      | "faculty"
+      | "advisor"
+      | "community-leader"
+      | "government-leader"
+      | "partner-institution"
+    >();
+
+    const roleCounts = teamMembers.reduce<Record<TeamMember["roleCategory"], number>>(
+      (counts, member) => {
+        counts[member.roleCategory] += 1;
+        return counts;
+      },
+      {
+        executive: 0,
+        faculty: 0,
+        advisor: 0,
+        "community-leader": 0,
+        "government-leader": 0,
+        "partner-institution": 0,
+      },
+    );
+
+    expect(roleCounts).toEqual({
+      executive: 15,
+      faculty: 0,
+      advisor: 8,
+      "community-leader": 12,
+      "government-leader": 0,
+      "partner-institution": 0,
+    });
+  });
+});

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,107 +1,300 @@
 export interface Program {
-    id: string;
-    title: string;
-    slug: string;
-    description: string;
-    fullDescription: string;
-    approach: string;
-    category: string;
-    image: string;
-    established: string;
-    locations: string[];
-    peopleServed: string;
-    keyPoints: string[];
-    impacts: string[];
-  }
-  
-  export interface Resource {
-    id: string;
-    title: string;
-    description: string;
-    category: string;
-    type: string;
-    image?: string;
-    url: string;
-    downloadUrl?: string;
-    programs: string[];
-    date: string;
-  }
-  
-  export interface News {
-    id: string;
-    title: string;
-    slug: string;
-    excerpt: string;
-    content: string[];
-    image: string;
-    date: string;
-    category: string;
-    featured?: boolean;
-    tags?: string[];
-  }
-  
-  export interface TeamMember {
-    id: string;
-    name: string;
-    title: string;
-    bio: string;
-    image: string;
-    socialLinks?: {
-      linkedin?: string;
-      twitter?: string;
-      email?: string;
-    };
-  }
-  
-  export interface Testimonial {
-    id: number;
-    quote: string;
-    name: string;
-    title: string;
-    image: string;
-  }
+  id: string;
+  title: string;
+  slug: string;
+  description: string;
+  fullDescription: string;
+  approach: string;
+  category: string;
+  image: string;
+  established: string;
+  locations: string[];
+  peopleServed: string;
+  keyPoints: string[];
+  impacts: string[];
+}
 
-  export interface Announcement {
-    id: string;
-    title: string;
-    description: string;
-    tag?: string;
-    tagColor?: "lapis" | "amber" | "skobeloff";
-    image?: string;
-    videoUrl?: string;
-    /** Optional poster override; otherwise YouTube/Vimeo preview or `image` is used. */
-    thumbnail?: string;
-    ctaText?: string;
-    ctaLink?: string;
-    isExternal?: boolean;
-    /**
-     * Optional substrings of `title` to highlight with brand accent colors
-     * (alternating cyan/amber). Substrings are matched literally, in order.
-     * Leave undefined or empty to render the title in plain white.
-     */
-    titleHighlights?: string[];
-  }
+export interface Resource {
+  id: string;
+  title: string;
+  description: string;
+  category: string;
+  type: string;
+  image?: string;
+  url: string;
+  downloadUrl?: string;
+  programs: string[];
+  date: string;
+}
 
-  export interface AnnouncementCampaign {
-    version: string;
-    slides: Announcement[];
-  }
+export interface News {
+  id: string;
+  title: string;
+  slug: string;
+  excerpt: string;
+  content: string[];
+  image: string;
+  date: string;
+  category: string;
+  featured?: boolean;
+  tags?: string[];
+}
 
-  export interface NewsItem {
-    id: string;
-    title: string;
-    excerpt: string;
-    content: string[];
-    image: string;
-    videoUrl: string | null;
-    thumbnail: string | null;
-    date: string | null;
-    category: string;
-    categoryColor: "lapis" | "amber" | "skobeloff";
-    tags: string[];
-    featured: boolean;
-    ctaText: string | null;
-    ctaLink: string | null;
-    isExternalCta: boolean;
-    source: "announcement" | "news";
-  }
+export interface TeamMember {
+  id: string;
+  name: string;
+  title: string;
+  bio: string;
+  image: string;
+  roleCategory:
+    | "executive"
+    | "faculty"
+    | "advisor"
+    | "community-leader"
+    | "government-leader"
+    | "partner-institution";
+  socialLinks?: {
+    linkedin?: string;
+    twitter?: string;
+    email?: string;
+  };
+}
+
+export interface Testimonial {
+  id: number;
+  quote: string;
+  name: string;
+  title: string;
+  image: string;
+}
+
+export interface Pillar {
+  id: string;
+  title: string;
+  description: string;
+  icon: string;
+  color: string;
+  features: string[];
+  link: string;
+}
+
+export interface AcademyModule {
+  id: string;
+  title: string;
+  description: string;
+  learningObjectives: string[];
+  facultyContributors: string[];
+  duration?: string;
+  order: number;
+}
+
+export interface AcademyCurriculum {
+  modules: AcademyModule[];
+  totalDuration: string;
+  certificationName: string;
+  certificationDescription: string;
+}
+
+export interface FacultyMember {
+  id: string;
+  name: string;
+  title: string;
+  institution: string;
+  bio: string;
+  image: string;
+  specialties: string[];
+  socialLinks?: {
+    linkedin?: string;
+    email?: string;
+    website?: string;
+  };
+}
+
+export interface CommunityHub {
+  id: string;
+  slug: string;
+  name: string;
+  location: string;
+  country: string;
+  description: string;
+  image: string;
+  color: string;
+  status: "active" | "in-development" | "planned";
+  missions: HubMission[];
+  communityStories?: Story[];
+  studentStories?: Story[];
+  facultyMentorship?: MentorshipInfo;
+  research?: ResearchItem[];
+  innovations?: InnovationItem[];
+  metrics: HubMetrics;
+}
+
+export interface HubMission {
+  id: number;
+  title: string;
+  description: string;
+}
+
+export interface Story {
+  id: string;
+  title: string;
+  excerpt: string;
+  content: string;
+  author: string;
+  role: string;
+  image?: string;
+  date: string;
+}
+
+export interface MentorshipInfo {
+  model: string;
+  mentors: string[];
+}
+
+export interface ResearchItem {
+  id: string;
+  title: string;
+  description: string;
+  status: "ongoing" | "completed" | "published";
+  link?: string;
+}
+
+export interface InnovationItem {
+  id: string;
+  title: string;
+  description: string;
+  category: "nkwapa" | "quality-improvement" | "technology";
+}
+
+export interface HubMetrics {
+  patientsServed: number;
+  studentsTrained: number;
+  communitiesReached: number;
+  partnersEngaged: number;
+}
+
+export interface Partner {
+  id: string;
+  name: string;
+  logo: string;
+  description: string;
+  category: "university" | "community" | "government" | "global";
+  website?: string;
+  country: string;
+}
+
+export interface PhilosophySection {
+  id: string;
+  title: string;
+  content: string;
+  order: number;
+  image?: string;
+  quote?: {
+    text: string;
+    author: string;
+    role: string;
+  };
+}
+
+export interface TimelineEvent {
+  id: string;
+  year: string;
+  title: string;
+  description: string;
+  icon?: string;
+  milestone: boolean;
+}
+
+export interface ImpactCategory {
+  id: string;
+  title: string;
+  metrics: ImpactMetric[];
+}
+
+export interface ImpactMetric {
+  id: string;
+  label: string;
+  currentValue: string;
+  futureValue?: string;
+  futureYear?: number;
+  icon?: string;
+}
+
+export interface MapLocation {
+  id: string;
+  name: string;
+  coordinates: {
+    lat: number;
+    lng: number;
+  };
+  type: "active-hub" | "planned-hub" | "partner";
+  description: string;
+}
+
+export interface BlogPost {
+  id: string;
+  slug: string;
+  title: string;
+  excerpt: string;
+  content: string;
+  author: string;
+  authorRole: string;
+  authorImage?: string;
+  category:
+    | "student-essay"
+    | "faculty-reflection"
+    | "article"
+    | "community-voice"
+    | "recorded-talk"
+    | "conference-session";
+  tags: string[];
+  image?: string;
+  date: string;
+  featured: boolean;
+  videoUrl?: string;
+}
+
+export interface Announcement {
+  id: string;
+  title: string;
+  description: string;
+  tag?: string;
+  tagColor?: "lapis" | "amber" | "skobeloff";
+  image?: string;
+  videoUrl?: string;
+  /** Optional poster override; otherwise YouTube/Vimeo preview or `image` is used. */
+  thumbnail?: string;
+  ctaText?: string;
+  ctaLink?: string;
+  isExternal?: boolean;
+  /**
+   * Optional substrings of `title` to highlight with brand accent colors
+   * (alternating cyan/amber). Substrings are matched literally, in order.
+   * Leave undefined or empty to render the title in plain white.
+   */
+  titleHighlights?: string[];
+}
+
+export interface AnnouncementCampaign {
+  version: string;
+  slides: Announcement[];
+}
+
+export interface NewsItem {
+  id: string;
+  title: string;
+  excerpt: string;
+  content: string[];
+  image: string;
+  videoUrl: string | null;
+  thumbnail: string | null;
+  date: string | null;
+  category: string;
+  categoryColor: "lapis" | "amber" | "skobeloff";
+  tags: string[];
+  featured: boolean;
+  ctaText: string | null;
+  ctaLink: string | null;
+  isExternalCta: boolean;
+  source: "announcement" | "news";
+}


### PR DESCRIPTION
## Summary

Closes #102.

Introduces the shared TypeScript data contracts required by the Akomapa rebrand, including models for organizational pillars, Academy content, faculty, Community Hubs, partnerships, philosophy sections, timeline events, impact data, map locations, and thought-leadership posts.

## Changes

- Added all rebrand interfaces to `src/lib/types.ts`
- Added the required `roleCategory` union to `TeamMember`
- Classified all existing team records:
  - 15 executive members
  - 12 community leaders
  - 8 advisors
- Renamed the homepage-specific `Pillar` type to `HomepagePillar`
- Preserved the homepage's existing data structure and behavior
- Converted touched type imports to type-only imports
- Added type-contract tests covering:
  - Every new exported interface
  - Nested Community Hub relationships
  - Optional properties
  - Status and category literal unions
  - Team role-category contracts and migrated data

## Compatibility

Existing data models remain intact. No routes, component behavior, dependencies, schemas, or visual output were changed.

## Validation

- [x] ESLint
- [x] TypeScript (`tsc --noEmit`)
- [x] Unit tests — 42 passed
- [x] Production build
- [x] Playwright E2E — 107 passed
- [x] Pre-commit hooks on every commit
- [x] Production dependency audit — 0 vulnerabilities
- [x] Clean final worktree