### PR TITLE
Rebrand/build akomapa academy page

### DIFF
--- a/e2e/philosophy.spec.ts
+++ b/e2e/philosophy.spec.ts
@@ -92,7 +92,7 @@ test.describe("Our Philosophy page", () => {
     await expect(partnerLinks.first()).toHaveAttribute("href", "/partnerships");
 
     await expect(page.locator("main img[alt]:not([alt=''])")).toHaveCount(
-      philosophySections.length,
+      philosophySections.length + 1,
     );
     expect(await hasHorizontalOverflow(page)).toBe(false);
   });

--- a/e2e/rebrand-foundation.spec.ts
+++ b/e2e/rebrand-foundation.spec.ts
@@ -323,7 +323,7 @@ test.describe("Akomapa rebrand foundation", () => {
           };
         });
 
-        const floralWhitePattern = /rgb\(252, 250, 239\)|oklab\(0\.98/;
+        const floralWhitePattern = /rgb\(252, 250, 239\)|oklab\(0\.9[6-9]/;
         const softWhitePattern = /rgb\(230, 231, 231\)|oklab\(0\.92/;
 
         expect(darkStyles.footerBackground).toBe("rgb(18, 21, 20)");

--- a/src/app/(main)/academy/page.tsx
+++ b/src/app/(main)/academy/page.tsx
@@ -1,6 +1,12 @@
 import type { Metadata } from "next";
-import RebrandPageShell from "@/components/shared/RebrandPageShell";
-import { BRAND } from "@/config/brand";
+import Breadcrumb from "@/components/layout/Breadcrumb";
+import AcademyHero from "@/components/academy/AcademyHero";
+import WhyEthicalLeadership from "@/components/academy/WhyEthicalLeadership";
+import CurriculumSection from "@/components/academy/CurriculumSection";
+import FacultyGrid from "@/components/academy/FacultyGrid";
+import CertificationSection from "@/components/academy/CertificationSection";
+import AcademyTestimonials from "@/components/academy/AcademyTestimonials";
+import ApplySection from "@/components/academy/ApplySection";
 
 export const metadata: Metadata = {
   title: "Akomapa Academy",
@@ -8,31 +14,19 @@ export const metadata: Metadata = {
     "Explore Akomapa Academy's approach to ethical global health leadership education, mentorship, and applied community learning.",
 };
 
-const highlights = [
-  {
-    title: "Leadership Education",
-    description:
-      "A practical curriculum develops the ethical judgment, systems thinking, and collaborative skills required in global health.",
-  },
-  {
-    title: "Mentorship",
-    description:
-      "Students and emerging professionals learn alongside experienced practitioners, researchers, and community leaders.",
-  },
-  {
-    title: "Applied Learning",
-    description:
-      "Education connects directly to community-centered service, research, innovation, and measurable health priorities.",
-  },
-] as const;
-
 export default function AcademyPage() {
   return (
-    <RebrandPageShell
-      eyebrow="Leadership Development"
-      title="Akomapa Academy"
-      description={BRAND.heroSubheadline}
-      highlights={highlights}
-    />
+    <div data-rebrand-page className="bg-background text-foreground">
+      <div className="container mx-auto">
+        <Breadcrumb />
+      </div>
+      <AcademyHero />
+      <WhyEthicalLeadership />
+      <CurriculumSection />
+      <FacultyGrid />
+      <CertificationSection />
+      <AcademyTestimonials />
+      <ApplySection />
+    </div>
   );
 }

--- a/src/components/academy/AcademyHero.tsx
+++ b/src/components/academy/AcademyHero.tsx
@@ -1,105 +1,119 @@
 import Image from "@/components/common/Image";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
 import {
   FadeIn,
   FadeInStagger,
   FadeInStaggerItem,
 } from "@/components/animations";
-import {
-  PublicCta,
-  SectionEyebrow,
-} from "@/components/shared/PublicPagePrimitives";
 import { academyOverview, academyCurriculum, academyFaculty } from "@/data/academy";
 import { LEADERSHIP_APP_FORM_URL } from "@/config/links";
 
 const heroStats = [
   {
     value: academyCurriculum.totalDuration,
-    label: "Intensive program",
+    label: "Intensive Program",
   },
   {
     value: `${academyCurriculum.modules.length}`,
-    label: "Core modules",
+    label: "Core Modules",
   },
   {
     value: `${academyFaculty.length}`,
-    label: "Expert faculty mentors",
+    label: "Expert Faculty",
   },
 ] as const;
+
+const ctaBaseClass =
+  "group inline-flex items-center justify-center gap-2 rounded-half px-8 py-6 h-auto text-base sm:text-lg font-medium transition-all duration-300 transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2";
 
 export default function AcademyHero() {
   return (
     <section
-      className="relative isolate overflow-hidden border-y border-[#0097b2]/15 bg-[#121514] text-[#FCFAEF]"
+      className="relative overflow-hidden bg-gradient-to-r from-[#0097b2] to-[#0F4C5C] py-16 sm:py-20 md:py-28"
       aria-labelledby="academy-hero-heading"
     >
-      <div className="absolute inset-0 -z-10">
-        <Image
-          src="/highlights/Akomapa-68.jpg"
-          alt=""
-          fill
-          priority
-          sizes="100vw"
-          className="object-cover opacity-50"
-          style={{ objectPosition: "center 30%" }}
-        />
-        <div
-          aria-hidden="true"
-          className="absolute inset-0 bg-gradient-to-br from-[#0097b2]/88 via-[#0F4C5C]/90 to-[#121514]/96"
-        />
-        <div
-          aria-hidden="true"
-          className="absolute inset-0 bg-[radial-gradient(circle_at_18%_22%,rgba(238,186,43,0.18),transparent_30%),linear-gradient(90deg,rgba(18,21,20,0.2),rgba(18,21,20,0.86))]"
-        />
+      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+        <div className="absolute -top-24 right-0 h-64 w-64 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
+        <div className="absolute bottom-0 -left-24 h-96 w-96 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
+        <div className="absolute bottom-0 right-0 h-80 w-80 rounded-full bg-[#F5C94D]/10 blur-3xl" />
       </div>
 
-      <div className="container mx-auto grid min-h-[520px] max-w-7xl items-center gap-8 px-4 py-14 sm:py-18 lg:grid-cols-[minmax(0,1fr)_minmax(280px,420px)] lg:gap-16 lg:py-20">
-        <FadeIn className="max-w-5xl">
-          <SectionEyebrow tone="gold">Leadership Development</SectionEyebrow>
-          <h1
-            id="academy-hero-heading"
-            className="mt-5 max-w-4xl font-heading text-5xl font-bold leading-tight text-[#FCFAEF] sm:text-6xl lg:text-7xl"
-          >
-            Akomapa Academy
-          </h1>
-          <p className="mt-4 max-w-3xl font-heading text-xl font-semibold leading-snug text-[#F5C94D] md:text-2xl">
-            {academyOverview.title}
-          </p>
-          <p className="mt-4 max-w-3xl font-body text-lg leading-8 text-[#FCFAEF]/78 md:text-xl">
-            {academyOverview.description}
-          </p>
-          <div className="mt-9 flex flex-col gap-4 sm:flex-row">
-            <PublicCta variant="gold" asChild icon>
-              <a
-                href={LEADERSHIP_APP_FORM_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Become a Scholar
-              </a>
-            </PublicCta>
-            <PublicCta href="#curriculum" variant="outline-light">
-              Explore Curriculum
-            </PublicCta>
-          </div>
-        </FadeIn>
+      <div className="container relative z-10 mx-auto px-4 sm:px-6">
+        <div className="flex flex-col gap-12 lg:flex-row lg:items-center lg:gap-16">
+          <FadeIn className="max-w-3xl flex-1">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#FCFAEF]/80 sm:text-sm">
+              Leadership Development
+            </p>
+            <h1
+              id="academy-hero-heading"
+              className="mt-4 text-3xl font-light leading-tight text-[#FCFAEF] sm:text-4xl md:text-5xl lg:text-6xl xl:text-7xl"
+            >
+              Akomapa Academy
+            </h1>
+            <p className="mt-4 text-lg font-semibold text-[#F5C94D] md:text-xl lg:text-2xl">
+              {academyOverview.title}
+            </p>
+            <p className="mt-4 max-w-2xl text-base leading-relaxed text-[#FCFAEF]/85 sm:text-lg">
+              {academyOverview.description}
+            </p>
 
-        <FadeInStagger
-          className="grid gap-3 sm:grid-cols-3 lg:grid-cols-1 lg:gap-4"
-          amount="some"
-        >
-          {heroStats.map((stat) => (
-            <FadeInStaggerItem key={stat.label}>
-              <div className="h-full rounded-xl border border-[#FCFAEF]/20 bg-[#121514]/44 p-4 shadow-[0_22px_70px_rgba(0,0,0,0.24)] backdrop-blur-md lg:p-5">
-                <p className="font-heading text-3xl font-bold leading-none text-[#F5C94D]">
-                  {stat.value}
-                </p>
-                <p className="mt-2 text-sm leading-6 text-[#FCFAEF]/78 sm:text-xs lg:text-sm">
-                  {stat.label}
-                </p>
+            <FadeInStagger
+              className="mt-8 grid grid-cols-1 gap-3 sm:grid-cols-3 sm:gap-4"
+              staggerDelay={0.1}
+            >
+              {heroStats.map((stat) => (
+                <FadeInStaggerItem key={stat.label} direction="up">
+                  <div className="rounded-xl border border-white/10 bg-white/5 p-3 sm:rounded-2xl sm:p-4">
+                    <p className="text-2xl font-semibold text-white sm:text-3xl">
+                      {stat.value}
+                    </p>
+                    <p className="mt-1 text-xs uppercase tracking-[0.2em] text-white/70 sm:tracking-[0.3em]">
+                      {stat.label}
+                    </p>
+                  </div>
+                </FadeInStaggerItem>
+              ))}
+            </FadeInStagger>
+
+            <FadeIn direction="up" delay={0.3}>
+              <div className="mt-8 flex flex-wrap gap-3 sm:gap-4">
+                <Button
+                  asChild
+                  className={`${ctaBaseClass} bg-[#eeba2b] text-[#FCFAEF] shadow-lg hover:bg-[#eeba2b]/80 hover:shadow-xl focus-visible:ring-[#F5C94D]`}
+                >
+                  <a
+                    href={LEADERSHIP_APP_FORM_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Become a Scholar
+                  </a>
+                </Button>
+                <Button
+                  asChild
+                  className={`${ctaBaseClass} bg-[#0097b2] text-[#FCFAEF] shadow-lg hover:bg-[#0097b2]/80 hover:shadow-xl focus-visible:ring-[#8DD4E6]`}
+                >
+                  <Link href="#curriculum">Explore Curriculum</Link>
+                </Button>
               </div>
-            </FadeInStaggerItem>
-          ))}
-        </FadeInStagger>
+            </FadeIn>
+          </FadeIn>
+
+          <FadeIn direction="left" delay={0.2} className="w-full lg:max-w-md xl:max-w-lg">
+            <div className="relative h-[280px] w-full overflow-hidden rounded-3xl border border-white/10 shadow-2xl sm:h-[360px] md:h-[420px] lg:h-[480px]">
+              <Image
+                src="/highlights/Akomapa-68.jpg"
+                alt="Akomapa Academy scholars collaborating in a learning session"
+                fill
+                priority
+                sizes="(min-width: 1024px) 40vw, 100vw"
+                className="object-cover object-center"
+              />
+              <div className="absolute inset-0 bg-gradient-to-t from-black/35 via-transparent to-transparent" />
+            </div>
+          </FadeIn>
+        </div>
       </div>
     </section>
   );

--- a/src/components/academy/AcademyHero.tsx
+++ b/src/components/academy/AcademyHero.tsx
@@ -1,0 +1,106 @@
+import Image from "@/components/common/Image";
+import {
+  FadeIn,
+  FadeInStagger,
+  FadeInStaggerItem,
+} from "@/components/animations";
+import {
+  PublicCta,
+  SectionEyebrow,
+} from "@/components/shared/PublicPagePrimitives";
+import { academyOverview, academyCurriculum, academyFaculty } from "@/data/academy";
+import { LEADERSHIP_APP_FORM_URL } from "@/config/links";
+
+const heroStats = [
+  {
+    value: academyCurriculum.totalDuration,
+    label: "Intensive program",
+  },
+  {
+    value: `${academyCurriculum.modules.length}`,
+    label: "Core modules",
+  },
+  {
+    value: `${academyFaculty.length}`,
+    label: "Expert faculty mentors",
+  },
+] as const;
+
+export default function AcademyHero() {
+  return (
+    <section
+      className="relative isolate overflow-hidden border-y border-[#0097b2]/15 bg-[#121514] text-[#FCFAEF]"
+      aria-labelledby="academy-hero-heading"
+    >
+      <div className="absolute inset-0 -z-10">
+        <Image
+          src="/highlights/Akomapa-68.jpg"
+          alt=""
+          fill
+          priority
+          sizes="100vw"
+          className="object-cover opacity-50"
+          style={{ objectPosition: "center 30%" }}
+        />
+        <div
+          aria-hidden="true"
+          className="absolute inset-0 bg-gradient-to-br from-[#0097b2]/88 via-[#0F4C5C]/90 to-[#121514]/96"
+        />
+        <div
+          aria-hidden="true"
+          className="absolute inset-0 bg-[radial-gradient(circle_at_18%_22%,rgba(238,186,43,0.18),transparent_30%),linear-gradient(90deg,rgba(18,21,20,0.2),rgba(18,21,20,0.86))]"
+        />
+      </div>
+
+      <div className="container mx-auto grid min-h-[520px] max-w-7xl items-center gap-8 px-4 py-14 sm:py-18 lg:grid-cols-[minmax(0,1fr)_minmax(280px,420px)] lg:gap-16 lg:py-20">
+        <FadeIn className="max-w-5xl">
+          <SectionEyebrow tone="gold">Leadership Development</SectionEyebrow>
+          <h1
+            id="academy-hero-heading"
+            className="mt-5 max-w-4xl font-heading text-5xl font-bold leading-tight text-[#FCFAEF] sm:text-6xl lg:text-7xl"
+          >
+            Akomapa Academy
+          </h1>
+          <p className="mt-4 max-w-3xl font-heading text-xl font-semibold leading-snug text-[#F5C94D] md:text-2xl">
+            {academyOverview.title}
+          </p>
+          <p className="mt-4 max-w-3xl font-body text-lg leading-8 text-[#FCFAEF]/78 md:text-xl">
+            {academyOverview.description}
+          </p>
+          <div className="mt-9 flex flex-col gap-4 sm:flex-row">
+            <PublicCta variant="gold" asChild icon>
+              <a
+                href={LEADERSHIP_APP_FORM_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Become a Scholar
+              </a>
+            </PublicCta>
+            <PublicCta href="#curriculum" variant="outline-light">
+              Explore Curriculum
+            </PublicCta>
+          </div>
+        </FadeIn>
+
+        <FadeInStagger
+          className="grid gap-3 sm:grid-cols-3 lg:grid-cols-1 lg:gap-4"
+          amount="some"
+        >
+          {heroStats.map((stat) => (
+            <FadeInStaggerItem key={stat.label}>
+              <div className="h-full rounded-xl border border-[#FCFAEF]/20 bg-[#121514]/44 p-4 shadow-[0_22px_70px_rgba(0,0,0,0.24)] backdrop-blur-md lg:p-5">
+                <p className="font-heading text-3xl font-bold leading-none text-[#F5C94D]">
+                  {stat.value}
+                </p>
+                <p className="mt-2 text-sm leading-6 text-[#FCFAEF]/78 sm:text-xs lg:text-sm">
+                  {stat.label}
+                </p>
+              </div>
+            </FadeInStaggerItem>
+          ))}
+        </FadeInStagger>
+      </div>
+    </section>
+  );
+}

--- a/src/components/academy/AcademyTestimonials.tsx
+++ b/src/components/academy/AcademyTestimonials.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import { ChevronLeft, ChevronRight, Quote } from "lucide-react";
 import Image from "@/components/common/Image";
-import { PublicSectionHeader } from "@/components/shared/PublicPagePrimitives";
+import { FadeIn } from "@/components/animations";
 import { academyTestimonials } from "@/data/academy";
 
 export default function AcademyTestimonials() {
@@ -41,17 +41,20 @@ export default function AcademyTestimonials() {
   const testimonial = academyTestimonials[currentIndex];
 
   return (
-    <section className="overflow-x-hidden bg-gradient-to-r from-[#0097b2] to-[#0F4C5C] py-16 text-[#FCFAEF] dark:from-[#121514] dark:to-[#0F4C5C] md:py-24">
-      <div className="container mx-auto px-4">
-        <PublicSectionHeader
-          eyebrow="Testimonials"
-          eyebrowTone="gold"
-          title="Voices From Our Scholars"
-          description="Hear from students and professionals whose leadership journeys were shaped by the Akomapa Academy experience."
-          className="mb-12"
-          titleClassName="text-[#FCFAEF] dark:text-[#FCFAEF]"
-          descriptionClassName="text-[#FCFAEF]/85"
-        />
+    <section className="bg-[#F4F1E8] py-16 dark:bg-[#1C1F1E] md:py-24">
+      <div className="container mx-auto px-4 sm:px-6">
+        <FadeIn direction="up" className="mx-auto mb-10 max-w-3xl space-y-3 text-center sm:space-y-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#0097b2] dark:text-[#66C4DC] sm:text-sm">
+            Testimonials
+          </p>
+          <h2 className="text-2xl font-bold text-[#0B2F3A] dark:text-[#FCFAEF] sm:text-3xl md:text-4xl">
+            Voices From Our Scholars
+          </h2>
+          <p className="text-base leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80 sm:text-lg">
+            Hear from students and professionals whose leadership journeys were
+            shaped by the Akomapa Academy experience.
+          </p>
+        </FadeIn>
 
         <div
           className="relative mx-auto max-w-4xl"
@@ -67,7 +70,7 @@ export default function AcademyTestimonials() {
                 shouldReduceMotion ? { opacity: 0 } : { opacity: 0, x: -20 }
               }
               transition={{ duration: shouldReduceMotion ? 0.01 : 0.3 }}
-              className="flex min-h-[380px] flex-col rounded-xl border border-white/15 bg-[#FCFAEF]/95 p-8 shadow-xl dark:bg-[#2F3332] md:min-h-[340px] md:p-12"
+              className="flex min-h-[380px] flex-col rounded-2xl border border-[#E6E7E7]/80 bg-white/95 p-8 shadow-xl dark:border-[#2E3433] dark:bg-[#2F3332] md:min-h-[340px] md:p-12"
             >
               <div className="absolute left-8 top-8 text-[#0097b2] opacity-20 dark:text-[#66C4DC]">
                 <Quote size={64} />
@@ -84,7 +87,7 @@ export default function AcademyTestimonials() {
                   <div className="mr-4 h-16 w-16 overflow-hidden rounded-full">
                     <Image
                       src={testimonial.image}
-                      alt={`${testimonial.name}`}
+                      alt={testimonial.name}
                       width={64}
                       height={64}
                       className="h-full w-full object-cover"
@@ -94,7 +97,7 @@ export default function AcademyTestimonials() {
                     <div className="text-lg font-bold text-[#1C1F1E] dark:text-[#FCFAEF]">
                       {testimonial.name}
                     </div>
-                    <div className="text-[#eeba2b] dark:text-[#F5C94D]">
+                    <div className="text-[#0097b2] dark:text-[#66C4DC]">
                       {testimonial.title}
                     </div>
                   </div>
@@ -109,7 +112,9 @@ export default function AcademyTestimonials() {
                 key={academyTestimonials[index].id}
                 onClick={() => setCurrentIndex(index)}
                 className={`h-3 w-3 rounded-full transition-colors ${
-                  index === currentIndex ? "bg-[#F5C94D]" : "bg-[#FCFAEF]/30"
+                  index === currentIndex
+                    ? "bg-[#0097b2] dark:bg-[#66C4DC]"
+                    : "bg-[#0097b2]/30 dark:bg-[#66C4DC]/30"
                 }`}
                 aria-label={`Go to testimonial ${index + 1}`}
               />
@@ -118,7 +123,7 @@ export default function AcademyTestimonials() {
 
           <button
             onClick={handlePrevious}
-            className="absolute left-0 top-1/2 flex h-10 w-10 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border border-[#E6E7E7] bg-[#FCFAEF] text-[#0097b2] shadow-md transition hover:bg-white focus:outline-none focus:ring-2 focus:ring-[#66C4DC] dark:border-[#2F3332] dark:bg-[#2F3332] dark:text-[#66C4DC] md:-left-3"
+            className="absolute left-0 top-1/2 flex h-10 w-10 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border border-[#E6E7E7] bg-white text-[#0097b2] shadow-md transition hover:bg-[#FCFAEF] focus:outline-none focus:ring-2 focus:ring-[#0097b2] dark:border-[#2E3433] dark:bg-[#2F3332] dark:text-[#66C4DC] md:-left-3"
             aria-label="Previous testimonial"
           >
             <ChevronLeft className="h-6 w-6" />
@@ -126,7 +131,7 @@ export default function AcademyTestimonials() {
 
           <button
             onClick={handleNext}
-            className="absolute right-0 top-1/2 flex h-10 w-10 translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border border-[#E6E7E7] bg-[#FCFAEF] text-[#0097b2] shadow-md transition hover:bg-white focus:outline-none focus:ring-2 focus:ring-[#66C4DC] dark:border-[#2F3332] dark:bg-[#2F3332] dark:text-[#66C4DC] md:-right-3"
+            className="absolute right-0 top-1/2 flex h-10 w-10 translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border border-[#E6E7E7] bg-white text-[#0097b2] shadow-md transition hover:bg-[#FCFAEF] focus:outline-none focus:ring-2 focus:ring-[#0097b2] dark:border-[#2E3433] dark:bg-[#2F3332] dark:text-[#66C4DC] md:-right-3"
             aria-label="Next testimonial"
           >
             <ChevronRight className="h-6 w-6" />

--- a/src/components/academy/AcademyTestimonials.tsx
+++ b/src/components/academy/AcademyTestimonials.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
+import { ChevronLeft, ChevronRight, Quote } from "lucide-react";
+import Image from "@/components/common/Image";
+import { PublicSectionHeader } from "@/components/shared/PublicPagePrimitives";
+import { academyTestimonials } from "@/data/academy";
+
+export default function AcademyTestimonials() {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isHovered, setIsHovered] = useState(false);
+  const shouldReduceMotion = useReducedMotion();
+
+  useEffect(() => {
+    if (isHovered || shouldReduceMotion) {
+      return;
+    }
+
+    const timer = setInterval(() => {
+      setCurrentIndex((prev) =>
+        prev === academyTestimonials.length - 1 ? 0 : prev + 1,
+      );
+    }, 30000);
+
+    return () => clearInterval(timer);
+  }, [isHovered, shouldReduceMotion]);
+
+  const handlePrevious = () => {
+    setCurrentIndex((prev) =>
+      prev === 0 ? academyTestimonials.length - 1 : prev - 1,
+    );
+  };
+
+  const handleNext = () => {
+    setCurrentIndex((prev) =>
+      prev === academyTestimonials.length - 1 ? 0 : prev + 1,
+    );
+  };
+
+  const testimonial = academyTestimonials[currentIndex];
+
+  return (
+    <section className="overflow-x-hidden bg-gradient-to-r from-[#0097b2] to-[#0F4C5C] py-16 text-[#FCFAEF] dark:from-[#121514] dark:to-[#0F4C5C] md:py-24">
+      <div className="container mx-auto px-4">
+        <PublicSectionHeader
+          eyebrow="Testimonials"
+          eyebrowTone="gold"
+          title="Voices From Our Scholars"
+          description="Hear from students and professionals whose leadership journeys were shaped by the Akomapa Academy experience."
+          className="mb-12"
+          titleClassName="text-[#FCFAEF] dark:text-[#FCFAEF]"
+          descriptionClassName="text-[#FCFAEF]/85"
+        />
+
+        <div
+          className="relative mx-auto max-w-4xl"
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+        >
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={currentIndex}
+              initial={shouldReduceMotion ? false : { opacity: 0, x: 20 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={
+                shouldReduceMotion ? { opacity: 0 } : { opacity: 0, x: -20 }
+              }
+              transition={{ duration: shouldReduceMotion ? 0.01 : 0.3 }}
+              className="flex min-h-[380px] flex-col rounded-xl border border-white/15 bg-[#FCFAEF]/95 p-8 shadow-xl dark:bg-[#2F3332] md:min-h-[340px] md:p-12"
+            >
+              <div className="absolute left-8 top-8 text-[#0097b2] opacity-20 dark:text-[#66C4DC]">
+                <Quote size={64} />
+              </div>
+
+              <div className="relative z-10 flex h-full flex-col">
+                <div className="flex flex-1 flex-col justify-center">
+                  <blockquote className="text-xl leading-relaxed text-[#2F3332] dark:text-[#E6E7E7] md:text-2xl">
+                    &quot;{testimonial.quote}&quot;
+                  </blockquote>
+                </div>
+
+                <div className="flex items-center">
+                  <div className="mr-4 h-16 w-16 overflow-hidden rounded-full">
+                    <Image
+                      src={testimonial.image}
+                      alt={`${testimonial.name}`}
+                      width={64}
+                      height={64}
+                      className="h-full w-full object-cover"
+                    />
+                  </div>
+                  <div>
+                    <div className="text-lg font-bold text-[#1C1F1E] dark:text-[#FCFAEF]">
+                      {testimonial.name}
+                    </div>
+                    <div className="text-[#eeba2b] dark:text-[#F5C94D]">
+                      {testimonial.title}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </motion.div>
+          </AnimatePresence>
+
+          <div className="mt-8 flex justify-center gap-2">
+            {academyTestimonials.map((_, index) => (
+              <button
+                key={academyTestimonials[index].id}
+                onClick={() => setCurrentIndex(index)}
+                className={`h-3 w-3 rounded-full transition-colors ${
+                  index === currentIndex ? "bg-[#F5C94D]" : "bg-[#FCFAEF]/30"
+                }`}
+                aria-label={`Go to testimonial ${index + 1}`}
+              />
+            ))}
+          </div>
+
+          <button
+            onClick={handlePrevious}
+            className="absolute left-0 top-1/2 flex h-10 w-10 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border border-[#E6E7E7] bg-[#FCFAEF] text-[#0097b2] shadow-md transition hover:bg-white focus:outline-none focus:ring-2 focus:ring-[#66C4DC] dark:border-[#2F3332] dark:bg-[#2F3332] dark:text-[#66C4DC] md:-left-3"
+            aria-label="Previous testimonial"
+          >
+            <ChevronLeft className="h-6 w-6" />
+          </button>
+
+          <button
+            onClick={handleNext}
+            className="absolute right-0 top-1/2 flex h-10 w-10 translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border border-[#E6E7E7] bg-[#FCFAEF] text-[#0097b2] shadow-md transition hover:bg-white focus:outline-none focus:ring-2 focus:ring-[#66C4DC] dark:border-[#2F3332] dark:bg-[#2F3332] dark:text-[#66C4DC] md:-right-3"
+            aria-label="Next testimonial"
+          >
+            <ChevronRight className="h-6 w-6" />
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/academy/AcademyTestimonials.tsx
+++ b/src/components/academy/AcademyTestimonials.tsx
@@ -41,7 +41,7 @@ export default function AcademyTestimonials() {
   const testimonial = academyTestimonials[currentIndex];
 
   return (
-    <section className="bg-[#F4F1E8] py-16 dark:bg-[#1C1F1E] md:py-24">
+    <section className="overflow-x-hidden bg-[#F4F1E8] py-16 dark:bg-[#1C1F1E] md:py-24">
       <div className="container mx-auto px-4 sm:px-6">
         <FadeIn direction="up" className="mx-auto mb-10 max-w-3xl space-y-3 text-center sm:space-y-4">
           <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#0097b2] dark:text-[#66C4DC] sm:text-sm">
@@ -123,7 +123,7 @@ export default function AcademyTestimonials() {
 
           <button
             onClick={handlePrevious}
-            className="absolute left-0 top-1/2 flex h-10 w-10 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border border-[#E6E7E7] bg-white text-[#0097b2] shadow-md transition hover:bg-[#FCFAEF] focus:outline-none focus:ring-2 focus:ring-[#0097b2] dark:border-[#2E3433] dark:bg-[#2F3332] dark:text-[#66C4DC] md:-left-3"
+            className="absolute -left-1 top-1/2 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full border border-[#E6E7E7] bg-white text-[#0097b2] shadow-md transition hover:bg-[#FCFAEF] focus:outline-none focus:ring-2 focus:ring-[#0097b2] dark:border-[#2E3433] dark:bg-[#2F3332] dark:text-[#66C4DC] md:-left-5"
             aria-label="Previous testimonial"
           >
             <ChevronLeft className="h-6 w-6" />
@@ -131,7 +131,7 @@ export default function AcademyTestimonials() {
 
           <button
             onClick={handleNext}
-            className="absolute right-0 top-1/2 flex h-10 w-10 translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border border-[#E6E7E7] bg-white text-[#0097b2] shadow-md transition hover:bg-[#FCFAEF] focus:outline-none focus:ring-2 focus:ring-[#0097b2] dark:border-[#2E3433] dark:bg-[#2F3332] dark:text-[#66C4DC] md:-right-3"
+            className="absolute -right-1 top-1/2 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full border border-[#E6E7E7] bg-white text-[#0097b2] shadow-md transition hover:bg-[#FCFAEF] focus:outline-none focus:ring-2 focus:ring-[#0097b2] dark:border-[#2E3433] dark:bg-[#2F3332] dark:text-[#66C4DC] md:-right-5"
             aria-label="Next testimonial"
           >
             <ChevronRight className="h-6 w-6" />

--- a/src/components/academy/ApplySection.tsx
+++ b/src/components/academy/ApplySection.tsx
@@ -1,0 +1,71 @@
+import Image from "@/components/common/Image";
+import { FadeIn } from "@/components/animations";
+import {
+  PublicCta,
+  SectionEyebrow,
+} from "@/components/shared/PublicPagePrimitives";
+import { LEADERSHIP_APP_FORM_URL } from "@/config/links";
+
+export default function ApplySection() {
+  return (
+    <section
+      className="relative isolate overflow-hidden bg-[#121514] py-20 text-[#FCFAEF] md:py-28"
+      aria-labelledby="apply-heading"
+    >
+      <div className="absolute inset-0 -z-10">
+        <Image
+          src="/highlights/Akomapa-62.jpg"
+          alt=""
+          fill
+          sizes="100vw"
+          className="object-cover opacity-30"
+          style={{ objectPosition: "center" }}
+        />
+        <div
+          aria-hidden="true"
+          className="absolute inset-0 bg-gradient-to-t from-[#121514]/90 via-[#121514]/60 to-[#121514]/90"
+        />
+        <div
+          aria-hidden="true"
+          className="absolute inset-0 bg-[radial-gradient(circle_at_50%_40%,rgba(238,186,43,0.12),transparent_50%)]"
+        />
+      </div>
+
+      <div className="container relative z-10 mx-auto px-4">
+        <FadeIn className="mx-auto max-w-3xl text-center">
+          <SectionEyebrow tone="gold">Become a Scholar</SectionEyebrow>
+          <h2
+            id="apply-heading"
+            className="mt-4 font-heading text-4xl font-bold leading-tight text-[#FCFAEF] md:text-5xl lg:text-6xl"
+          >
+            Ready to Lead With Purpose?
+          </h2>
+          <p className="mx-auto mt-6 max-w-2xl text-lg leading-relaxed text-[#FCFAEF]/84 md:text-xl">
+            The Akomapa Academy welcomes students and emerging health
+            professionals who are committed to ethical leadership, community
+            partnership, and creating lasting change in global health.
+          </p>
+          <div className="mt-10 flex flex-col justify-center gap-4 sm:flex-row">
+            <PublicCta
+              variant="gold"
+              asChild
+              icon
+              className="px-10 py-5 text-lg md:text-xl"
+            >
+              <a
+                href={LEADERSHIP_APP_FORM_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Apply to the Academy
+              </a>
+            </PublicCta>
+            <PublicCta href="/get-involved" variant="outline-light">
+              Other Ways to Get Involved
+            </PublicCta>
+          </div>
+        </FadeIn>
+      </div>
+    </section>
+  );
+}

--- a/src/components/academy/ApplySection.tsx
+++ b/src/components/academy/ApplySection.tsx
@@ -1,56 +1,43 @@
-import Image from "@/components/common/Image";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
 import { FadeIn } from "@/components/animations";
-import {
-  PublicCta,
-  SectionEyebrow,
-} from "@/components/shared/PublicPagePrimitives";
 import { LEADERSHIP_APP_FORM_URL } from "@/config/links";
+
+const ctaBaseClass =
+  "group inline-flex items-center justify-center gap-2 rounded-half px-8 py-6 h-auto text-base sm:text-lg font-medium transition-all duration-300 transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2";
 
 export default function ApplySection() {
   return (
     <section
-      className="relative isolate overflow-hidden bg-[#121514] py-20 text-[#FCFAEF] md:py-28"
+      className="relative overflow-hidden bg-gradient-to-r from-[#0097b2] to-[#0F4C5C] py-20 text-[#FCFAEF] md:py-28"
       aria-labelledby="apply-heading"
     >
-      <div className="absolute inset-0 -z-10">
-        <Image
-          src="/highlights/Akomapa-62.jpg"
-          alt=""
-          fill
-          sizes="100vw"
-          className="object-cover opacity-30"
-          style={{ objectPosition: "center" }}
-        />
-        <div
-          aria-hidden="true"
-          className="absolute inset-0 bg-gradient-to-t from-[#121514]/90 via-[#121514]/60 to-[#121514]/90"
-        />
-        <div
-          aria-hidden="true"
-          className="absolute inset-0 bg-[radial-gradient(circle_at_50%_40%,rgba(238,186,43,0.12),transparent_50%)]"
-        />
+      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+        <div className="absolute -top-24 right-12 h-64 w-64 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
+        <div className="absolute bottom-0 -left-16 h-80 w-80 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
+        <div className="absolute top-1/2 left-1/2 h-96 w-96 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[#F5C94D]/8 blur-3xl" />
       </div>
 
-      <div className="container relative z-10 mx-auto px-4">
+      <div className="container relative z-10 mx-auto px-4 sm:px-6">
         <FadeIn className="mx-auto max-w-3xl text-center">
-          <SectionEyebrow tone="gold">Become a Scholar</SectionEyebrow>
+          <p className="text-sm font-semibold uppercase tracking-[0.25em] text-[#F5C94D]">
+            Become a Scholar
+          </p>
           <h2
             id="apply-heading"
-            className="mt-4 font-heading text-4xl font-bold leading-tight text-[#FCFAEF] md:text-5xl lg:text-6xl"
+            className="mt-4 text-3xl font-bold leading-tight sm:text-4xl md:text-5xl"
           >
             Ready to Lead With Purpose?
           </h2>
-          <p className="mx-auto mt-6 max-w-2xl text-lg leading-relaxed text-[#FCFAEF]/84 md:text-xl">
+          <p className="mx-auto mt-6 max-w-2xl text-base leading-relaxed text-[#FCFAEF]/85 sm:text-lg">
             The Akomapa Academy welcomes students and emerging health
             professionals who are committed to ethical leadership, community
             partnership, and creating lasting change in global health.
           </p>
-          <div className="mt-10 flex flex-col justify-center gap-4 sm:flex-row">
-            <PublicCta
-              variant="gold"
+          <div className="mt-10 flex flex-col justify-center gap-3 sm:flex-row sm:gap-4">
+            <Button
               asChild
-              icon
-              className="px-10 py-5 text-lg md:text-xl"
+              className={`${ctaBaseClass} bg-[#eeba2b] px-10 py-7 text-lg text-[#FCFAEF] shadow-lg hover:bg-[#eeba2b]/80 hover:shadow-xl focus-visible:ring-[#F5C94D] md:text-xl`}
             >
               <a
                 href={LEADERSHIP_APP_FORM_URL}
@@ -59,10 +46,13 @@ export default function ApplySection() {
               >
                 Apply to the Academy
               </a>
-            </PublicCta>
-            <PublicCta href="/get-involved" variant="outline-light">
-              Other Ways to Get Involved
-            </PublicCta>
+            </Button>
+            <Button
+              asChild
+              className={`${ctaBaseClass} bg-[#0097b2] text-[#FCFAEF] shadow-lg hover:bg-[#0097b2]/80 hover:shadow-xl focus-visible:ring-[#8DD4E6]`}
+            >
+              <Link href="/get-involved">Other Ways to Get Involved</Link>
+            </Button>
           </div>
         </FadeIn>
       </div>

--- a/src/components/academy/CertificationSection.tsx
+++ b/src/components/academy/CertificationSection.tsx
@@ -1,12 +1,7 @@
 import { CheckCircle2 } from "lucide-react";
 import Image from "@/components/common/Image";
+import { Button } from "@/components/ui/button";
 import { FadeIn } from "@/components/animations";
-import {
-  MediaFrame,
-  PublicCta,
-  PublicSection,
-  SectionEyebrow,
-} from "@/components/shared/PublicPagePrimitives";
 import { academyCurriculum } from "@/data/academy";
 import { LEADERSHIP_APP_FORM_URL } from "@/config/links";
 
@@ -16,62 +11,73 @@ const certificationRequirements = [
   "Present an applied community-centered capstone project",
 ] as const;
 
+const ctaBaseClass =
+  "group inline-flex items-center justify-center gap-2 rounded-half px-8 py-6 h-auto text-base sm:text-lg font-medium transition-all duration-300 transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2";
+
 export default function CertificationSection() {
   return (
-    <PublicSection tone="dark" spacing="normal" containerClassName="max-w-7xl">
-      <div className="mx-auto grid max-w-6xl items-center gap-10 md:grid-cols-2 md:gap-12 lg:gap-16">
-        <FadeIn direction="left" amount="some">
-          <MediaFrame className="mx-auto w-full max-w-xl" aspect="wide">
-            <Image
-              src="/highlights/Akomapa-40.jpg"
-              alt="Academy scholars in a capstone presentation"
-              fill
-              sizes="(min-width: 1280px) 560px, (min-width: 768px) 45vw, 100vw"
-              className="object-cover"
-              style={{ objectPosition: "center" }}
-            />
-            <div
-              aria-hidden="true"
-              className="absolute inset-0 bg-gradient-to-t from-[#121514]/48 via-transparent to-transparent"
-            />
-          </MediaFrame>
-        </FadeIn>
-
-        <FadeIn direction="right" delay={0.08} amount="some">
-          <div>
-            <SectionEyebrow tone="gold">Certification</SectionEyebrow>
-            <h2 className="mt-4 font-heading text-3xl font-bold leading-tight text-[#FCFAEF] md:text-4xl">
-              {academyCurriculum.certificationName}
-            </h2>
-            <p className="mt-4 text-lg leading-relaxed text-[#FCFAEF]/84">
-              {academyCurriculum.certificationDescription}
-            </p>
-
-            <ul className="mt-6 space-y-3">
-              {certificationRequirements.map((requirement) => (
-                <li key={requirement} className="flex items-start gap-3">
-                  <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-[#F5C94D]" />
-                  <span className="text-base text-[#FCFAEF]/90">
-                    {requirement}
-                  </span>
-                </li>
-              ))}
-            </ul>
-
-            <div className="mt-8">
-              <PublicCta variant="gold" asChild icon>
-                <a
-                  href={LEADERSHIP_APP_FORM_URL}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Apply Now
-                </a>
-              </PublicCta>
-            </div>
-          </div>
-        </FadeIn>
+    <section className="relative overflow-hidden bg-gradient-to-r from-[#0097b2] to-[#0F4C5C] py-16 text-[#FCFAEF] md:py-24">
+      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+        <div className="absolute -top-16 left-12 h-48 w-48 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
+        <div className="absolute bottom-0 right-0 h-64 w-64 rounded-full bg-[#F5C94D]/10 blur-3xl" />
       </div>
-    </PublicSection>
+
+      <div className="container relative z-10 mx-auto px-4 sm:px-6">
+        <div className="mx-auto grid max-w-6xl items-center gap-10 lg:grid-cols-2 lg:gap-16">
+          <FadeIn direction="up" delay={0.1}>
+            <div className="relative h-[280px] w-full overflow-hidden rounded-3xl border border-white/10 shadow-2xl sm:h-[360px] md:h-[420px]">
+              <Image
+                src="/highlights/Akomapa-40.jpg"
+                alt="Academy scholars in a capstone presentation"
+                fill
+                sizes="(min-width: 1024px) 50vw, 100vw"
+                className="object-cover object-center"
+              />
+              <div className="absolute inset-0 bg-gradient-to-t from-black/35 via-transparent to-transparent" />
+            </div>
+          </FadeIn>
+
+          <FadeIn direction="up" delay={0.2}>
+            <div>
+              <p className="text-sm font-semibold uppercase tracking-[0.25em] text-[#F5C94D]">
+                Certification
+              </p>
+              <h2 className="mt-4 text-3xl font-bold leading-tight md:text-4xl">
+                {academyCurriculum.certificationName}
+              </h2>
+              <p className="mt-4 text-base leading-relaxed text-[#FCFAEF]/85 sm:text-lg">
+                {academyCurriculum.certificationDescription}
+              </p>
+
+              <ul className="mt-6 space-y-3">
+                {certificationRequirements.map((requirement) => (
+                  <li key={requirement} className="flex items-start gap-3">
+                    <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-[#F5C94D]" />
+                    <span className="text-base text-[#FCFAEF]/90">
+                      {requirement}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+
+              <div className="mt-8">
+                <Button
+                  asChild
+                  className={`${ctaBaseClass} bg-[#eeba2b] text-[#FCFAEF] shadow-lg hover:bg-[#eeba2b]/80 hover:shadow-xl focus-visible:ring-[#F5C94D]`}
+                >
+                  <a
+                    href={LEADERSHIP_APP_FORM_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Apply Now
+                  </a>
+                </Button>
+              </div>
+            </div>
+          </FadeIn>
+        </div>
+      </div>
+    </section>
   );
 }

--- a/src/components/academy/CertificationSection.tsx
+++ b/src/components/academy/CertificationSection.tsx
@@ -1,0 +1,77 @@
+import { CheckCircle2 } from "lucide-react";
+import Image from "@/components/common/Image";
+import { FadeIn } from "@/components/animations";
+import {
+  MediaFrame,
+  PublicCta,
+  PublicSection,
+  SectionEyebrow,
+} from "@/components/shared/PublicPagePrimitives";
+import { academyCurriculum } from "@/data/academy";
+import { LEADERSHIP_APP_FORM_URL } from "@/config/links";
+
+const certificationRequirements = [
+  "Complete all 8 core modules",
+  "Participate in faculty and peer learning sessions",
+  "Present an applied community-centered capstone project",
+] as const;
+
+export default function CertificationSection() {
+  return (
+    <PublicSection tone="dark" spacing="normal" containerClassName="max-w-7xl">
+      <div className="mx-auto grid max-w-6xl items-center gap-10 md:grid-cols-2 md:gap-12 lg:gap-16">
+        <FadeIn direction="left" amount="some">
+          <MediaFrame className="mx-auto w-full max-w-xl" aspect="wide">
+            <Image
+              src="/highlights/Akomapa-40.jpg"
+              alt="Academy scholars in a capstone presentation"
+              fill
+              sizes="(min-width: 1280px) 560px, (min-width: 768px) 45vw, 100vw"
+              className="object-cover"
+              style={{ objectPosition: "center" }}
+            />
+            <div
+              aria-hidden="true"
+              className="absolute inset-0 bg-gradient-to-t from-[#121514]/48 via-transparent to-transparent"
+            />
+          </MediaFrame>
+        </FadeIn>
+
+        <FadeIn direction="right" delay={0.08} amount="some">
+          <div>
+            <SectionEyebrow tone="gold">Certification</SectionEyebrow>
+            <h2 className="mt-4 font-heading text-3xl font-bold leading-tight text-[#FCFAEF] md:text-4xl">
+              {academyCurriculum.certificationName}
+            </h2>
+            <p className="mt-4 text-lg leading-relaxed text-[#FCFAEF]/84">
+              {academyCurriculum.certificationDescription}
+            </p>
+
+            <ul className="mt-6 space-y-3">
+              {certificationRequirements.map((requirement) => (
+                <li key={requirement} className="flex items-start gap-3">
+                  <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-[#F5C94D]" />
+                  <span className="text-base text-[#FCFAEF]/90">
+                    {requirement}
+                  </span>
+                </li>
+              ))}
+            </ul>
+
+            <div className="mt-8">
+              <PublicCta variant="gold" asChild icon>
+                <a
+                  href={LEADERSHIP_APP_FORM_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Apply Now
+                </a>
+              </PublicCta>
+            </div>
+          </div>
+        </FadeIn>
+      </div>
+    </PublicSection>
+  );
+}

--- a/src/components/academy/CurriculumSection.tsx
+++ b/src/components/academy/CurriculumSection.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { CheckCircle2, ChevronDown, Clock, Users } from "lucide-react";
+import { FadeIn } from "@/components/animations";
+import {
+  PublicSection,
+  PublicSectionHeader,
+} from "@/components/shared/PublicPagePrimitives";
+import { academyCurriculum, academyFaculty } from "@/data/academy";
+import type { AcademyModule } from "@/lib/types";
+
+const accentColors = ["#0097b2", "#F5C94D", "#66C4DC", "#eeba2b"] as const;
+
+function getAccentColor(index: number) {
+  return accentColors[index % accentColors.length];
+}
+
+function resolveFacultyNames(contributorIds: string[]): string {
+  return contributorIds
+    .map((id) => academyFaculty.find((f) => f.id === id)?.name)
+    .filter(Boolean)
+    .join(", ");
+}
+
+function ModuleAccordion({ modules }: { modules: AcademyModule[] }) {
+  const [openId, setOpenId] = useState<string | null>(modules[0]?.id ?? null);
+
+  return (
+    <div className="w-full space-y-3 sm:space-y-4">
+      {modules.map((module, index) => {
+        const isOpen = openId === module.id;
+        const accent = getAccentColor(index);
+
+        return (
+          <div
+            key={module.id}
+            className="overflow-hidden rounded-2xl border border-neutral-200/50 bg-white text-[#0F4C5C] shadow-md shadow-black/10 transition-all duration-200 hover:-translate-y-0.5 dark:border-[#2F3332] dark:bg-[#2F3332] dark:text-[#FCFAEF] dark:shadow-black/30"
+          >
+            <button
+              type="button"
+              onClick={() => setOpenId(isOpen ? null : module.id)}
+              className="flex w-full items-start justify-between gap-3 px-4 py-4 text-left sm:items-center sm:gap-4 sm:px-6 sm:py-5"
+              aria-expanded={isOpen}
+              aria-controls={`module-content-${module.id}`}
+            >
+              <div className="min-w-0 flex-1 space-y-2 sm:space-y-3">
+                <span
+                  className="inline-flex items-center rounded-full px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.2em] sm:px-3 sm:text-xs sm:tracking-[0.3em]"
+                  style={{
+                    color: accent,
+                    backgroundColor: `${accent}1A`,
+                  }}
+                >
+                  Module {module.order}
+                </span>
+                <h3 className="text-base font-semibold leading-tight text-[#0F4C5C] dark:text-[#FCFAEF] sm:text-lg md:text-xl">
+                  {module.title}
+                </h3>
+              </div>
+              <ChevronDown
+                className={`mt-1 h-4 w-4 flex-shrink-0 text-[#0F4C5C] transition-transform duration-200 dark:text-[#FCFAEF] sm:mt-0 sm:h-5 sm:w-5 ${
+                  isOpen ? "rotate-180" : ""
+                }`}
+              />
+            </button>
+
+            <AnimatePresence initial={false}>
+              {isOpen && (
+                <motion.div
+                  id={`module-content-${module.id}`}
+                  initial={{ height: 0, opacity: 0 }}
+                  animate={{ height: "auto", opacity: 1 }}
+                  exit={{ height: 0, opacity: 0 }}
+                  transition={{ duration: 0.3, ease: "easeInOut" }}
+                  style={{ overflow: "hidden" }}
+                >
+                  <div className="space-y-4 px-4 pb-4 sm:px-6 sm:pb-6">
+                    <p className="text-sm leading-relaxed text-[#2F3332] dark:text-[#E6E7E7] sm:text-base">
+                      {module.description}
+                    </p>
+
+                    <div>
+                      <h4 className="font-subheading text-xs font-bold uppercase tracking-widest text-[#0097b2] dark:text-[#66C4DC]">
+                        Learning Objectives
+                      </h4>
+                      <ul className="mt-2 space-y-1.5">
+                        {module.learningObjectives.map((objective) => (
+                          <li
+                            key={objective}
+                            className="flex items-start gap-2 text-sm text-[#2F3332]/85 dark:text-[#E6E7E7]/85"
+                          >
+                            <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-[#0097b2] dark:text-[#66C4DC]" />
+                            <span>{objective}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+
+                    <div className="flex flex-wrap items-center gap-3 text-xs text-[#2F3332]/70 dark:text-[#E6E7E7]/70">
+                      {module.duration ? (
+                        <span className="inline-flex items-center gap-1.5 rounded-full bg-[#0097b2]/10 px-3 py-1 font-semibold text-[#0097b2] dark:bg-[#66C4DC]/15 dark:text-[#66C4DC]">
+                          <Clock className="h-3 w-3" />
+                          {module.duration}
+                        </span>
+                      ) : null}
+                      <span className="inline-flex items-center gap-1.5">
+                        <Users className="h-3 w-3 text-[#0097b2] dark:text-[#66C4DC]" />
+                        {resolveFacultyNames(module.facultyContributors)}
+                      </span>
+                    </div>
+                  </div>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function CurriculumSection() {
+  return (
+    <PublicSection
+      id="curriculum"
+      tone="white"
+      spacing="spacious"
+      className="scroll-mt-20"
+    >
+      <FadeIn>
+        <PublicSectionHeader
+          eyebrow="Curriculum"
+          title="8 Modules. One Transformative Journey."
+          description={`A ${academyCurriculum.totalDuration} program covering ethical leadership, community partnership, research, innovation, and an applied capstone project.`}
+          alignment="center"
+          className="mb-12 md:mb-16"
+        />
+      </FadeIn>
+
+      <div className="mx-auto max-w-3xl">
+        <ModuleAccordion modules={academyCurriculum.modules} />
+      </div>
+    </PublicSection>
+  );
+}

--- a/src/components/academy/CurriculumSection.tsx
+++ b/src/components/academy/CurriculumSection.tsx
@@ -4,10 +4,6 @@ import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { CheckCircle2, ChevronDown, Clock, Users } from "lucide-react";
 import { FadeIn } from "@/components/animations";
-import {
-  PublicSection,
-  PublicSectionHeader,
-} from "@/components/shared/PublicPagePrimitives";
 import { academyCurriculum, academyFaculty } from "@/data/academy";
 import type { AcademyModule } from "@/lib/types";
 
@@ -36,7 +32,7 @@ function ModuleAccordion({ modules }: { modules: AcademyModule[] }) {
         return (
           <div
             key={module.id}
-            className="overflow-hidden rounded-2xl border border-neutral-200/50 bg-white text-[#0F4C5C] shadow-md shadow-black/10 transition-all duration-200 hover:-translate-y-0.5 dark:border-[#2F3332] dark:bg-[#2F3332] dark:text-[#FCFAEF] dark:shadow-black/30"
+            className="overflow-hidden rounded-2xl border border-white/20 bg-[#0B2F3A]/60 text-[#FCFAEF] shadow-lg shadow-black/30 backdrop-blur-sm transition-all duration-200 hover:-translate-y-0.5"
           >
             <button
               type="button"
@@ -55,12 +51,12 @@ function ModuleAccordion({ modules }: { modules: AcademyModule[] }) {
                 >
                   Module {module.order}
                 </span>
-                <h3 className="text-base font-semibold leading-tight text-[#0F4C5C] dark:text-[#FCFAEF] sm:text-lg md:text-xl">
+                <h3 className="text-base font-semibold leading-tight text-[#FCFAEF] sm:text-lg md:text-xl">
                   {module.title}
                 </h3>
               </div>
               <ChevronDown
-                className={`mt-1 h-4 w-4 flex-shrink-0 text-[#0F4C5C] transition-transform duration-200 dark:text-[#FCFAEF] sm:mt-0 sm:h-5 sm:w-5 ${
+                className={`mt-1 h-4 w-4 flex-shrink-0 text-[#FCFAEF] transition-transform duration-200 sm:mt-0 sm:h-5 sm:w-5 ${
                   isOpen ? "rotate-180" : ""
                 }`}
               />
@@ -77,36 +73,36 @@ function ModuleAccordion({ modules }: { modules: AcademyModule[] }) {
                   style={{ overflow: "hidden" }}
                 >
                   <div className="space-y-4 px-4 pb-4 sm:px-6 sm:pb-6">
-                    <p className="text-sm leading-relaxed text-[#2F3332] dark:text-[#E6E7E7] sm:text-base">
+                    <p className="text-sm leading-relaxed text-[#FCFAEF]/85 sm:text-base">
                       {module.description}
                     </p>
 
                     <div>
-                      <h4 className="font-subheading text-xs font-bold uppercase tracking-widest text-[#0097b2] dark:text-[#66C4DC]">
+                      <h4 className="text-xs font-bold uppercase tracking-widest text-[#F5C94D]">
                         Learning Objectives
                       </h4>
                       <ul className="mt-2 space-y-1.5">
                         {module.learningObjectives.map((objective) => (
                           <li
                             key={objective}
-                            className="flex items-start gap-2 text-sm text-[#2F3332]/85 dark:text-[#E6E7E7]/85"
+                            className="flex items-start gap-2 text-sm text-[#FCFAEF]/85"
                           >
-                            <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-[#0097b2] dark:text-[#66C4DC]" />
+                            <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-[#F5C94D]" />
                             <span>{objective}</span>
                           </li>
                         ))}
                       </ul>
                     </div>
 
-                    <div className="flex flex-wrap items-center gap-3 text-xs text-[#2F3332]/70 dark:text-[#E6E7E7]/70">
+                    <div className="flex flex-wrap items-center gap-3 text-xs text-[#FCFAEF]/70">
                       {module.duration ? (
-                        <span className="inline-flex items-center gap-1.5 rounded-full bg-[#0097b2]/10 px-3 py-1 font-semibold text-[#0097b2] dark:bg-[#66C4DC]/15 dark:text-[#66C4DC]">
+                        <span className="inline-flex items-center gap-1.5 rounded-full bg-white/10 px-3 py-1 font-semibold text-[#FCFAEF]">
                           <Clock className="h-3 w-3" />
                           {module.duration}
                         </span>
                       ) : null}
                       <span className="inline-flex items-center gap-1.5">
-                        <Users className="h-3 w-3 text-[#0097b2] dark:text-[#66C4DC]" />
+                        <Users className="h-3 w-3 text-[#F5C94D]" />
                         {resolveFacultyNames(module.facultyContributors)}
                       </span>
                     </div>
@@ -123,25 +119,36 @@ function ModuleAccordion({ modules }: { modules: AcademyModule[] }) {
 
 export default function CurriculumSection() {
   return (
-    <PublicSection
+    <section
       id="curriculum"
-      tone="white"
-      spacing="spacious"
-      className="scroll-mt-20"
+      className="relative scroll-mt-20 overflow-hidden bg-gradient-to-r from-[#0097b2] to-[#0F4C5C] py-16 text-[#FCFAEF] md:py-24"
     >
-      <FadeIn>
-        <PublicSectionHeader
-          eyebrow="Curriculum"
-          title="8 Modules. One Transformative Journey."
-          description={`A ${academyCurriculum.totalDuration} program covering ethical leadership, community partnership, research, innovation, and an applied capstone project.`}
-          alignment="center"
-          className="mb-12 md:mb-16"
-        />
-      </FadeIn>
-
-      <div className="mx-auto max-w-3xl">
-        <ModuleAccordion modules={academyCurriculum.modules} />
+      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+        <div className="absolute -top-24 -left-24 h-64 w-64 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
+        <div className="absolute bottom-0 right-0 h-80 w-80 rounded-full bg-[#F5C94D]/10 blur-3xl" />
       </div>
-    </PublicSection>
+
+      <div className="container relative z-10 mx-auto px-4 sm:px-6">
+        <FadeIn>
+          <div className="mx-auto mb-12 max-w-3xl space-y-4 text-center">
+            <p className="text-sm font-semibold uppercase tracking-[0.2em] text-[#F5C94D]">
+              Curriculum
+            </p>
+            <h2 className="text-3xl font-bold md:text-4xl">
+              8 Modules. One Transformative Journey.
+            </h2>
+            <p className="text-base leading-relaxed text-[#FCFAEF]/85 sm:text-lg">
+              A {academyCurriculum.totalDuration} program covering ethical
+              leadership, community partnership, research, innovation, and an
+              applied capstone project.
+            </p>
+          </div>
+        </FadeIn>
+
+        <div className="mx-auto max-w-3xl">
+          <ModuleAccordion modules={academyCurriculum.modules} />
+        </div>
+      </div>
+    </section>
   );
 }

--- a/src/components/academy/FacultyGrid.tsx
+++ b/src/components/academy/FacultyGrid.tsx
@@ -1,0 +1,109 @@
+import { Linkedin, Mail } from "lucide-react";
+import Image from "@/components/common/Image";
+import {
+  FadeIn,
+  FadeInStagger,
+  FadeInStaggerItem,
+} from "@/components/animations";
+import {
+  PublicSection,
+  PublicSectionHeader,
+  SurfaceCard,
+} from "@/components/shared/PublicPagePrimitives";
+import { academyFaculty } from "@/data/academy";
+import type { FacultyMember } from "@/lib/types";
+
+function FacultyCard({ faculty }: { faculty: FacultyMember }) {
+  const hasLinks = faculty.socialLinks?.linkedin || faculty.socialLinks?.email;
+
+  return (
+    <SurfaceCard interactive className="overflow-hidden">
+      <div className="relative aspect-[4/5]">
+        <Image
+          src={faculty.image}
+          alt={`${faculty.name}, ${faculty.title}`}
+          fill
+          sizes="(min-width: 1024px) 25vw, (min-width: 640px) 50vw, 100vw"
+          className="object-cover"
+          style={{ objectPosition: "center top" }}
+        />
+        <div
+          aria-hidden="true"
+          className="absolute inset-0 bg-gradient-to-t from-[#121514]/60 via-transparent to-transparent"
+        />
+      </div>
+
+      <div className="p-5">
+        <h3 className="font-heading text-lg font-bold text-[#1C1F1E] dark:text-[#FCFAEF]">
+          {faculty.name}
+        </h3>
+        <p className="mt-1 text-sm text-[#2F3332]/70 dark:text-[#E6E7E7]/70">
+          {faculty.title}
+        </p>
+        <p className="mt-0.5 text-sm font-semibold text-[#0097b2] dark:text-[#66C4DC]">
+          {faculty.institution}
+        </p>
+
+        <div className="mt-3 flex flex-wrap gap-1.5">
+          {faculty.specialties.map((specialty) => (
+            <span
+              key={specialty}
+              className="rounded-full bg-[#0097b2]/8 px-2.5 py-0.5 text-xs text-[#0097b2] dark:bg-[#66C4DC]/12 dark:text-[#66C4DC]"
+            >
+              {specialty}
+            </span>
+          ))}
+        </div>
+
+        {hasLinks ? (
+          <div className="mt-4 flex gap-2">
+            {faculty.socialLinks?.linkedin ? (
+              <a
+                href={faculty.socialLinks.linkedin}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex h-8 w-8 items-center justify-center rounded-md text-[#2F3332]/60 transition-colors hover:bg-[#0097b2]/10 hover:text-[#0097b2] dark:text-[#E6E7E7]/60 dark:hover:bg-[#66C4DC]/15 dark:hover:text-[#66C4DC]"
+                aria-label={`${faculty.name} on LinkedIn`}
+              >
+                <Linkedin className="h-4 w-4" />
+              </a>
+            ) : null}
+            {faculty.socialLinks?.email ? (
+              <a
+                href={`mailto:${faculty.socialLinks.email}`}
+                className="inline-flex h-8 w-8 items-center justify-center rounded-md text-[#2F3332]/60 transition-colors hover:bg-[#0097b2]/10 hover:text-[#0097b2] dark:text-[#E6E7E7]/60 dark:hover:bg-[#66C4DC]/15 dark:hover:text-[#66C4DC]"
+                aria-label={`Email ${faculty.name}`}
+              >
+                <Mail className="h-4 w-4" />
+              </a>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </SurfaceCard>
+  );
+}
+
+export default function FacultyGrid() {
+  return (
+    <PublicSection tone="cream" spacing="normal" withTexture>
+      <FadeIn>
+        <PublicSectionHeader
+          eyebrow="Faculty"
+          title="Learn From Leaders in the Field"
+          description="Our faculty bring decades of experience across community medicine, health systems, clinical education, and public health leadership."
+          alignment="center"
+          className="mb-12 md:mb-16"
+        />
+      </FadeIn>
+
+      <FadeInStagger className="mx-auto grid max-w-6xl grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
+        {academyFaculty.map((faculty) => (
+          <FadeInStaggerItem key={faculty.id}>
+            <FacultyCard faculty={faculty} />
+          </FadeInStaggerItem>
+        ))}
+      </FadeInStagger>
+    </PublicSection>
+  );
+}

--- a/src/components/academy/FacultyGrid.tsx
+++ b/src/components/academy/FacultyGrid.tsx
@@ -72,7 +72,7 @@ function FacultyCard({ faculty }: { faculty: FacultyMember }) {
 
 export default function FacultyGrid() {
   return (
-    <section className="bg-[#FCFAEF] py-16 dark:bg-[#1C1F1E] md:py-24">
+    <section className="overflow-x-hidden bg-[#FCFAEF] py-16 dark:bg-[#1C1F1E] md:py-24">
       <div className="container mx-auto px-4 sm:px-6">
         <FadeIn direction="up" className="mx-auto mb-10 max-w-3xl space-y-3 text-center sm:space-y-4">
           <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#0097b2] dark:text-[#66C4DC] sm:text-sm">

--- a/src/components/academy/FacultyGrid.tsx
+++ b/src/components/academy/FacultyGrid.tsx
@@ -1,15 +1,6 @@
 import { Linkedin, Mail } from "lucide-react";
 import Image from "@/components/common/Image";
-import {
-  FadeIn,
-  FadeInStagger,
-  FadeInStaggerItem,
-} from "@/components/animations";
-import {
-  PublicSection,
-  PublicSectionHeader,
-  SurfaceCard,
-} from "@/components/shared/PublicPagePrimitives";
+import { FadeIn, FadeInStagger, FadeInStaggerItem } from "@/components/animations";
 import { academyFaculty } from "@/data/academy";
 import type { FacultyMember } from "@/lib/types";
 
@@ -17,34 +8,29 @@ function FacultyCard({ faculty }: { faculty: FacultyMember }) {
   const hasLinks = faculty.socialLinks?.linkedin || faculty.socialLinks?.email;
 
   return (
-    <SurfaceCard interactive className="overflow-hidden">
-      <div className="relative aspect-[4/5]">
+    <div className="group flex flex-col overflow-hidden rounded-[28px] border border-[#E6E7E7]/80 bg-white/95 shadow-sm transition-all duration-500 hover:-translate-y-1 hover:shadow-xl dark:border-[#2E3433] dark:bg-[#1C1F1E]/95">
+      <div className="relative h-80 w-full overflow-hidden sm:h-96 md:h-[28rem] lg:h-[24rem]">
         <Image
           src={faculty.image}
           alt={`${faculty.name}, ${faculty.title}`}
           fill
           sizes="(min-width: 1024px) 25vw, (min-width: 640px) 50vw, 100vw"
-          className="object-cover"
-          style={{ objectPosition: "center top" }}
-        />
-        <div
-          aria-hidden="true"
-          className="absolute inset-0 bg-gradient-to-t from-[#121514]/60 via-transparent to-transparent"
+          className="object-cover object-center"
         />
       </div>
 
-      <div className="p-5">
-        <h3 className="font-heading text-lg font-bold text-[#1C1F1E] dark:text-[#FCFAEF]">
-          {faculty.name}
-        </h3>
-        <p className="mt-1 text-sm text-[#2F3332]/70 dark:text-[#E6E7E7]/70">
-          {faculty.title}
-        </p>
-        <p className="mt-0.5 text-sm font-semibold text-[#0097b2] dark:text-[#66C4DC]">
+      <div className="flex flex-col gap-2 px-6 py-6">
+        <p className="text-xs uppercase tracking-[0.3em] text-[#0097b2] dark:text-[#66C4DC]">
           {faculty.institution}
         </p>
+        <h3 className="text-xl font-semibold text-[#0B2F3A] dark:text-[#FCFAEF]">
+          {faculty.name}
+        </h3>
+        <p className="text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
+          {faculty.title}
+        </p>
 
-        <div className="mt-3 flex flex-wrap gap-1.5">
+        <div className="mt-2 flex flex-wrap gap-1.5">
           {faculty.specialties.map((specialty) => (
             <span
               key={specialty}
@@ -56,13 +42,13 @@ function FacultyCard({ faculty }: { faculty: FacultyMember }) {
         </div>
 
         {hasLinks ? (
-          <div className="mt-4 flex gap-2">
+          <div className="mt-2 flex items-center gap-3 pt-2">
             {faculty.socialLinks?.linkedin ? (
               <a
                 href={faculty.socialLinks.linkedin}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex h-8 w-8 items-center justify-center rounded-md text-[#2F3332]/60 transition-colors hover:bg-[#0097b2]/10 hover:text-[#0097b2] dark:text-[#E6E7E7]/60 dark:hover:bg-[#66C4DC]/15 dark:hover:text-[#66C4DC]"
+                className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-[#E6E7E7] text-[#0B2F3A] transition-colors hover:bg-[#0097b2]/10 dark:border-[#2E3433] dark:text-[#FCFAEF] dark:hover:bg-[#0097b2]/20"
                 aria-label={`${faculty.name} on LinkedIn`}
               >
                 <Linkedin className="h-4 w-4" />
@@ -71,7 +57,7 @@ function FacultyCard({ faculty }: { faculty: FacultyMember }) {
             {faculty.socialLinks?.email ? (
               <a
                 href={`mailto:${faculty.socialLinks.email}`}
-                className="inline-flex h-8 w-8 items-center justify-center rounded-md text-[#2F3332]/60 transition-colors hover:bg-[#0097b2]/10 hover:text-[#0097b2] dark:text-[#E6E7E7]/60 dark:hover:bg-[#66C4DC]/15 dark:hover:text-[#66C4DC]"
+                className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-[#E6E7E7] text-[#0B2F3A] transition-colors hover:bg-[#0097b2]/10 dark:border-[#2E3433] dark:text-[#FCFAEF] dark:hover:bg-[#0097b2]/20"
                 aria-label={`Email ${faculty.name}`}
               >
                 <Mail className="h-4 w-4" />
@@ -80,30 +66,35 @@ function FacultyCard({ faculty }: { faculty: FacultyMember }) {
           </div>
         ) : null}
       </div>
-    </SurfaceCard>
+    </div>
   );
 }
 
 export default function FacultyGrid() {
   return (
-    <PublicSection tone="cream" spacing="normal" withTexture>
-      <FadeIn>
-        <PublicSectionHeader
-          eyebrow="Faculty"
-          title="Learn From Leaders in the Field"
-          description="Our faculty bring decades of experience across community medicine, health systems, clinical education, and public health leadership."
-          alignment="center"
-          className="mb-12 md:mb-16"
-        />
-      </FadeIn>
+    <section className="bg-[#FCFAEF] py-16 dark:bg-[#1C1F1E] md:py-24">
+      <div className="container mx-auto px-4 sm:px-6">
+        <FadeIn direction="up" className="mx-auto mb-10 max-w-3xl space-y-3 text-center sm:space-y-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#0097b2] dark:text-[#66C4DC] sm:text-sm">
+            Faculty
+          </p>
+          <h2 className="text-2xl font-bold text-[#0B2F3A] dark:text-[#FCFAEF] sm:text-3xl md:text-4xl">
+            Learn From Leaders in the Field
+          </h2>
+          <p className="text-base leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80 sm:text-lg">
+            Our faculty bring decades of experience across community medicine,
+            health systems, clinical education, and public health leadership.
+          </p>
+        </FadeIn>
 
-      <FadeInStagger className="mx-auto grid max-w-6xl grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
-        {academyFaculty.map((faculty) => (
-          <FadeInStaggerItem key={faculty.id}>
-            <FacultyCard faculty={faculty} />
-          </FadeInStaggerItem>
-        ))}
-      </FadeInStagger>
-    </PublicSection>
+        <FadeInStagger className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4 sm:gap-6">
+          {academyFaculty.map((faculty) => (
+            <FadeInStaggerItem key={faculty.id}>
+              <FacultyCard faculty={faculty} />
+            </FadeInStaggerItem>
+          ))}
+        </FadeInStagger>
+      </div>
+    </section>
   );
 }

--- a/src/components/academy/WhyEthicalLeadership.tsx
+++ b/src/components/academy/WhyEthicalLeadership.tsx
@@ -1,13 +1,6 @@
 import { AlertTriangle, Shield, Sparkles } from "lucide-react";
 import Image from "@/components/common/Image";
-import { FadeIn } from "@/components/animations";
-import {
-  IconBadge,
-  MediaFrame,
-  PublicSection,
-  PublicSectionHeader,
-  SurfaceCard,
-} from "@/components/shared/PublicPagePrimitives";
+import { FadeIn, FadeInStagger, FadeInStaggerItem } from "@/components/animations";
 import { academyOverview } from "@/data/academy";
 
 const reasons = [
@@ -16,72 +9,83 @@ const reasons = [
     title: "The Gap in Health Education",
     description:
       "Most health professional training emphasizes clinical knowledge but overlooks ethics, power analysis, and community partnership — the skills that determine whether interventions help or harm.",
+    accentColor: "#0097b2",
   },
   {
     icon: Shield,
     title: "Why Ethics and Partnership Matter",
     description:
       "Health professionals make decisions that affect communities, institutions, and public trust. Ethical leadership equips them to examine power, listen across differences, and use evidence responsibly.",
+    accentColor: "#eeba2b",
   },
   {
     icon: Sparkles,
     title: "The Akomapa Difference",
     description:
       "The Academy combines faculty dialogue, case-based study, community practice, and mentorship — preparing leaders who build solutions with the people those solutions are intended to serve.",
+    accentColor: "#0F4C5C",
   },
 ] as const;
 
 export default function WhyEthicalLeadership() {
   return (
-    <PublicSection tone="cream" spacing="normal" withTexture>
-      <PublicSectionHeader
-        eyebrow="Why It Matters"
-        title="The Case for Ethical Leadership"
-        description={academyOverview.whyItMatters}
-        alignment="center"
-        className="mb-12 md:mb-16"
-      />
-
-      <div className="mx-auto grid max-w-6xl items-center gap-10 md:grid-cols-2 md:gap-12 lg:gap-16">
-        <FadeIn direction="left" amount="some">
-          <MediaFrame className="mx-auto w-full max-w-xl" aspect="wide">
-            <Image
-              src="/highlights/Akomapa-61.jpg"
-              alt="Students and faculty engaged in collaborative learning"
-              fill
-              sizes="(min-width: 1280px) 560px, (min-width: 768px) 45vw, 100vw"
-              className="object-cover"
-              style={{ objectPosition: "center" }}
-            />
-            <div
-              aria-hidden="true"
-              className="absolute inset-0 bg-gradient-to-t from-[#121514]/48 via-transparent to-transparent"
-            />
-          </MediaFrame>
+    <section className="bg-[#FCFAEF] py-16 dark:bg-[#1C1F1E] md:py-24">
+      <div className="container mx-auto px-4 sm:px-6">
+        <FadeIn direction="up" className="mx-auto mb-10 max-w-3xl space-y-3 text-center sm:space-y-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#0097b2] dark:text-[#66C4DC] sm:text-sm">
+            Why It Matters
+          </p>
+          <h2 className="text-2xl font-bold text-[#1C1F1E] dark:text-[#FCFAEF] sm:text-3xl md:text-4xl">
+            The Case for Ethical Leadership
+          </h2>
+          <p className="text-base leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80 sm:text-lg">
+            {academyOverview.whyItMatters}
+          </p>
         </FadeIn>
 
-        <FadeIn direction="right" delay={0.08} amount="some">
-          <div className="space-y-4">
+        <div className="mx-auto grid max-w-6xl items-center gap-10 lg:grid-cols-2 lg:gap-16">
+          <FadeIn direction="up" delay={0.1}>
+            <div className="relative h-[280px] w-full overflow-hidden rounded-3xl shadow-2xl sm:h-[360px] md:h-[420px]">
+              <Image
+                src="/highlights/Akomapa-61.jpg"
+                alt="Students and faculty engaged in collaborative learning"
+                fill
+                sizes="(min-width: 1024px) 50vw, 100vw"
+                className="object-cover object-center"
+              />
+              <div className="absolute inset-0 bg-gradient-to-t from-black/25 via-transparent to-transparent" />
+            </div>
+          </FadeIn>
+
+          <FadeInStagger className="space-y-4" staggerDelay={0.1}>
             {reasons.map((reason) => (
-              <SurfaceCard key={reason.title} className="p-5">
-                <div className="flex items-start gap-4">
-                  <IconBadge>
-                    <reason.icon className="h-5 w-5" />
-                  </IconBadge>
-                  <div>
-                    <h3 className="font-heading text-lg font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
-                      {reason.title}
-                    </h3>
-                    <p className="mt-1.5 text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
-                      {reason.description}
-                    </p>
+              <FadeInStaggerItem key={reason.title} direction="up">
+                <div className="rounded-2xl border border-[#E6E7E7]/80 bg-white/95 p-6 shadow-sm transition-all duration-500 hover:-translate-y-1 hover:shadow-xl dark:border-[#2E3433] dark:bg-[#1C1F1E]/95">
+                  <div className="flex items-start gap-4">
+                    <span
+                      className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-lg"
+                      style={{
+                        backgroundColor: `${reason.accentColor}15`,
+                        color: reason.accentColor,
+                      }}
+                    >
+                      <reason.icon className="h-5 w-5" />
+                    </span>
+                    <div>
+                      <h3 className="text-lg font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+                        {reason.title}
+                      </h3>
+                      <p className="mt-1.5 text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
+                        {reason.description}
+                      </p>
+                    </div>
                   </div>
                 </div>
-              </SurfaceCard>
+              </FadeInStaggerItem>
             ))}
-          </div>
-        </FadeIn>
+          </FadeInStagger>
+        </div>
       </div>
-    </PublicSection>
+    </section>
   );
 }

--- a/src/components/academy/WhyEthicalLeadership.tsx
+++ b/src/components/academy/WhyEthicalLeadership.tsx
@@ -1,0 +1,87 @@
+import { AlertTriangle, Shield, Sparkles } from "lucide-react";
+import Image from "@/components/common/Image";
+import { FadeIn } from "@/components/animations";
+import {
+  IconBadge,
+  MediaFrame,
+  PublicSection,
+  PublicSectionHeader,
+  SurfaceCard,
+} from "@/components/shared/PublicPagePrimitives";
+import { academyOverview } from "@/data/academy";
+
+const reasons = [
+  {
+    icon: AlertTriangle,
+    title: "The Gap in Health Education",
+    description:
+      "Most health professional training emphasizes clinical knowledge but overlooks ethics, power analysis, and community partnership — the skills that determine whether interventions help or harm.",
+  },
+  {
+    icon: Shield,
+    title: "Why Ethics and Partnership Matter",
+    description:
+      "Health professionals make decisions that affect communities, institutions, and public trust. Ethical leadership equips them to examine power, listen across differences, and use evidence responsibly.",
+  },
+  {
+    icon: Sparkles,
+    title: "The Akomapa Difference",
+    description:
+      "The Academy combines faculty dialogue, case-based study, community practice, and mentorship — preparing leaders who build solutions with the people those solutions are intended to serve.",
+  },
+] as const;
+
+export default function WhyEthicalLeadership() {
+  return (
+    <PublicSection tone="cream" spacing="normal" withTexture>
+      <PublicSectionHeader
+        eyebrow="Why It Matters"
+        title="The Case for Ethical Leadership"
+        description={academyOverview.whyItMatters}
+        alignment="center"
+        className="mb-12 md:mb-16"
+      />
+
+      <div className="mx-auto grid max-w-6xl items-center gap-10 md:grid-cols-2 md:gap-12 lg:gap-16">
+        <FadeIn direction="left" amount="some">
+          <MediaFrame className="mx-auto w-full max-w-xl" aspect="wide">
+            <Image
+              src="/highlights/Akomapa-61.jpg"
+              alt="Students and faculty engaged in collaborative learning"
+              fill
+              sizes="(min-width: 1280px) 560px, (min-width: 768px) 45vw, 100vw"
+              className="object-cover"
+              style={{ objectPosition: "center" }}
+            />
+            <div
+              aria-hidden="true"
+              className="absolute inset-0 bg-gradient-to-t from-[#121514]/48 via-transparent to-transparent"
+            />
+          </MediaFrame>
+        </FadeIn>
+
+        <FadeIn direction="right" delay={0.08} amount="some">
+          <div className="space-y-4">
+            {reasons.map((reason) => (
+              <SurfaceCard key={reason.title} className="p-5">
+                <div className="flex items-start gap-4">
+                  <IconBadge>
+                    <reason.icon className="h-5 w-5" />
+                  </IconBadge>
+                  <div>
+                    <h3 className="font-heading text-lg font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+                      {reason.title}
+                    </h3>
+                    <p className="mt-1.5 text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
+                      {reason.description}
+                    </p>
+                  </div>
+                </div>
+              </SurfaceCard>
+            ))}
+          </div>
+        </FadeIn>
+      </div>
+    </PublicSection>
+  );
+}

--- a/src/components/academy/WhyEthicalLeadership.tsx
+++ b/src/components/academy/WhyEthicalLeadership.tsx
@@ -29,7 +29,7 @@ const reasons = [
 
 export default function WhyEthicalLeadership() {
   return (
-    <section className="bg-[#FCFAEF] py-16 dark:bg-[#1C1F1E] md:py-24">
+    <section className="overflow-x-hidden bg-[#FCFAEF] py-16 dark:bg-[#1C1F1E] md:py-24">
       <div className="container mx-auto px-4 sm:px-6">
         <FadeIn direction="up" className="mx-auto mb-10 max-w-3xl space-y-3 text-center sm:space-y-4">
           <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#0097b2] dark:text-[#66C4DC] sm:text-sm">

--- a/src/components/philosophy/PhilosophyHero.tsx
+++ b/src/components/philosophy/PhilosophyHero.tsx
@@ -1,6 +1,11 @@
 import Image from "@/components/common/Image";
-import { FadeIn, FadeInStagger, FadeInStaggerItem } from "@/components/animations";
-import { PublicCta, SectionEyebrow } from "@/components/shared/PublicPagePrimitives";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import {
+  FadeIn,
+  FadeInStagger,
+  FadeInStaggerItem,
+} from "@/components/animations";
 
 const philosophyStats = [
   {
@@ -17,72 +22,89 @@ const philosophyStats = [
   },
 ] as const;
 
+const ctaBaseClass =
+  "group inline-flex items-center justify-center gap-2 rounded-half px-8 py-6 h-auto text-base sm:text-lg font-medium transition-all duration-300 transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2";
+
 export default function PhilosophyHero() {
   return (
     <section
-      className="relative isolate overflow-hidden border-y border-[#0097b2]/15 bg-[#121514] text-[#FCFAEF]"
+      className="relative overflow-hidden bg-gradient-to-r from-[#0097b2] to-[#0F4C5C] py-16 sm:py-20 md:py-28"
       aria-labelledby="philosophy-hero-heading"
     >
-      <div className="absolute inset-0 -z-10">
-        <Image
-          src="/highlights/Akomapa-73.jpg"
-          alt=""
-          fill
-          priority
-          sizes="100vw"
-          className="object-cover opacity-50"
-          style={{ objectPosition: "center" }}
-        />
-        <div
-          aria-hidden="true"
-          className="absolute inset-0 bg-gradient-to-br from-[#0097b2]/88 via-[#0F4C5C]/90 to-[#121514]/96"
-        />
-        <div
-          aria-hidden="true"
-          className="absolute inset-0 bg-[radial-gradient(circle_at_18%_22%,rgba(238,186,43,0.18),transparent_30%),linear-gradient(90deg,rgba(18,21,20,0.2),rgba(18,21,20,0.86))]"
-        />
+      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+        <div className="absolute -top-24 right-0 h-64 w-64 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
+        <div className="absolute bottom-0 -left-24 h-96 w-96 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
+        <div className="absolute bottom-0 right-0 h-80 w-80 rounded-full bg-[#F5C94D]/10 blur-3xl" />
       </div>
 
-      <div className="container mx-auto grid min-h-[460px] max-w-7xl items-center gap-8 px-4 py-14 sm:py-18 lg:grid-cols-[minmax(0,1fr)_minmax(280px,420px)] lg:gap-16 lg:py-20">
-        <FadeIn className="max-w-5xl">
-          <SectionEyebrow tone="gold">Ethics, Partnership, Impact</SectionEyebrow>
-          <h1
-            id="philosophy-hero-heading"
-            className="mt-5 max-w-4xl font-heading text-5xl font-bold leading-tight text-[#FCFAEF] sm:text-6xl lg:text-7xl"
-          >
-            Our Philosophy
-          </h1>
-          <p className="mt-6 max-w-3xl font-body text-xl leading-9 text-[#FCFAEF]/88 md:text-2xl">
-            Building a different future for global health &mdash; one rooted in
-            ethics, partnership, and sustainable impact.
-          </p>
-          <div className="mt-9 flex flex-col gap-4 sm:flex-row">
-            <PublicCta href="/get-involved" variant="gold">
-              Join Us
-            </PublicCta>
-            <PublicCta href="/partnerships" variant="outline-light">
-              Partner With Us
-            </PublicCta>
-          </div>
-        </FadeIn>
+      <div className="container relative z-10 mx-auto px-4 sm:px-6">
+        <div className="flex flex-col gap-12 lg:flex-row lg:items-center lg:gap-16">
+          <FadeIn className="max-w-3xl flex-1">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#F5C94D] sm:text-sm">
+              Ethics, Partnership, Impact
+            </p>
+            <h1
+              id="philosophy-hero-heading"
+              className="mt-4 text-3xl font-light leading-tight text-[#FCFAEF] sm:text-4xl md:text-5xl lg:text-6xl xl:text-7xl"
+            >
+              Our Philosophy
+            </h1>
+            <p className="mt-6 max-w-2xl text-base leading-relaxed text-[#FCFAEF]/85 sm:text-lg md:text-xl">
+              Building a different future for global health &mdash; one rooted in
+              ethics, partnership, and sustainable impact.
+            </p>
 
-        <FadeInStagger
-          className="grid gap-3 sm:grid-cols-3 lg:grid-cols-1 lg:gap-4"
-          amount="some"
-        >
-          {philosophyStats.map((stat) => (
-            <FadeInStaggerItem key={stat.label}>
-              <div className="h-full rounded-xl border border-[#FCFAEF]/20 bg-[#121514]/44 p-4 shadow-[0_22px_70px_rgba(0,0,0,0.24)] backdrop-blur-md lg:p-5">
-                <p className="font-heading text-3xl font-bold leading-none text-[#F5C94D]">
-                  {stat.value}
-                </p>
-                <p className="mt-2 text-sm leading-6 text-[#FCFAEF]/78 sm:text-xs lg:text-sm">
-                  {stat.label}
-                </p>
+            <FadeInStagger
+              className="mt-8 grid grid-cols-1 gap-3 sm:grid-cols-3 sm:gap-4"
+              staggerDelay={0.1}
+            >
+              {philosophyStats.map((stat) => (
+                <FadeInStaggerItem key={stat.label} direction="up">
+                  <div className="rounded-xl border border-white/10 bg-white/5 p-3 sm:rounded-2xl sm:p-4">
+                    <p className="text-2xl font-semibold text-white sm:text-3xl">
+                      {stat.value}
+                    </p>
+                    <p className="mt-1 text-xs leading-snug text-white/70 sm:text-sm">
+                      {stat.label}
+                    </p>
+                  </div>
+                </FadeInStaggerItem>
+              ))}
+            </FadeInStagger>
+
+            <FadeIn direction="up" delay={0.3}>
+              <div className="mt-8 flex flex-wrap gap-3 sm:gap-4">
+                <Button
+                  asChild
+                  className={`${ctaBaseClass} bg-[#eeba2b] text-[#FCFAEF] shadow-lg hover:bg-[#eeba2b]/80 hover:shadow-xl focus-visible:ring-[#F5C94D]`}
+                >
+                  <Link href="/get-involved">Join Us</Link>
+                </Button>
+                <Button
+                  asChild
+                  className={`${ctaBaseClass} bg-[#0097b2] text-[#FCFAEF] shadow-lg hover:bg-[#0097b2]/80 hover:shadow-xl focus-visible:ring-[#8DD4E6]`}
+                >
+                  <Link href="/partnerships">Partner With Us</Link>
+                </Button>
               </div>
-            </FadeInStaggerItem>
-          ))}
-        </FadeInStagger>
+            </FadeIn>
+          </FadeIn>
+
+          <FadeIn direction="left" delay={0.2} className="w-full lg:max-w-md xl:max-w-lg">
+            <div className="relative h-[280px] w-full overflow-hidden rounded-3xl border border-white/10 shadow-2xl sm:h-[360px] md:h-[420px] lg:h-[480px]">
+              <Image
+                src="/highlights/Akomapa-73.jpg"
+                alt="Akomapa student leaders and community partners gathered together"
+                fill
+                priority
+                sizes="(min-width: 1024px) 40vw, 100vw"
+                className="object-cover"
+                style={{ objectPosition: "center" }}
+              />
+              <div className="absolute inset-0 bg-gradient-to-t from-black/35 via-transparent to-transparent" />
+            </div>
+          </FadeIn>
+        </div>
       </div>
     </section>
   );

--- a/src/components/philosophy/PhilosophySection.tsx
+++ b/src/components/philosophy/PhilosophySection.tsx
@@ -1,11 +1,6 @@
 import type { PhilosophySection as PhilosophySectionType } from "@/lib/types";
 import Image from "@/components/common/Image";
 import { FadeIn } from "@/components/animations";
-import {
-  MediaFrame,
-  PublicSection,
-  SectionEyebrow,
-} from "@/components/shared/PublicPagePrimitives";
 import { cn } from "@/lib/utils";
 
 type PhilosophySectionProps = {
@@ -14,8 +9,10 @@ type PhilosophySectionProps = {
   className?: string;
 };
 
-function getTone(index: number) {
-  return index % 2 === 0 ? "cream" : "white";
+function getSectionBg(index: number) {
+  return index % 2 === 0
+    ? "bg-[#FCFAEF] dark:bg-[#1C1F1E]"
+    : "bg-[#F4F1E8] dark:bg-[#1C1F1E]";
 }
 
 export default function PhilosophySection({
@@ -28,88 +25,95 @@ export default function PhilosophySection({
   const headingId = `${section.id}-heading`;
 
   return (
-    <PublicSection
+    <section
       id={section.id}
       aria-labelledby={headingId}
-      tone={getTone(index)}
-      spacing="normal"
-      withTexture={index % 3 === 0}
-      className={cn("scroll-mt-28 border-t border-[#0097b2]/10", className)}
-      containerClassName="max-w-7xl"
+      className={cn(
+        "relative isolate scroll-mt-28 overflow-hidden border-t border-[#0097b2]/10 py-16 dark:border-[#FCFAEF]/10 md:py-24",
+        getSectionBg(index),
+        className,
+      )}
     >
-      <div className="mx-auto grid max-w-6xl items-center justify-items-center gap-10 md:grid-cols-2 md:gap-12 lg:gap-16">
-        <FadeIn
-          direction={isImageFirstOnDesktop ? "right" : "left"}
-          amount="some"
-          className={cn(
-            "order-1 w-full",
-            isImageFirstOnDesktop ? "md:order-1" : "md:order-2",
-          )}
-        >
-          <MediaFrame className="mx-auto w-full max-w-xl" aspect="wide">
-            {section.image ? (
-              <Image
-                src={section.image}
-                alt={section.imageAlt ?? ""}
-                fill
-                sizes="(min-width: 1280px) 560px, (min-width: 768px) 45vw, 100vw"
-                className="object-cover"
-                style={{ objectPosition: section.imagePosition ?? "center" }}
-              />
-            ) : (
-              <div className="h-full w-full bg-[#0097b2]/12" aria-hidden="true" />
+      <div className="container mx-auto max-w-7xl px-4">
+        <div className="mx-auto grid max-w-6xl items-center justify-items-center gap-10 md:grid-cols-2 md:gap-12 lg:gap-16">
+          <FadeIn
+            direction={isImageFirstOnDesktop ? "right" : "left"}
+            amount="some"
+            className={cn(
+              "order-1 w-full",
+              isImageFirstOnDesktop ? "md:order-1" : "md:order-2",
             )}
-            <div
-              aria-hidden="true"
-              className="absolute inset-0 bg-gradient-to-t from-[#121514]/48 via-transparent to-transparent"
-            />
-          </MediaFrame>
-        </FadeIn>
-
-        <FadeIn
-          delay={0.08}
-          amount="some"
-          className={cn(
-            "order-2 w-full",
-            isImageFirstOnDesktop ? "md:order-2" : "md:order-1",
-          )}
-        >
-          <article className="mx-auto max-w-xl">
-            <SectionEyebrow>Principle {section.order}</SectionEyebrow>
-            <h2
-              id={headingId}
-              className="mt-4 font-heading text-3xl font-bold leading-tight text-[#1C1F1E] dark:text-[#FCFAEF] md:text-4xl lg:text-5xl"
-            >
-              {section.title}
-            </h2>
-            <div className="mt-6 space-y-5 font-body text-lg leading-8 text-[#2F3332]/82 dark:text-[#E6E7E7]/82">
-              {paragraphs.map((paragraph) => (
-                <p key={paragraph}>{paragraph}</p>
-              ))}
+          >
+            <div className="relative mx-auto h-[280px] w-full max-w-xl overflow-hidden rounded-3xl shadow-2xl sm:h-[340px] md:h-[400px]">
+              {section.image ? (
+                <Image
+                  src={section.image}
+                  alt={section.imageAlt ?? ""}
+                  fill
+                  sizes="(min-width: 1280px) 560px, (min-width: 768px) 45vw, 100vw"
+                  className="object-cover"
+                  style={{ objectPosition: section.imagePosition ?? "center" }}
+                />
+              ) : (
+                <div
+                  className="h-full w-full bg-[#0097b2]/12"
+                  aria-hidden="true"
+                />
+              )}
+              <div
+                aria-hidden="true"
+                className="absolute inset-0 bg-gradient-to-t from-black/25 via-transparent to-transparent"
+              />
             </div>
+          </FadeIn>
 
-            {section.quote ? (
-              <blockquote className="mt-8 border-l-4 border-[#eeba2b] pl-5">
-                <p className="relative font-heading text-2xl font-semibold leading-snug text-[#1C1F1E] dark:text-[#FCFAEF]">
-                  <span
-                    aria-hidden="true"
-                    className="absolute -left-4 -top-5 text-6xl leading-none text-[#eeba2b]/45"
-                  >
-                    &ldquo;
-                  </span>
-                  {section.quote.text}
-                </p>
-                <footer className="mt-4 font-body text-sm font-semibold uppercase tracking-[0.16em] text-[#0097b2] dark:text-[#66C4DC]">
-                  {section.quote.author}
-                  <span className="block pt-1 normal-case tracking-normal text-[#2F3332]/62 dark:text-[#FCFAEF]/62">
-                    {section.quote.role}
-                  </span>
-                </footer>
-              </blockquote>
-            ) : null}
-          </article>
-        </FadeIn>
+          <FadeIn
+            delay={0.08}
+            amount="some"
+            className={cn(
+              "order-2 w-full",
+              isImageFirstOnDesktop ? "md:order-2" : "md:order-1",
+            )}
+          >
+            <article className="mx-auto max-w-xl">
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#0097b2] dark:text-[#66C4DC] sm:text-sm">
+                Principle {section.order}
+              </p>
+              <h2
+                id={headingId}
+                className="mt-4 text-2xl font-bold leading-tight text-[#1C1F1E] dark:text-[#FCFAEF] sm:text-3xl md:text-4xl"
+              >
+                {section.title}
+              </h2>
+              <div className="mt-6 space-y-5 text-base leading-relaxed text-[#2F3332]/82 dark:text-[#E6E7E7]/82 sm:text-lg">
+                {paragraphs.map((paragraph) => (
+                  <p key={paragraph}>{paragraph}</p>
+                ))}
+              </div>
+
+              {section.quote ? (
+                <blockquote className="mt-8 border-l-4 border-[#eeba2b] pl-5">
+                  <p className="relative text-xl font-semibold leading-snug text-[#1C1F1E] dark:text-[#FCFAEF] sm:text-2xl">
+                    <span
+                      aria-hidden="true"
+                      className="absolute -left-4 -top-5 text-6xl leading-none text-[#eeba2b]/45"
+                    >
+                      &ldquo;
+                    </span>
+                    {section.quote.text}
+                  </p>
+                  <footer className="mt-4 text-sm font-semibold uppercase tracking-[0.16em] text-[#0097b2] dark:text-[#66C4DC]">
+                    {section.quote.author}
+                    <span className="block pt-1 normal-case tracking-normal text-[#2F3332]/62 dark:text-[#FCFAEF]/62">
+                      {section.quote.role}
+                    </span>
+                  </footer>
+                </blockquote>
+              ) : null}
+            </article>
+          </FadeIn>
+        </div>
       </div>
-    </PublicSection>
+    </section>
   );
 }

--- a/src/components/philosophy/PhilosophyVision.tsx
+++ b/src/components/philosophy/PhilosophyVision.tsx
@@ -1,37 +1,48 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
 import { FadeIn } from "@/components/animations";
-import {
-  PublicCta,
-  PublicSection,
-  SectionEyebrow,
-} from "@/components/shared/PublicPagePrimitives";
+
+const ctaBaseClass =
+  "group inline-flex items-center justify-center gap-2 rounded-half px-8 py-6 h-auto text-base sm:text-lg font-medium transition-all duration-300 transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2";
 
 export default function PhilosophyVision() {
   return (
-    <PublicSection
-      tone="teal"
-      spacing="spacious"
-      className="border-t border-[#FCFAEF]/15"
-      containerClassName="max-w-5xl"
-    >
-      <FadeIn className="text-center">
-        <SectionEyebrow tone="gold">Our Vision For Global Health</SectionEyebrow>
-        <h2 className="mx-auto mt-4 max-w-4xl font-heading text-4xl font-bold leading-tight text-[#FCFAEF] md:text-5xl lg:text-6xl">
-          Transform how global health is taught, practiced, and led.
-        </h2>
-        <p className="mx-auto mt-6 max-w-3xl font-body text-lg leading-8 text-[#FCFAEF]/84 md:text-xl">
-          Akomapa is building a movement where students, faculty, health
-          professionals, and communities learn together, lead ethically, and
-          strengthen systems that last beyond any single project.
-        </p>
-        <div className="mt-9 flex flex-col justify-center gap-4 sm:flex-row">
-          <PublicCta href="/get-involved" variant="gold">
-            Join Us
-          </PublicCta>
-          <PublicCta href="/partnerships" variant="outline-light">
-            Partner With Us
-          </PublicCta>
-        </div>
-      </FadeIn>
-    </PublicSection>
+    <section className="relative overflow-hidden border-t border-[#FCFAEF]/15 bg-gradient-to-r from-[#0097b2] to-[#0F4C5C] py-20 text-[#FCFAEF] md:py-28">
+      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+        <div className="absolute -top-24 right-12 h-64 w-64 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
+        <div className="absolute bottom-0 -left-16 h-80 w-80 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
+        <div className="absolute top-1/2 left-1/2 h-96 w-96 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[#F5C94D]/8 blur-3xl" />
+      </div>
+
+      <div className="container relative z-10 mx-auto max-w-5xl px-4 sm:px-6">
+        <FadeIn className="text-center">
+          <p className="text-sm font-semibold uppercase tracking-[0.25em] text-[#F5C94D]">
+            Our Vision For Global Health
+          </p>
+          <h2 className="mx-auto mt-4 max-w-4xl text-3xl font-bold leading-tight sm:text-4xl md:text-5xl">
+            Transform how global health is taught, practiced, and led.
+          </h2>
+          <p className="mx-auto mt-6 max-w-3xl text-base leading-relaxed text-[#FCFAEF]/85 sm:text-lg md:text-xl">
+            Akomapa is building a movement where students, faculty, health
+            professionals, and communities learn together, lead ethically, and
+            strengthen systems that last beyond any single project.
+          </p>
+          <div className="mt-10 flex flex-col justify-center gap-3 sm:flex-row sm:gap-4">
+            <Button
+              asChild
+              className={`${ctaBaseClass} bg-[#eeba2b] text-[#FCFAEF] shadow-lg hover:bg-[#eeba2b]/80 hover:shadow-xl focus-visible:ring-[#F5C94D]`}
+            >
+              <Link href="/get-involved">Join Us</Link>
+            </Button>
+            <Button
+              asChild
+              className={`${ctaBaseClass} bg-[#0097b2] text-[#FCFAEF] shadow-lg hover:bg-[#0097b2]/80 hover:shadow-xl focus-visible:ring-[#8DD4E6]`}
+            >
+              <Link href="/partnerships">Partner With Us</Link>
+            </Button>
+          </div>
+        </FadeIn>
+      </div>
+    </section>
   );
 }

--- a/src/data/team.ts
+++ b/src/data/team.ts
@@ -338,7 +338,7 @@ export const teamMembers: TeamMember[] = [
     name: "Dr. Derek Anamaale Tuoyire",
     title: "Head of Community Medicine - University of Cape Coast",
     bio: "Dr. Derek Anamaale Tuoyire serves on our Advisory Board, bringing his expertise in community medicine from the University of Cape Coast to guide our community health initiatives.",
-    image: "/images/team/derek-anamaale-tuoyire.jpg",
+    image: "/images/team/dr-tuoyire.jpeg",
     socialLinks: {
       linkedin: "https://ca.linkedin.com/in/derek-anamaale-tuoyire-phd-mph-72823887",
       email: "#"
@@ -374,7 +374,7 @@ export const teamMembers: TeamMember[] = [
     name: "Dr. Jeremy Schwartz",
     title: "Head of Chronic Care Access Lab - Yale University",
     bio: "Dr. Jeremy Schwartz serves on our Advisory Board, providing expertise in chronic care access and healthcare delivery from his position at Yale University.",
-    image: "/images/team/jeremy-schwartz.jpg",
+    image: "/images/team/jeremy-schwartz.jpeg",
     socialLinks: {
       linkedin: "https://www.linkedin.com/in/jeremy-schwartz-ba7ab056",
       email: "#"
@@ -386,7 +386,7 @@ export const teamMembers: TeamMember[] = [
     name: "Dr. Adrian Mayo",
     title: "Assistant Clinical Professor - David Geffen School of Medicine, UCLA",
     bio: "Dr. Adrian Mayo serves on our Advisory Board, bringing clinical expertise and research insights from his position at the David Geffen School of Medicine at UCLA.",
-    image: "/images/team/adrian-mayo.jpg",
+    image: "/images/team/placeholder.jpg",
     socialLinks: {
       linkedin: "https://www.linkedin.com/in/adrian-mayo-936790193",
       email: "#"


### PR DESCRIPTION
### Summary
Built the full Akomapa Academy page at /academy — replacing the RebrandPageShell shell with a comprehensive, flagship 7-section page
Designed to match the site-wide visual consistency (teal gradient + cream alternation) seen on the Team page, UCC Clinic page, and other established pages — no dark/black backgrounds
Components Created (src/components/academy/)
AcademyHero — Teal gradient hero with decorative blurred circles, image card, stat badges (10-16 weeks, 8 modules, 4 faculty), and dual CTAs
WhyEthicalLeadership — Cream section with image + 3 cards (The Gap, Why Ethics Matter, Akomapa Difference) using accent-colored icon badges
CurriculumSection — Teal gradient section with interactive accordion for all 8 modules; expanded items show learning objectives, faculty names, and duration pills
FacultyGrid — Cream section with responsive 4-column card grid matching the Team page card pattern (image, institution, name, title, specialties, social links)
CertificationSection — Teal gradient section with image + certification requirements checklist and "Apply Now" CTA
AcademyTestimonials — Cream section with auto-playing carousel, dot pagination, prev/next navigation, prefers-reduced-motion support
ApplySection — Bold teal gradient CTA section with oversized "Apply to the Academy" button
Section Tone Rhythm
teal (hero) → cream (why) → teal (curriculum) → cream (faculty) → teal (certification) → cream (testimonials) → teal (apply)

### File Modified
src/app/(main)/academy/page.tsx — Replaced RebrandPageShell with full section composition following the Philosophy page pattern
Key Design Decisions
Used teal gradient (from-[#0097b2] to-[#0F4C5C]) + cream (#FCFAEF) alternation — consistent with Team page, UCC Clinic, and other pages
Decorative blurred circles for depth (matching UCC Clinic hero)
Rounded card and image patterns matching Team page cards (rounded-[28px], hover lift)
CTA button styling matches site-wide pattern (rounded-half, hover:scale-105)
All data sourced from src/data/academy.ts, application links from src/config/links.ts
Acceptance Criteria
 Page accessible at /academy with correct metadata
 Hero section with headline, stats, description, and CTAs
 "Why Ethical Leadership" section with 3 explanatory cards
 Curriculum accordion with all 8 modules (objectives, faculty, duration)
 Faculty grid with photos, titles, institutions, specialties, social links
 Certificate section with requirements and "Apply Now" CTA
 Testimonials carousel with auto-play and navigation
 Apply section with prominent CTA and application link
 Fully responsive (mobile, tablet, desktop)
 Dark mode compatible
 Scroll animations (FadeIn/FadeInStagger)
 Breadcrumb: Home > Academy
 Visual consistency with existing pages (no dark/black backgrounds)
 All checks pass (ESLint, TypeScript, build)
### Test Plan
 Visit /academy — all 7 sections render correctly
 Test responsive at 375px, 768px, 1440px
 Toggle dark mode — sections adapt correctly
 Click "Become a Scholar" — opens Google Form in new tab
 Click "Explore Curriculum" — scrolls to curriculum section
 Expand/collapse accordion modules — smooth animation
 Testimonials carousel auto-plays, pauses on hover
 Faculty images load via ImageKit
 Breadcrumb shows Home > Academy
 Compare visual consistency with /about/team and /clinics/akomapa-ucc

Close #111 