### PR TITLE
Rebrand/build our philosophy page

### DIFF
--- a/e2e/pages-render.spec.ts
+++ b/e2e/pages-render.spec.ts
@@ -9,6 +9,7 @@ const pages = [
   { path: '/', title: 'Akomapa' },
   { path: '/about', title: 'About' },
   { path: '/about/team', title: 'Team' },
+  { path: '/philosophy', title: 'Our Philosophy' },
   { path: '/academy', title: 'Academy' },
   { path: '/programs', title: 'Programs' },
   { path: '/programs/akomapa-young-advocates', title: 'Young Advocates' },

--- a/e2e/philosophy.spec.ts
+++ b/e2e/philosophy.spec.ts
@@ -1,0 +1,176 @@
+import { expect, test, type Page } from "@playwright/test";
+import { announcementCampaign } from "../src/data/announcements";
+import { philosophySections } from "../src/data/philosophy";
+
+async function preparePage(page: Page, theme?: "light" | "dark") {
+  await page.addInitScript(
+    ({ announcementVersion, storedTheme }) => {
+      localStorage.setItem(
+        "akomapa-announcements-dismissed",
+        announcementVersion,
+      );
+
+      if (storedTheme) {
+        localStorage.setItem("akomapa-theme", storedTheme);
+        document.documentElement.classList.remove("light", "dark");
+        document.documentElement.classList.add(storedTheme);
+      }
+    },
+    {
+      announcementVersion: announcementCampaign.version,
+      storedTheme: theme ?? null,
+    },
+  );
+}
+
+async function hasHorizontalOverflow(page: Page) {
+  return page.evaluate(
+    () => document.documentElement.scrollWidth - window.innerWidth > 1,
+  );
+}
+
+test.describe("Our Philosophy page", () => {
+  test.beforeEach(async ({ page }) => {
+    await preparePage(page);
+  });
+
+  test("renders metadata, breadcrumb, sections, quotes, and CTAs", async ({
+    page,
+  }) => {
+    await page.goto("/philosophy", { waitUntil: "domcontentloaded" });
+
+    await expect(page).toHaveTitle(/Our Philosophy/);
+    await expect(page.locator('meta[name="description"]')).toHaveAttribute(
+      "content",
+      /ethical global health leadership/i,
+    );
+    await expect(page.locator("[data-rebrand-page]")).toBeVisible();
+
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: "Our Philosophy",
+        exact: true,
+      }),
+    ).toHaveCount(1);
+    await expect(
+      page.getByRole("navigation").filter({ hasText: "Our Philosophy" }).first(),
+    ).toContainText("Our Philosophy");
+
+    for (const section of philosophySections) {
+      await expect(
+        page.getByRole("heading", {
+          level: 2,
+          name: section.title,
+          exact: true,
+        }),
+      ).toBeVisible();
+
+      await expect(page.locator(`#${section.id}`)).toBeVisible();
+
+      if (section.quote) {
+        await expect(page.getByText(section.quote.text)).toBeVisible();
+      }
+    }
+
+    await expect(
+      page.getByRole("heading", {
+        level: 2,
+        name: "Transform how global health is taught, practiced, and led.",
+      }),
+    ).toBeVisible();
+
+    const joinLinks = page.getByRole("link", { name: "Join Us", exact: true });
+    await expect(joinLinks).toHaveCount(2);
+    await expect(joinLinks.first()).toHaveAttribute("href", "/get-involved");
+
+    const partnerLinks = page.getByRole("link", {
+      name: "Partner With Us",
+      exact: true,
+    });
+    await expect(partnerLinks).toHaveCount(2);
+    await expect(partnerLinks.first()).toHaveAttribute("href", "/partnerships");
+
+    await expect(page.locator("main img[alt]:not([alt=''])")).toHaveCount(
+      philosophySections.length,
+    );
+    expect(await hasHorizontalOverflow(page)).toBe(false);
+  });
+
+  test("alternates section media placement on desktop", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/philosophy", { waitUntil: "domcontentloaded" });
+
+    const firstSection = page.locator(`#${philosophySections[0].id}`);
+    await firstSection.scrollIntoViewIfNeeded();
+    const firstHeadingBox = await firstSection
+      .getByRole("heading", { level: 2 })
+      .boundingBox();
+    const firstImageBox = await firstSection.locator("img").boundingBox();
+
+    expect(firstHeadingBox).not.toBeNull();
+    expect(firstImageBox).not.toBeNull();
+    expect(firstImageBox!.x).toBeGreaterThan(firstHeadingBox!.x);
+
+    const secondSection = page.locator(`#${philosophySections[1].id}`);
+    await secondSection.scrollIntoViewIfNeeded();
+    const secondHeadingBox = await secondSection
+      .getByRole("heading", { level: 2 })
+      .boundingBox();
+    const secondImageBox = await secondSection.locator("img").boundingBox();
+
+    expect(secondHeadingBox).not.toBeNull();
+    expect(secondImageBox).not.toBeNull();
+    expect(secondImageBox!.x).toBeLessThan(secondHeadingBox!.x);
+    expect(await hasHorizontalOverflow(page)).toBe(false);
+  });
+
+  test("stacks section media above text on mobile", async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto("/philosophy", { waitUntil: "domcontentloaded" });
+
+    const firstSection = page.locator(`#${philosophySections[0].id}`);
+    await firstSection.scrollIntoViewIfNeeded();
+
+    const imageBox = await firstSection.locator("img").boundingBox();
+    const headingBox = await firstSection
+      .getByRole("heading", { level: 2 })
+      .boundingBox();
+
+    expect(imageBox).not.toBeNull();
+    expect(headingBox).not.toBeNull();
+    expect(imageBox!.y).toBeLessThan(headingBox!.y);
+    expect(await hasHorizontalOverflow(page)).toBe(false);
+  });
+
+  test("remains readable in dark mode", async ({ page }) => {
+    await preparePage(page, "dark");
+    await page.goto("/philosophy", { waitUntil: "domcontentloaded" });
+
+    await expect(page.locator("html")).toHaveClass(/dark/);
+    await expect(page.locator("[data-rebrand-page]")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Our Philosophy", level: 1 }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: philosophySections[0].title, level: 2 }),
+    ).toBeVisible();
+
+    const firstSectionStyles = await page
+      .locator(`#${philosophySections[0].id}`)
+      .evaluate((section) => {
+        const heading = section.querySelector("h2");
+        const paragraph = section.querySelector("p");
+
+        return {
+          background: getComputedStyle(section).backgroundColor,
+          heading: heading ? getComputedStyle(heading).color : "",
+          paragraph: paragraph ? getComputedStyle(paragraph).color : "",
+        };
+      });
+
+    expect(firstSectionStyles.background).not.toBe(firstSectionStyles.heading);
+    expect(firstSectionStyles.background).not.toBe(firstSectionStyles.paragraph);
+    expect(await hasHorizontalOverflow(page)).toBe(false);
+  });
+});

--- a/src/app/(main)/philosophy/page.tsx
+++ b/src/app/(main)/philosophy/page.tsx
@@ -21,32 +21,27 @@ export default function PhilosophyPage() {
 
       <PhilosophyHero />
 
-      <div className="relative">
-        <div className="pointer-events-none absolute inset-y-0 left-0 hidden w-full xl:block">
-          <div className="container sticky top-24 mx-auto h-0 px-4">
-            <nav
-              aria-label="On this page"
-              className="pointer-events-auto ml-auto hidden w-56 translate-x-4 rounded-xl border border-[#0097b2]/15 bg-[#FCFAEF]/92 p-4 shadow-[0_18px_45px_rgba(15,76,92,0.12)] backdrop-blur-md dark:border-[#FCFAEF]/10 dark:bg-[#121514]/84 xl:block"
-            >
-              <p className="font-subheading text-xs font-bold uppercase tracking-[0.16em] text-[#0097b2] dark:text-[#66C4DC]">
-                On this page
-              </p>
-              <ol className="mt-4 space-y-2">
-                {philosophySections.map((section) => (
-                  <li key={section.id}>
-                    <Link
-                      href={`#${section.id}`}
-                      className="block rounded-md px-2 py-1.5 text-sm leading-snug text-[#2F3332]/76 transition-colors hover:bg-[#0097b2]/10 hover:text-[#0097b2] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] dark:text-[#FCFAEF]/74 dark:hover:bg-[#66C4DC]/12 dark:hover:text-[#66C4DC]"
-                    >
-                      {section.title}
-                    </Link>
-                  </li>
-                ))}
-              </ol>
-            </nav>
-          </div>
+      <nav
+        aria-label="On this page"
+        className="border-b border-[#0097b2]/10 bg-[#FCFAEF] dark:border-[#FCFAEF]/10 dark:bg-[#121514]"
+      >
+        <div className="container mx-auto max-w-7xl px-4 py-4">
+          <ol className="flex gap-2 overflow-x-auto pb-1 md:flex-wrap md:justify-center md:overflow-visible md:pb-0">
+            {philosophySections.map((section) => (
+              <li key={section.id} className="shrink-0">
+                <Link
+                  href={`#${section.id}`}
+                  className="inline-flex min-h-10 items-center rounded-md border border-[#0097b2]/18 bg-white/72 px-4 py-2 text-sm font-semibold text-[#2F3332]/78 transition-colors hover:border-[#0097b2]/35 hover:bg-[#0097b2]/10 hover:text-[#0097b2] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] dark:border-[#FCFAEF]/12 dark:bg-[#2F3332]/54 dark:text-[#FCFAEF]/78 dark:hover:border-[#66C4DC]/35 dark:hover:bg-[#66C4DC]/12 dark:hover:text-[#66C4DC]"
+                >
+                  {section.title}
+                </Link>
+              </li>
+            ))}
+          </ol>
         </div>
+      </nav>
 
+      <div>
         {philosophySections.map((section, index) => (
           <PhilosophySection
             key={section.id}

--- a/src/app/(main)/philosophy/page.tsx
+++ b/src/app/(main)/philosophy/page.tsx
@@ -1,38 +1,62 @@
 import type { Metadata } from "next";
-import RebrandPageShell from "@/components/shared/RebrandPageShell";
-import { BRAND } from "@/config/brand";
+import Link from "next/link";
+import Breadcrumb from "@/components/layout/Breadcrumb";
+import PhilosophyHero from "@/components/philosophy/PhilosophyHero";
+import PhilosophySection from "@/components/philosophy/PhilosophySection";
+import PhilosophyVision from "@/components/philosophy/PhilosophyVision";
+import { philosophySections } from "@/data/philosophy";
 
 export const metadata: Metadata = {
   title: "Our Philosophy",
   description:
-    "Discover Akomapa's philosophy of ethical leadership, community ownership, and equitable global health partnership.",
+    "Explore Akomapa's philosophy of ethical global health leadership, community partnership, reciprocal learning, and sustainable impact.",
 };
-
-const highlights = [
-  {
-    title: "Ethical Leadership",
-    description:
-      "We prepare emerging health professionals to lead with humility, accountability, and respect for the communities they serve.",
-  },
-  {
-    title: "Community Ownership",
-    description:
-      "Local priorities and lived experience guide the solutions, relationships, and measures of success that we build together.",
-  },
-  {
-    title: "Equitable Partnership",
-    description:
-      "We pursue long-term collaboration grounded in shared decision-making, mutual learning, and sustainable impact.",
-  },
-] as const;
 
 export default function PhilosophyPage() {
   return (
-    <RebrandPageShell
-      eyebrow="Our Foundation"
-      title="Our Philosophy"
-      description={BRAND.mission}
-      highlights={highlights}
-    />
+    <div data-rebrand-page className="bg-background text-foreground">
+      <div className="container mx-auto">
+        <Breadcrumb />
+      </div>
+
+      <PhilosophyHero />
+
+      <div className="relative">
+        <div className="pointer-events-none absolute inset-y-0 left-0 hidden w-full xl:block">
+          <div className="container sticky top-24 mx-auto h-0 px-4">
+            <nav
+              aria-label="On this page"
+              className="pointer-events-auto ml-auto hidden w-56 translate-x-4 rounded-xl border border-[#0097b2]/15 bg-[#FCFAEF]/92 p-4 shadow-[0_18px_45px_rgba(15,76,92,0.12)] backdrop-blur-md dark:border-[#FCFAEF]/10 dark:bg-[#121514]/84 xl:block"
+            >
+              <p className="font-subheading text-xs font-bold uppercase tracking-[0.16em] text-[#0097b2] dark:text-[#66C4DC]">
+                On this page
+              </p>
+              <ol className="mt-4 space-y-2">
+                {philosophySections.map((section) => (
+                  <li key={section.id}>
+                    <Link
+                      href={`#${section.id}`}
+                      className="block rounded-md px-2 py-1.5 text-sm leading-snug text-[#2F3332]/76 transition-colors hover:bg-[#0097b2]/10 hover:text-[#0097b2] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] dark:text-[#FCFAEF]/74 dark:hover:bg-[#66C4DC]/12 dark:hover:text-[#66C4DC]"
+                    >
+                      {section.title}
+                    </Link>
+                  </li>
+                ))}
+              </ol>
+            </nav>
+          </div>
+        </div>
+
+        {philosophySections.map((section, index) => (
+          <PhilosophySection
+            key={section.id}
+            section={section}
+            index={index}
+          />
+        ))}
+      </div>
+
+      <PhilosophyVision />
+    </div>
   );
 }

--- a/src/components/layout/Breadcrumb.tsx
+++ b/src/components/layout/Breadcrumb.tsx
@@ -36,7 +36,18 @@ function BreadcrumbContent() {
         .join(' ');
     };
 
+    const segmentLabels: Record<string, string> = {
+      philosophy: "Our Philosophy",
+      "ncd-impact": "NCD Impact",
+      "community-hubs": "Community Health Hubs",
+      "get-involved": "Get Involved",
+    };
+
     const label = (() => {
+      if (segmentLabels[segment]) {
+        return segmentLabels[segment];
+      }
+
       if (
         index > 0 &&
         (parentSegment === "clinics" || parentSegment === "programs")

--- a/src/components/philosophy/PhilosophyHero.tsx
+++ b/src/components/philosophy/PhilosophyHero.tsx
@@ -1,10 +1,6 @@
 import Image from "@/components/common/Image";
 import { FadeIn, FadeInStagger, FadeInStaggerItem } from "@/components/animations";
-import {
-  PublicCta,
-  PublicSection,
-  SectionEyebrow,
-} from "@/components/shared/PublicPagePrimitives";
+import { PublicCta, SectionEyebrow } from "@/components/shared/PublicPagePrimitives";
 
 const philosophyStats = [
   {
@@ -23,11 +19,9 @@ const philosophyStats = [
 
 export default function PhilosophyHero() {
   return (
-    <PublicSection
-      tone="dark"
-      spacing="spacious"
-      className="border-y border-[#FCFAEF]/10"
-      containerClassName="max-w-7xl"
+    <section
+      className="relative isolate overflow-hidden border-y border-[#0097b2]/15 bg-[#121514] text-[#FCFAEF]"
+      aria-labelledby="philosophy-hero-heading"
     >
       <div className="absolute inset-0 -z-10">
         <Image
@@ -36,19 +30,26 @@ export default function PhilosophyHero() {
           fill
           priority
           sizes="100vw"
-          className="object-cover opacity-35"
+          className="object-cover opacity-50"
           style={{ objectPosition: "center" }}
         />
         <div
           aria-hidden="true"
-          className="absolute inset-0 bg-gradient-to-br from-[#0097b2]/85 via-[#0F4C5C]/88 to-[#121514]/96"
+          className="absolute inset-0 bg-gradient-to-br from-[#0097b2]/88 via-[#0F4C5C]/90 to-[#121514]/96"
+        />
+        <div
+          aria-hidden="true"
+          className="absolute inset-0 bg-[radial-gradient(circle_at_18%_22%,rgba(238,186,43,0.18),transparent_30%),linear-gradient(90deg,rgba(18,21,20,0.2),rgba(18,21,20,0.86))]"
         />
       </div>
 
-      <div className="grid items-end gap-10 lg:grid-cols-[minmax(0,1fr)_360px] lg:gap-16">
+      <div className="container mx-auto grid min-h-[460px] max-w-7xl items-center gap-8 px-4 py-14 sm:py-18 lg:grid-cols-[minmax(0,1fr)_minmax(280px,420px)] lg:gap-16 lg:py-20">
         <FadeIn className="max-w-5xl">
           <SectionEyebrow tone="gold">Ethics, Partnership, Impact</SectionEyebrow>
-          <h1 className="mt-5 max-w-4xl font-heading text-5xl font-bold leading-tight text-[#FCFAEF] sm:text-6xl lg:text-7xl">
+          <h1
+            id="philosophy-hero-heading"
+            className="mt-5 max-w-4xl font-heading text-5xl font-bold leading-tight text-[#FCFAEF] sm:text-6xl lg:text-7xl"
+          >
             Our Philosophy
           </h1>
           <p className="mt-6 max-w-3xl font-body text-xl leading-9 text-[#FCFAEF]/88 md:text-2xl">
@@ -65,14 +66,17 @@ export default function PhilosophyHero() {
           </div>
         </FadeIn>
 
-        <FadeInStagger className="grid gap-4" amount="some">
+        <FadeInStagger
+          className="grid gap-3 sm:grid-cols-3 lg:grid-cols-1 lg:gap-4"
+          amount="some"
+        >
           {philosophyStats.map((stat) => (
             <FadeInStaggerItem key={stat.label}>
-              <div className="rounded-xl border border-[#FCFAEF]/18 bg-[#121514]/42 p-5 shadow-[0_20px_55px_rgba(0,0,0,0.2)] backdrop-blur-md">
-                <p className="font-heading text-3xl font-bold text-[#F5C94D]">
+              <div className="h-full rounded-xl border border-[#FCFAEF]/20 bg-[#121514]/44 p-4 shadow-[0_22px_70px_rgba(0,0,0,0.24)] backdrop-blur-md lg:p-5">
+                <p className="font-heading text-3xl font-bold leading-none text-[#F5C94D]">
                   {stat.value}
                 </p>
-                <p className="mt-2 text-sm leading-6 text-[#FCFAEF]/78">
+                <p className="mt-2 text-sm leading-6 text-[#FCFAEF]/78 sm:text-xs lg:text-sm">
                   {stat.label}
                 </p>
               </div>
@@ -80,6 +84,6 @@ export default function PhilosophyHero() {
           ))}
         </FadeInStagger>
       </div>
-    </PublicSection>
+    </section>
   );
 }

--- a/src/components/philosophy/PhilosophyHero.tsx
+++ b/src/components/philosophy/PhilosophyHero.tsx
@@ -1,0 +1,85 @@
+import Image from "@/components/common/Image";
+import { FadeIn, FadeInStagger, FadeInStaggerItem } from "@/components/animations";
+import {
+  PublicCta,
+  PublicSection,
+  SectionEyebrow,
+} from "@/components/shared/PublicPagePrimitives";
+
+const philosophyStats = [
+  {
+    value: "43M",
+    label: "NCD deaths globally in 2021",
+  },
+  {
+    value: "73%",
+    label: "of NCD deaths in low- and middle-income countries",
+  },
+  {
+    value: "9",
+    label: "principles shaping Akomapa's approach",
+  },
+] as const;
+
+export default function PhilosophyHero() {
+  return (
+    <PublicSection
+      tone="dark"
+      spacing="spacious"
+      className="border-y border-[#FCFAEF]/10"
+      containerClassName="max-w-7xl"
+    >
+      <div className="absolute inset-0 -z-10">
+        <Image
+          src="/highlights/Akomapa-73.jpg"
+          alt=""
+          fill
+          priority
+          sizes="100vw"
+          className="object-cover opacity-35"
+          style={{ objectPosition: "center" }}
+        />
+        <div
+          aria-hidden="true"
+          className="absolute inset-0 bg-gradient-to-br from-[#0097b2]/85 via-[#0F4C5C]/88 to-[#121514]/96"
+        />
+      </div>
+
+      <div className="grid items-end gap-10 lg:grid-cols-[minmax(0,1fr)_360px] lg:gap-16">
+        <FadeIn className="max-w-5xl">
+          <SectionEyebrow tone="gold">Ethics, Partnership, Impact</SectionEyebrow>
+          <h1 className="mt-5 max-w-4xl font-heading text-5xl font-bold leading-tight text-[#FCFAEF] sm:text-6xl lg:text-7xl">
+            Our Philosophy
+          </h1>
+          <p className="mt-6 max-w-3xl font-body text-xl leading-9 text-[#FCFAEF]/88 md:text-2xl">
+            Building a different future for global health &mdash; one rooted in
+            ethics, partnership, and sustainable impact.
+          </p>
+          <div className="mt-9 flex flex-col gap-4 sm:flex-row">
+            <PublicCta href="/get-involved" variant="gold">
+              Join Us
+            </PublicCta>
+            <PublicCta href="/partnerships" variant="outline-light">
+              Partner With Us
+            </PublicCta>
+          </div>
+        </FadeIn>
+
+        <FadeInStagger className="grid gap-4" amount="some">
+          {philosophyStats.map((stat) => (
+            <FadeInStaggerItem key={stat.label}>
+              <div className="rounded-xl border border-[#FCFAEF]/18 bg-[#121514]/42 p-5 shadow-[0_20px_55px_rgba(0,0,0,0.2)] backdrop-blur-md">
+                <p className="font-heading text-3xl font-bold text-[#F5C94D]">
+                  {stat.value}
+                </p>
+                <p className="mt-2 text-sm leading-6 text-[#FCFAEF]/78">
+                  {stat.label}
+                </p>
+              </div>
+            </FadeInStaggerItem>
+          ))}
+        </FadeInStagger>
+      </div>
+    </PublicSection>
+  );
+}

--- a/src/components/philosophy/PhilosophySection.tsx
+++ b/src/components/philosophy/PhilosophySection.tsx
@@ -32,16 +32,17 @@ export default function PhilosophySection({
       id={section.id}
       aria-labelledby={headingId}
       tone={getTone(index)}
-      spacing="spacious"
+      spacing="normal"
       withTexture={index % 3 === 0}
       className={cn("scroll-mt-28 border-t border-[#0097b2]/10", className)}
-      containerClassName="max-w-7xl xl:pr-72"
+      containerClassName="max-w-7xl"
     >
-      <div className="grid items-center gap-10 md:grid-cols-2 md:gap-12 lg:gap-20">
+      <div className="mx-auto grid max-w-6xl items-center justify-items-center gap-10 md:grid-cols-2 md:gap-12 lg:gap-16">
         <FadeIn
           direction={isImageFirstOnDesktop ? "right" : "left"}
+          amount="some"
           className={cn(
-            "order-1",
+            "order-1 w-full",
             isImageFirstOnDesktop ? "md:order-1" : "md:order-2",
           )}
         >
@@ -67,12 +68,13 @@ export default function PhilosophySection({
 
         <FadeIn
           delay={0.08}
+          amount="some"
           className={cn(
-            "order-2",
+            "order-2 w-full",
             isImageFirstOnDesktop ? "md:order-2" : "md:order-1",
           )}
         >
-          <article className="mx-auto max-w-2xl">
+          <article className="mx-auto max-w-xl">
             <SectionEyebrow>Principle {section.order}</SectionEyebrow>
             <h2
               id={headingId}

--- a/src/components/philosophy/PhilosophySection.tsx
+++ b/src/components/philosophy/PhilosophySection.tsx
@@ -1,0 +1,113 @@
+import type { PhilosophySection as PhilosophySectionType } from "@/lib/types";
+import Image from "@/components/common/Image";
+import { FadeIn } from "@/components/animations";
+import {
+  MediaFrame,
+  PublicSection,
+  SectionEyebrow,
+} from "@/components/shared/PublicPagePrimitives";
+import { cn } from "@/lib/utils";
+
+type PhilosophySectionProps = {
+  section: PhilosophySectionType;
+  index: number;
+  className?: string;
+};
+
+function getTone(index: number) {
+  return index % 2 === 0 ? "cream" : "white";
+}
+
+export default function PhilosophySection({
+  section,
+  index,
+  className,
+}: PhilosophySectionProps) {
+  const isImageFirstOnDesktop = index % 2 === 1;
+  const paragraphs = section.content.split("\n\n");
+  const headingId = `${section.id}-heading`;
+
+  return (
+    <PublicSection
+      id={section.id}
+      aria-labelledby={headingId}
+      tone={getTone(index)}
+      spacing="spacious"
+      withTexture={index % 3 === 0}
+      className={cn("scroll-mt-28 border-t border-[#0097b2]/10", className)}
+      containerClassName="max-w-7xl xl:pr-72"
+    >
+      <div className="grid items-center gap-10 md:grid-cols-2 md:gap-12 lg:gap-20">
+        <FadeIn
+          direction={isImageFirstOnDesktop ? "right" : "left"}
+          className={cn(
+            "order-1",
+            isImageFirstOnDesktop ? "md:order-1" : "md:order-2",
+          )}
+        >
+          <MediaFrame className="mx-auto w-full max-w-xl" aspect="wide">
+            {section.image ? (
+              <Image
+                src={section.image}
+                alt={section.imageAlt ?? ""}
+                fill
+                sizes="(min-width: 1280px) 560px, (min-width: 768px) 45vw, 100vw"
+                className="object-cover"
+                style={{ objectPosition: section.imagePosition ?? "center" }}
+              />
+            ) : (
+              <div className="h-full w-full bg-[#0097b2]/12" aria-hidden="true" />
+            )}
+            <div
+              aria-hidden="true"
+              className="absolute inset-0 bg-gradient-to-t from-[#121514]/48 via-transparent to-transparent"
+            />
+          </MediaFrame>
+        </FadeIn>
+
+        <FadeIn
+          delay={0.08}
+          className={cn(
+            "order-2",
+            isImageFirstOnDesktop ? "md:order-2" : "md:order-1",
+          )}
+        >
+          <article className="mx-auto max-w-2xl">
+            <SectionEyebrow>Principle {section.order}</SectionEyebrow>
+            <h2
+              id={headingId}
+              className="mt-4 font-heading text-3xl font-bold leading-tight text-[#1C1F1E] dark:text-[#FCFAEF] md:text-4xl lg:text-5xl"
+            >
+              {section.title}
+            </h2>
+            <div className="mt-6 space-y-5 font-body text-lg leading-8 text-[#2F3332]/82 dark:text-[#E6E7E7]/82">
+              {paragraphs.map((paragraph) => (
+                <p key={paragraph}>{paragraph}</p>
+              ))}
+            </div>
+
+            {section.quote ? (
+              <blockquote className="mt-8 border-l-4 border-[#eeba2b] pl-5">
+                <p className="relative font-heading text-2xl font-semibold leading-snug text-[#1C1F1E] dark:text-[#FCFAEF]">
+                  <span
+                    aria-hidden="true"
+                    className="absolute -left-4 -top-5 text-6xl leading-none text-[#eeba2b]/45"
+                  >
+                    &ldquo;
+                  </span>
+                  {section.quote.text}
+                </p>
+                <footer className="mt-4 font-body text-sm font-semibold uppercase tracking-[0.16em] text-[#0097b2] dark:text-[#66C4DC]">
+                  {section.quote.author}
+                  <span className="block pt-1 normal-case tracking-normal text-[#2F3332]/62 dark:text-[#FCFAEF]/62">
+                    {section.quote.role}
+                  </span>
+                </footer>
+              </blockquote>
+            ) : null}
+          </article>
+        </FadeIn>
+      </div>
+    </PublicSection>
+  );
+}

--- a/src/components/philosophy/PhilosophyVision.tsx
+++ b/src/components/philosophy/PhilosophyVision.tsx
@@ -1,0 +1,37 @@
+import { FadeIn } from "@/components/animations";
+import {
+  PublicCta,
+  PublicSection,
+  SectionEyebrow,
+} from "@/components/shared/PublicPagePrimitives";
+
+export default function PhilosophyVision() {
+  return (
+    <PublicSection
+      tone="teal"
+      spacing="spacious"
+      className="border-t border-[#FCFAEF]/15"
+      containerClassName="max-w-5xl"
+    >
+      <FadeIn className="text-center">
+        <SectionEyebrow tone="gold">Our Vision For Global Health</SectionEyebrow>
+        <h2 className="mx-auto mt-4 max-w-4xl font-heading text-4xl font-bold leading-tight text-[#FCFAEF] md:text-5xl lg:text-6xl">
+          Transform how global health is taught, practiced, and led.
+        </h2>
+        <p className="mx-auto mt-6 max-w-3xl font-body text-lg leading-8 text-[#FCFAEF]/84 md:text-xl">
+          Akomapa is building a movement where students, faculty, health
+          professionals, and communities learn together, lead ethically, and
+          strengthen systems that last beyond any single project.
+        </p>
+        <div className="mt-9 flex flex-col justify-center gap-4 sm:flex-row">
+          <PublicCta href="/get-involved" variant="gold">
+            Join Us
+          </PublicCta>
+          <PublicCta href="/partnerships" variant="outline-light">
+            Partner With Us
+          </PublicCta>
+        </div>
+      </FadeIn>
+    </PublicSection>
+  );
+}

--- a/src/data/__tests__/rebrand-data.test.ts
+++ b/src/data/__tests__/rebrand-data.test.ts
@@ -190,7 +190,17 @@ describe("rebrand content data", () => {
       expect(paragraphs.length).toBeGreaterThanOrEqual(2);
       expect(paragraphs.length).toBeLessThanOrEqual(3);
       expect(paragraphs.every((paragraph) => paragraph.length > 80)).toBe(true);
+      expect(section.image).toMatch(/^\/[a-z0-9-/.]+$/i);
+      expect(section.imageAlt?.length).toBeGreaterThan(30);
     }
+
+    const silentEpidemic = philosophySections.find(
+      ({ id }) => id === "silent-epidemic",
+    );
+    expect(silentEpidemic?.content).toContain("43 million");
+    expect(silentEpidemic?.content).toContain("73%");
+    expect(silentEpidemic?.content).toContain("18 million");
+    expect(silentEpidemic?.content).toContain("82%");
 
     expect(timeline).toHaveLength(6);
     expectUniqueIds(timeline);

--- a/src/data/philosophy.ts
+++ b/src/data/philosophy.ts
@@ -7,6 +7,10 @@ export const philosophySections: PhilosophySection[] = [
     content:
       "The world faces health challenges that cannot be solved by clinical knowledge alone. Inequitable access, fragmented systems, and preventable non-communicable diseases demand leaders who can listen carefully, work across disciplines, and act with integrity.\n\nAkomapa exists to develop those leaders while partnering with communities on practical solutions. We connect leadership education with community-driven care, research, and responsible innovation so learning and impact reinforce one another.",
     order: 1,
+    image: "/highlights/Akomapa-73.jpg",
+    imageAlt:
+      "Akomapa student leaders and community partners gathered after a community health activity",
+    imagePosition: "center",
     quote: {
       text: "A good heart is the beginning of leadership, not the end of preparation.",
       author: "Akomapa Health Foundation",
@@ -19,13 +23,21 @@ export const philosophySections: PhilosophySection[] = [
     content:
       "Throughout history, students have challenged assumptions, advanced research, strengthened communities, and helped shape the future of medicine and public health. Their curiosity and willingness to imagine new possibilities can move institutions and systems forward.\n\nAt Akomapa, students are not simply the leaders of tomorrow. With rigorous preparation, accountable mentorship, and meaningful community partnership, they are contributors to change today.",
     order: 2,
+    image: "/highlights/Akomapa-40.jpg",
+    imageAlt:
+      "Akomapa students learning together during a leadership development session",
+    imagePosition: "center",
   },
   {
     id: "silent-epidemic",
     title: "The Silent Epidemic",
     content:
-      "Non-communicable diseases such as hypertension and diabetes are among the leading causes of illness and death worldwide. Too many people remain undiagnosed, untreated, or disconnected from consistent care until preventable complications occur.\n\nAkomapa began with a commitment to confront this silent epidemic. Our community health hubs bring prevention, screening, education, referral support, and follow-up closer to communities while preparing emerging health professionals to lead with skill and humility.",
+      "Non-communicable diseases such as cardiovascular disease, cancer, chronic respiratory disease, and diabetes killed at least 43 million people in 2021, including 73% of NCD deaths in low- and middle-income countries. Ghana shares this burden as communities face hypertension, diabetes, stroke, and other chronic conditions that are too often detected late.\n\nAkomapa began with a commitment to confront this silent epidemic. Our community health hubs bring prevention, screening, education, referral support, and follow-up closer to communities while preparing emerging health professionals to lead with skill and humility. The stakes are urgent: 18 million people died from an NCD before age 70 in 2021, and 82% of those premature deaths occurred in low- and middle-income countries.",
     order: 3,
+    image: "/highlights/Akomapa-28.jpg",
+    imageAlt:
+      "Akomapa health professionals conducting a community screening with residents",
+    imagePosition: "center",
   },
   {
     id: "good-intentions",
@@ -33,6 +45,10 @@ export const philosophySections: PhilosophySection[] = [
     content:
       "For decades, global health has been driven by passionate individuals seeking to improve lives. Yet many well-intentioned efforts have struggled because they lacked community partnership, ethical reflection, or long-term sustainability.\n\nLasting change requires more than enthusiasm. It requires accountability, cultural humility, evidence, shared decision-making, and the discipline to ask whether an intervention strengthens local priorities and systems.",
     order: 4,
+    image: "/highlights/Akomapa-66.jpg",
+    imageAlt:
+      "Akomapa student leaders listening during a community-centered health program",
+    imagePosition: "center",
     quote: {
       text: "Responsible service begins by asking who defines the problem, who holds power, and who remains after a project ends.",
       author: "Akomapa Academy",
@@ -45,6 +61,10 @@ export const philosophySections: PhilosophySection[] = [
     content:
       "Ethical leadership means making decisions with transparency, humility, courage, and respect for the people affected by them. It means recognizing power differences, examining unintended consequences, and accepting responsibility for results.\n\nWe help emerging leaders practice these habits through reflection, case-based learning, mentorship, and real community work. Technical excellence matters, but it must be guided by sound judgment and a commitment to equity.",
     order: 5,
+    image: "/highlights/Akomapa-61.jpg",
+    imageAlt:
+      "Akomapa mentors and student leaders in conversation during a leadership session",
+    imagePosition: "center",
   },
   {
     id: "community-partnership",
@@ -52,6 +72,10 @@ export const philosophySections: PhilosophySection[] = [
     content:
       "Communities are experts in their own needs, histories, strengths, and aspirations. Effective health initiatives are therefore built with communities rather than delivered to them.\n\nAkomapa works with community leaders, health professionals, public institutions, and residents to shape priorities and evaluate progress. Shared ownership creates more relevant programs, stronger trust, and solutions that can endure.",
     order: 6,
+    image: "/highlights/ucc.jpg",
+    imageAlt:
+      "Akomapa community partners and health leaders collaborating at the UCC hub",
+    imagePosition: "center",
   },
   {
     id: "reciprocal-learning",
@@ -59,6 +83,10 @@ export const philosophySections: PhilosophySection[] = [
     content:
       "Knowledge does not move in only one direction. Students, faculty, health workers, and community members each bring experience that can deepen the understanding of everyone involved.\n\nOur programs create space for reciprocal learning across professions, institutions, countries, and generations. Participants are expected to teach, listen, question assumptions, and carry new insight back to their own communities and systems.",
     order: 7,
+    image: "/gallery/gallery-pic-5.jpg",
+    imageAlt:
+      "Akomapa students, faculty, and community members learning together",
+    imagePosition: "center",
   },
   {
     id: "sustainability",
@@ -66,6 +94,10 @@ export const philosophySections: PhilosophySection[] = [
     content:
       "A successful program should strengthen the people, relationships, and systems that remain after a single clinic day, cohort, or grant. Sustainability is designed from the beginning rather than added as an afterthought.\n\nWe prioritize local leadership, durable partnerships, responsible data practices, referral networks, and models that can adapt over time. Growth is meaningful only when quality, trust, and community ownership grow with it.",
     order: 8,
+    image: "/highlights/Akomapa-20.jpg",
+    imageAlt:
+      "Akomapa community health team preparing sustainable care resources",
+    imagePosition: "center",
   },
   {
     id: "vision-for-global-health",
@@ -73,6 +105,10 @@ export const philosophySections: PhilosophySection[] = [
     content:
       "We envision global health as a field defined by ethical leadership, equitable partnership, and shared responsibility. Communities should have meaningful power in decisions, and emerging professionals should learn to work across boundaries without reproducing them.\n\nAkomapa is building a connected movement of leaders and community health hubs that can learn together, generate evidence, and develop practical solutions. Our goal is a healthier world shaped by people who lead with both competence and a good heart.",
     order: 9,
+    image: "/highlights/Akomapa-10.jpg",
+    imageAlt:
+      "Akomapa partners and student leaders standing together after community work",
+    imagePosition: "center",
     quote: {
       text: "Developing leaders. Strengthening communities. Transforming global health.",
       author: "Akomapa Health Foundation",

--- a/src/lib/__tests__/types.test.ts
+++ b/src/lib/__tests__/types.test.ts
@@ -171,6 +171,9 @@ describe("rebrand data model contracts", () => {
       title: "A Good Heart",
       content: "Health leadership begins with service.",
       order: 1,
+      image: "/highlights/Akomapa-20.jpg",
+      imageAlt: "Akomapa students learning alongside community partners.",
+      imagePosition: "center",
     };
 
     const timelineEvent: TimelineEvent = {
@@ -243,7 +246,7 @@ describe("rebrand data model contracts", () => {
     expectTypeOf<OptionalKeys<ResearchItem>>().toEqualTypeOf<"link">();
     expectTypeOf<OptionalKeys<Partner>>().toEqualTypeOf<"website">();
     expectTypeOf<OptionalKeys<PhilosophySection>>().toEqualTypeOf<
-      "image" | "quote"
+      "image" | "imageAlt" | "imagePosition" | "quote"
     >();
     expectTypeOf<OptionalKeys<TimelineEvent>>().toEqualTypeOf<"icon">();
     expectTypeOf<OptionalKeys<ImpactMetric>>().toEqualTypeOf<

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -196,6 +196,8 @@ export interface PhilosophySection {
   content: string;
   order: number;
   image?: string;
+  imageAlt?: string;
+  imagePosition?: string;
   quote?: {
     text: string;
     author: string;


### PR DESCRIPTION
## Summary
- Replaced the placeholder `/philosophy` route with a full editorial Our Philosophy page.
- Added reusable philosophy hero, section, and final CTA components using the existing Akomapa design system.
- Updated philosophy content with meaningful ImageKit imagery and current WHO NCD statistics.

## Implementation Details
- Renders hero, breadcrumb, sticky desktop table of contents, nine data-backed philosophy sections, pull quotes, and final CTAs.
- Supports alternating desktop section layouts, mobile image-first stacking, dark mode, and scroll-triggered fade reveals.
- Extended `PhilosophySection` with optional image alt/position metadata.
- Updated breadcrumb labeling so the page shows “Home > Our Philosophy”.

## Testing
- Added dedicated Playwright coverage for metadata, breadcrumb, headings, CTAs, images, quotes, desktop alternation, mobile stacking, dark mode, and overflow.
- Added `/philosophy` to generic page render coverage.
- Full validation passed: lint, typecheck, build, unit tests, and 410 Playwright tests.

## Research Notes
- Confirmed current implementation patterns against Next metadata docs, Next Image docs, Motion scroll animation docs, and WHO’s current NCD fact sheet.
- WHO figures used: 43M NCD deaths in 2021, 73% in LMICs, 18M premature deaths, 82% of premature deaths in LMICs.

## Residual Notes
- `next lint` passes but emits the existing Next.js deprecation warning for future Next 16 migration.

Close #110 