### PR TITLE
[Rebrand] Rewrite Clinics pages as Community Learning & Care Hubs (#118)

### DIFF
--- a/e2e/community-hubs.spec.ts
+++ b/e2e/community-hubs.spec.ts
@@ -1,0 +1,168 @@
+import { expect, test, type Page } from "@playwright/test";
+import { announcementCampaign } from "../src/data/announcements";
+import {
+  communityHubs,
+  communityHubsListing,
+  getHubHref,
+  hubActivities,
+  hubMissions,
+  hubBreadcrumbLabels,
+  hubRouteSlugs,
+} from "../src/data/community-hubs";
+
+async function preparePage(page: Page, theme?: "light" | "dark") {
+  await page.addInitScript(
+    ({ announcementVersion, storedTheme }) => {
+      localStorage.setItem(
+        "akomapa-announcements-dismissed",
+        announcementVersion,
+      );
+
+      if (storedTheme) {
+        localStorage.setItem("akomapa-theme", storedTheme);
+        document.documentElement.classList.remove("light", "dark");
+        document.documentElement.classList.add(storedTheme);
+      }
+    },
+    {
+      announcementVersion: announcementCampaign.version,
+      storedTheme: theme ?? null,
+    },
+  );
+}
+
+async function hasHorizontalOverflow(page: Page) {
+  return page.evaluate(
+    () => document.documentElement.scrollWidth - window.innerWidth > 1,
+  );
+}
+
+test.describe("Community Health Hubs listing page", () => {
+  test.beforeEach(async ({ page }) => {
+    await preparePage(page);
+  });
+
+  test("renders metadata, hero, missions, activities, hub cards, and value props", async ({
+    page,
+  }) => {
+    await page.goto("/community-hubs", { waitUntil: "domcontentloaded" });
+
+    await expect(page).toHaveTitle(/Community Health Hubs/);
+    await expect(page.locator("[data-rebrand-page]")).toBeVisible();
+
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: communityHubsListing.headline,
+        exact: true,
+      }),
+    ).toHaveCount(1);
+
+    await expect(page.getByText(communityHubsListing.subheadline)).toBeVisible();
+
+    for (const mission of hubMissions) {
+      await expect(
+        page.locator("#five-missions").getByRole("heading", {
+          level: 3,
+          name: mission.title,
+          exact: true,
+        }),
+      ).toBeVisible();
+    }
+
+    for (const activity of hubActivities) {
+      await expect(
+        page.locator("#hub-activities").getByRole("heading", {
+          level: 3,
+          name: activity.title,
+          exact: true,
+        }),
+      ).toBeVisible();
+    }
+
+    const hubCardsSection = page.locator("#our-hubs");
+    for (const hub of communityHubs) {
+      await expect(
+        hubCardsSection.getByRole("link", { name: new RegExp(hub.name) }),
+      ).toHaveAttribute("href", getHubHref(hub));
+    }
+
+    await expect(
+      page.getByRole("navigation").filter({ hasText: "Community Health Hubs" }).first(),
+    ).toBeVisible();
+
+    expect(await hasHorizontalOverflow(page)).toBe(false);
+  });
+
+  test("does not contain student-run clinic language", async ({ page }) => {
+    await page.goto("/community-hubs", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByText(/student-run clinic/i)).toHaveCount(0);
+    await expect(page.getByText(/Student-powered clinics/i)).toHaveCount(0);
+  });
+
+  test("remains readable in dark mode", async ({ page }) => {
+    await preparePage(page, "dark");
+    await page.goto("/community-hubs", { waitUntil: "domcontentloaded" });
+
+    await expect(page.locator("html")).toHaveClass(/dark/);
+    await expect(
+      page.getByRole("heading", { name: communityHubsListing.headline, level: 1 }),
+    ).toBeVisible();
+
+    expect(await hasHorizontalOverflow(page)).toBe(false);
+  });
+});
+
+for (const routeSlug of hubRouteSlugs) {
+  test.describe(`Community hub detail page /community-hubs/${routeSlug}`, () => {
+    test.beforeEach(async ({ page }) => {
+      await preparePage(page);
+    });
+
+    test("renders hero, metrics, mentorship, and placeholder sections", async ({
+      page,
+    }) => {
+      const hub = communityHubs.find(({ routeSlug: slug }) => slug === routeSlug)!;
+
+      await page.goto(`/community-hubs/${routeSlug}`, {
+        waitUntil: "domcontentloaded",
+      });
+
+      await expect(page.locator("[data-rebrand-page]")).toBeVisible();
+      await expect(
+        page.getByRole("heading", { level: 1, name: hub.name, exact: true }),
+      ).toBeVisible();
+
+      await expect(page.getByText("Community members served")).toBeVisible();
+      await expect(page.getByText("Students trained")).toBeVisible();
+      await expect(page.getByText("Communities reached")).toBeVisible();
+      await expect(page.getByText("Partners engaged")).toBeVisible();
+
+      await expect(page.getByText(hub.facultyMentorship!.model)).toBeVisible();
+
+      await expect(page.getByText(/Community stories are coming soon/i)).toBeVisible();
+      await expect(page.getByText(/Student stories are coming soon/i)).toBeVisible();
+      await expect(page.getByText(/Research updates are coming soon/i)).toBeVisible();
+      await expect(page.getByText(/Innovation updates are coming soon/i)).toBeVisible();
+
+      await expect(
+        page.getByRole("navigation").filter({ hasText: hubBreadcrumbLabels[routeSlug] }).first(),
+      ).toBeVisible();
+
+      expect(await hasHorizontalOverflow(page)).toBe(false);
+    });
+  });
+}
+
+test.describe("Clinics redirects", () => {
+  test("redirects legacy clinic routes to community hubs", async ({ page }) => {
+    await preparePage(page);
+
+    await page.goto("/clinics", { waitUntil: "domcontentloaded" });
+    await expect(page).toHaveURL(/\/community-hubs$/);
+
+    await page.goto("/clinics/akomapa-ucc", { waitUntil: "domcontentloaded" });
+    await expect(page).toHaveURL(/\/community-hubs\/ucc$/);
+  });
+});

--- a/e2e/rebrand-foundation.spec.ts
+++ b/e2e/rebrand-foundation.spec.ts
@@ -28,7 +28,7 @@ const destinationRoutes = [
   { path: "/ncd-impact", heading: "NCD Impact" },
   { path: "/partnerships", heading: "Equitable Partnerships" },
   { path: "/impact", heading: "Our Impact" },
-  { path: "/community-hubs", heading: "Community Health Hubs" },
+  { path: "/community-hubs", heading: "Student-Powered Community Health Hubs" },
   { path: "/get-involved", heading: "Get Involved" },
 ] as const;
 

--- a/src/app/(main)/community-hubs/nhp/page.tsx
+++ b/src/app/(main)/community-hubs/nhp/page.tsx
@@ -1,37 +1,22 @@
 import type { Metadata } from "next";
-import RebrandPageShell from "@/components/shared/RebrandPageShell";
+import Breadcrumb from "@/components/layout/Breadcrumb";
+import CommunityHubDetailPage from "@/components/community-hubs/CommunityHubDetailPage";
+import { getHubByRouteSlug } from "@/data/community-hubs";
+
+const hub = getHubByRouteSlug("nhp");
 
 export const metadata: Metadata = {
-  title: "Akomapa NHP Yale Community Health Hub",
-  description:
-    "Learn about the Akomapa NHP Yale Community Health Hub — a global partnership for prevention, screening, referral, and health learning.",
+  title: hub.name,
+  description: hub.description,
 };
 
-const highlights = [
-  {
-    title: "Global Partnership",
-    description:
-      "A collaboration with Yale's New Haven Program bridging global health education with community-centered care.",
-  },
-  {
-    title: "Community Health",
-    description:
-      "Delivering NCD prevention, screening, and health education through equitable, community-driven approaches.",
-  },
-  {
-    title: "Student Development",
-    description:
-      "Creating opportunities for students to develop ethical leadership skills through cross-cultural health partnerships.",
-  },
-] as const;
-
-export default function NHPYaleHubPage() {
+export default function NHPHubPage() {
   return (
-    <RebrandPageShell
-      eyebrow="Community Health Hub"
-      title="Akomapa NHP Yale Hub"
-      description="The Akomapa NHP Yale Community Health Hub connects students and faculty across institutions to address health inequities through ethical, community-centered practice and global collaboration."
-      highlights={highlights}
-    />
+    <div data-rebrand-page className="bg-background text-foreground">
+      <div className="container mx-auto">
+        <Breadcrumb />
+      </div>
+      <CommunityHubDetailPage hub={hub} />
+    </div>
   );
 }

--- a/src/app/(main)/community-hubs/page.tsx
+++ b/src/app/(main)/community-hubs/page.tsx
@@ -1,37 +1,28 @@
 import type { Metadata } from "next";
-import RebrandPageShell from "@/components/shared/RebrandPageShell";
+import Breadcrumb from "@/components/layout/Breadcrumb";
+import FiveMissions from "@/components/community-hubs/FiveMissions";
+import HubActivities from "@/components/community-hubs/HubActivities";
+import HubCardGrid from "@/components/community-hubs/HubCardGrid";
+import HubsHero from "@/components/community-hubs/HubsHero";
+import WhyHubsMatter from "@/components/community-hubs/WhyHubsMatter";
+import { communityHubsListing } from "@/data/community-hubs";
 
 export const metadata: Metadata = {
-  title: "Community Health Hubs",
-  description:
-    "Learn about Akomapa's community health hubs and their role in locally led prevention, screening, referral, and health learning.",
+  title: communityHubsListing.metadata.title,
+  description: communityHubsListing.metadata.description,
 };
-
-const highlights = [
-  {
-    title: "Locally Led",
-    description:
-      "Each hub is shaped with community partners who understand local priorities, strengths, and barriers to care.",
-  },
-  {
-    title: "Connected Services",
-    description:
-      "Prevention, screening, education, referral, and follow-up are designed as connected parts of a stronger care journey.",
-  },
-  {
-    title: "Learning Platform",
-    description:
-      "Hubs create responsible opportunities for leadership development, community research, and practical innovation.",
-  },
-] as const;
 
 export default function CommunityHubsPage() {
   return (
-    <RebrandPageShell
-      eyebrow="Care Close to Home"
-      title="Community Health Hubs"
-      description="Community health hubs bring prevention, education, screening, referral support, and collaborative learning closer to the people they are designed to serve."
-      highlights={highlights}
-    />
+    <div data-rebrand-page className="bg-background text-foreground">
+      <div className="container mx-auto">
+        <Breadcrumb />
+      </div>
+      <HubsHero />
+      <FiveMissions />
+      <HubActivities />
+      <HubCardGrid />
+      <WhyHubsMatter />
+    </div>
   );
 }

--- a/src/app/(main)/community-hubs/ucc/page.tsx
+++ b/src/app/(main)/community-hubs/ucc/page.tsx
@@ -1,37 +1,22 @@
 import type { Metadata } from "next";
-import RebrandPageShell from "@/components/shared/RebrandPageShell";
+import Breadcrumb from "@/components/layout/Breadcrumb";
+import CommunityHubDetailPage from "@/components/community-hubs/CommunityHubDetailPage";
+import { getHubByRouteSlug } from "@/data/community-hubs";
+
+const hub = getHubByRouteSlug("ucc");
 
 export const metadata: Metadata = {
-  title: "Akomapa UCC Community Health Hub",
-  description:
-    "Learn about the Akomapa UCC Community Health Hub at the University of Cape Coast — locally led prevention, screening, referral, and health learning.",
+  title: hub.name,
+  description: hub.description,
 };
-
-const highlights = [
-  {
-    title: "University Partnership",
-    description:
-      "Working alongside the University of Cape Coast to develop ethical health leaders through community-centered practice.",
-  },
-  {
-    title: "Community Health",
-    description:
-      "Addressing the NCD epidemic through prevention, screening, education, and referral in partnership with local communities.",
-  },
-  {
-    title: "Student Development",
-    description:
-      "Providing students with hands-on experience in ethical, community-driven healthcare delivery and leadership.",
-  },
-] as const;
 
 export default function UCCHubPage() {
   return (
-    <RebrandPageShell
-      eyebrow="Community Health Hub"
-      title="Akomapa UCC Hub"
-      description="The Akomapa UCC Community Health Hub at the University of Cape Coast brings together students, faculty, and community partners to improve access to care while developing future health leaders."
-      highlights={highlights}
-    />
+    <div data-rebrand-page className="bg-background text-foreground">
+      <div className="container mx-auto">
+        <Breadcrumb />
+      </div>
+      <CommunityHubDetailPage hub={hub} />
+    </div>
   );
 }

--- a/src/app/(main)/community-hubs/ug/page.tsx
+++ b/src/app/(main)/community-hubs/ug/page.tsx
@@ -1,37 +1,22 @@
 import type { Metadata } from "next";
-import RebrandPageShell from "@/components/shared/RebrandPageShell";
+import Breadcrumb from "@/components/layout/Breadcrumb";
+import CommunityHubDetailPage from "@/components/community-hubs/CommunityHubDetailPage";
+import { getHubByRouteSlug } from "@/data/community-hubs";
+
+const hub = getHubByRouteSlug("ug");
 
 export const metadata: Metadata = {
-  title: "Akomapa UG Community Health Hub",
-  description:
-    "Learn about the Akomapa UG Community Health Hub at the University of Ghana — locally led prevention, screening, referral, and health learning.",
+  title: hub.name,
+  description: hub.description,
 };
-
-const highlights = [
-  {
-    title: "University Partnership",
-    description:
-      "Collaborating with the University of Ghana to strengthen community health outcomes and develop ethical health leaders.",
-  },
-  {
-    title: "Community Health",
-    description:
-      "Tackling non-communicable diseases through integrated prevention, screening, and referral services in local communities.",
-  },
-  {
-    title: "Student Development",
-    description:
-      "Equipping students with leadership skills and practical experience in community-centered healthcare.",
-  },
-] as const;
 
 export default function UGHubPage() {
   return (
-    <RebrandPageShell
-      eyebrow="Community Health Hub"
-      title="Akomapa UG Hub"
-      description="The Akomapa UG Community Health Hub at the University of Ghana partners with students, faculty, and communities to deliver care and develop the next generation of ethical health leaders."
-      highlights={highlights}
-    />
+    <div data-rebrand-page className="bg-background text-foreground">
+      <div className="container mx-auto">
+        <Breadcrumb />
+      </div>
+      <CommunityHubDetailPage hub={hub} />
+    </div>
   );
 }

--- a/src/components/community-hubs/CommunityHubDetailPage.tsx
+++ b/src/components/community-hubs/CommunityHubDetailPage.tsx
@@ -1,0 +1,36 @@
+import HubDetailHero from "@/components/community-hubs/HubDetailHero";
+import HubInnovation from "@/components/community-hubs/HubInnovation";
+import HubMetrics from "@/components/community-hubs/HubMetrics";
+import HubResearch from "@/components/community-hubs/HubResearch";
+import MentorshipSection from "@/components/community-hubs/MentorshipSection";
+import StoriesSection from "@/components/community-hubs/StoriesSection";
+import { hubEmptyStates } from "@/data/community-hubs";
+import type { CommunityHub } from "@/lib/types";
+
+type CommunityHubDetailPageProps = {
+  hub: CommunityHub;
+};
+
+export default function CommunityHubDetailPage({ hub }: CommunityHubDetailPageProps) {
+  return (
+    <>
+      <HubDetailHero hub={hub} />
+      <HubMetrics hub={hub} />
+      <StoriesSection
+        title="Community Stories"
+        stories={hub.communityStories}
+        emptyState={hubEmptyStates.communityStories}
+        sectionId="community-stories"
+      />
+      <StoriesSection
+        title="Student Stories"
+        stories={hub.studentStories}
+        emptyState={hubEmptyStates.studentStories}
+        sectionId="student-stories"
+      />
+      <MentorshipSection mentorship={hub.facultyMentorship} />
+      <HubResearch items={hub.research} emptyState={hubEmptyStates.research} />
+      <HubInnovation items={hub.innovations} emptyState={hubEmptyStates.innovation} />
+    </>
+  );
+}

--- a/src/components/community-hubs/FiveMissions.tsx
+++ b/src/components/community-hubs/FiveMissions.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import {
+  FlaskConical,
+  GraduationCap,
+  Handshake,
+  Heart,
+  Lightbulb,
+  type LucideIcon,
+} from "lucide-react";
+import { FadeIn, FadeInStagger, FadeInStaggerItem } from "@/components/animations";
+import {
+  IconBadge,
+  PublicSection,
+  PublicSectionHeader,
+} from "@/components/shared/PublicPagePrimitives";
+import { hubMissions } from "@/data/community-hubs";
+
+const missionIcons: LucideIcon[] = [
+  Heart,
+  GraduationCap,
+  Handshake,
+  FlaskConical,
+  Lightbulb,
+];
+
+export default function FiveMissions() {
+  return (
+    <PublicSection tone="cream" spacing="normal" withTexture id="five-missions">
+      <FadeIn>
+        <PublicSectionHeader
+          eyebrow="Every Hub, Five Missions"
+          title="What Our Hubs Are Built to Do"
+          description="Each Community Learning & Care Hub is a platform for healthcare delivery, leadership development, partnership, research, and innovation."
+          titleId="five-missions-heading"
+        />
+      </FadeIn>
+
+      <FadeInStagger className="mt-12 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+        {hubMissions.map((mission, index) => {
+          const Icon = missionIcons[index] ?? Heart;
+
+          return (
+            <FadeInStaggerItem key={mission.id} direction="up">
+              <div className="flex h-full flex-col items-center rounded-xl border border-[#E6E7E7] bg-white/88 p-6 text-center shadow-sm dark:border-[#2F3332] dark:bg-[#2F3332]/70">
+                <IconBadge className="h-12 w-12">
+                  <Icon className="h-5 w-5" aria-hidden="true" />
+                </IconBadge>
+                <p className="mt-4 text-sm font-semibold uppercase tracking-wide text-[#0097b2] dark:text-[#66C4DC]">
+                  {String(mission.id).padStart(2, "0")}
+                </p>
+                <h3 className="mt-2 text-lg font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+                  {mission.title}
+                </h3>
+                <p className="mt-2 text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
+                  {mission.description}
+                </p>
+              </div>
+            </FadeInStaggerItem>
+          );
+        })}
+      </FadeInStagger>
+    </PublicSection>
+  );
+}

--- a/src/components/community-hubs/HubActivities.tsx
+++ b/src/components/community-hubs/HubActivities.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import {
+  ArrowRightLeft,
+  BookOpen,
+  FlaskConical,
+  GraduationCap,
+  HeartHandshake,
+  Lightbulb,
+  Stethoscope,
+  Users,
+  type LucideIcon,
+} from "lucide-react";
+import { FadeIn, FadeInStagger, FadeInStaggerItem } from "@/components/animations";
+import {
+  IconBadge,
+  PublicSection,
+  PublicSectionHeader,
+  SurfaceCard,
+} from "@/components/shared/PublicPagePrimitives";
+import { hubActivities, type HubActivityIcon } from "@/data/community-hubs";
+
+const activityIconMap: Record<HubActivityIcon, LucideIcon> = {
+  Stethoscope,
+  ArrowRightLeft,
+  BookOpen,
+  Users,
+  GraduationCap,
+  HeartHandshake,
+  FlaskConical,
+  Lightbulb,
+};
+
+export default function HubActivities() {
+  return (
+    <PublicSection tone="white" spacing="normal" id="hub-activities">
+      <FadeIn>
+        <PublicSectionHeader
+          eyebrow="What Happens at Each Hub"
+          title="Learning, Care, and Partnership in Action"
+          description="From screening and education to mentorship and innovation pilots, hub activity connects community priorities with student leadership development."
+          titleId="hub-activities-heading"
+        />
+      </FadeIn>
+
+      <FadeInStagger className="mt-12 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
+        {hubActivities.map((activity) => {
+          const Icon = activityIconMap[activity.icon];
+
+          return (
+            <FadeInStaggerItem key={activity.id} direction="up">
+              <SurfaceCard className="h-full p-6">
+                <IconBadge>
+                  <Icon className="h-5 w-5" aria-hidden="true" />
+                </IconBadge>
+                <h3 className="mt-4 text-lg font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+                  {activity.title}
+                </h3>
+                <p className="mt-2 text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
+                  {activity.description}
+                </p>
+              </SurfaceCard>
+            </FadeInStaggerItem>
+          );
+        })}
+      </FadeInStagger>
+    </PublicSection>
+  );
+}

--- a/src/components/community-hubs/HubCard.tsx
+++ b/src/components/community-hubs/HubCard.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowRight, MapPin } from "lucide-react";
+import type { CSSProperties } from "react";
+import Image from "@/components/common/Image";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { CommunityHub } from "@/lib/types";
+import { getHubHref } from "@/data/community-hubs";
+
+const statusLabels = {
+  active: "Active",
+  "in-development": "In development",
+  planned: "Planned",
+} as const;
+
+type HubCardProps = {
+  hub: CommunityHub;
+};
+
+export default function HubCard({ hub }: HubCardProps) {
+  const href = getHubHref(hub);
+
+  return (
+    <article className="h-full">
+      <Card
+        data-testid="community-hub-card"
+        data-hub-id={hub.id}
+        data-accent-color={hub.color}
+        className="homepage-hover-card h-full gap-0 overflow-hidden rounded-xl border-x border-b border-t-4 border-[#E6E7E7] bg-white py-0 text-[#1C1F1E] shadow-sm dark:border-[#2F3332] dark:bg-[#1C1F1E] dark:text-[#FCFAEF] dark:shadow-lg"
+        style={
+          {
+            borderTopColor: hub.color,
+            "--homepage-hover-border-color": hub.color,
+          } as CSSProperties
+        }
+      >
+        <div className="relative aspect-[16/10] overflow-hidden">
+          <Image
+            src={hub.image}
+            alt={`${hub.name} in ${hub.location}`}
+            fill
+            sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
+            className="object-cover transition-transform duration-500 motion-safe:hover:scale-[1.03]"
+          />
+          <div
+            aria-hidden="true"
+            className="absolute inset-0 bg-gradient-to-t from-[#121514]/55 via-transparent to-transparent"
+          />
+          <span className="absolute right-4 top-4 rounded-full bg-[#FCFAEF]/95 px-3 py-1 text-xs font-bold text-[#1C1F1E] shadow-sm">
+            {statusLabels[hub.status]}
+          </span>
+        </div>
+
+        <CardHeader className="px-6 pb-4 pt-6">
+          <CardTitle>
+            <h3 className="text-2xl leading-tight text-[#1C1F1E] dark:text-[#FCFAEF]">
+              {hub.name}
+            </h3>
+          </CardTitle>
+          <div className="mt-3 flex items-start gap-2 text-sm font-medium text-[#0097b2] dark:text-[#66C4DC]">
+            <MapPin className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+            <span>
+              {hub.location}, {hub.country}
+            </span>
+          </div>
+        </CardHeader>
+
+        <CardContent className="flex flex-1 flex-col px-6 pb-6">
+          <CardDescription className="flex-1 text-base leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]">
+            {hub.description}
+          </CardDescription>
+
+          <dl className="mt-4 grid grid-cols-2 gap-3 text-sm">
+            <div>
+              <dt className="text-[#2F3332]/60 dark:text-[#E6E7E7]/60">Served</dt>
+              <dd className="font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+                {hub.metrics.patientsServed.toLocaleString()}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-[#2F3332]/60 dark:text-[#E6E7E7]/60">Students</dt>
+              <dd className="font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+                {hub.metrics.studentsTrained.toLocaleString()}
+              </dd>
+            </div>
+          </dl>
+
+          <Button
+            asChild
+            variant="link"
+            className="mt-6 h-auto w-fit justify-start p-0 text-base font-bold text-[#0097b2] hover:text-[#eeba2b] dark:text-[#66C4DC] dark:hover:text-[#F5C94D]"
+          >
+            <Link href={href} aria-label={`Learn more about ${hub.name}`}>
+              Learn More
+              <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
+            </Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </article>
+  );
+}

--- a/src/components/community-hubs/HubCardGrid.tsx
+++ b/src/components/community-hubs/HubCardGrid.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { FadeIn, FadeInStagger, FadeInStaggerItem } from "@/components/animations";
+import { PublicSection, PublicSectionHeader } from "@/components/shared/PublicPagePrimitives";
+import { communityHubs } from "@/data/community-hubs";
+import HubCard from "@/components/community-hubs/HubCard";
+
+export default function HubCardGrid() {
+  return (
+    <PublicSection tone="cream" spacing="normal" withTexture id="our-hubs">
+      <FadeIn>
+        <PublicSectionHeader
+          eyebrow="Our Hubs"
+          title="Three Platforms, One Movement"
+          description="Explore Akomapa's active and in-development community health hubs across Ghana and the United States."
+          titleId="our-hubs-heading"
+        />
+      </FadeIn>
+
+      <FadeInStagger className="mt-12 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {communityHubs.map((hub) => (
+          <FadeInStaggerItem key={hub.id} direction="up" className="h-full">
+            <HubCard hub={hub} />
+          </FadeInStaggerItem>
+        ))}
+      </FadeInStagger>
+    </PublicSection>
+  );
+}

--- a/src/components/community-hubs/HubDetailHero.tsx
+++ b/src/components/community-hubs/HubDetailHero.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import Image from "@/components/common/Image";
+import { MapPin } from "lucide-react";
+import { FadeIn } from "@/components/animations";
+import type { CommunityHub } from "@/lib/types";
+
+const statusLabels = {
+  active: "Active",
+  "in-development": "In development",
+  planned: "Planned",
+} as const;
+
+type HubDetailHeroProps = {
+  hub: CommunityHub;
+};
+
+export default function HubDetailHero({ hub }: HubDetailHeroProps) {
+  return (
+    <section
+      className="relative overflow-hidden py-16 sm:py-20 md:py-24"
+      style={{
+        background: `linear-gradient(135deg, ${hub.color} 0%, #0F4C5C 100%)`,
+      }}
+      aria-labelledby="hub-detail-hero-heading"
+    >
+      <div className="container relative z-10 mx-auto px-4 sm:px-6">
+        <div className="grid items-center gap-10 lg:grid-cols-12 lg:gap-14">
+          <FadeIn className="lg:col-span-7">
+            <span className="inline-flex rounded-full bg-[#FCFAEF]/15 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-[#FCFAEF]">
+              {statusLabels[hub.status]}
+            </span>
+            <h1
+              id="hub-detail-hero-heading"
+              className="mt-4 text-3xl font-light leading-tight text-[#FCFAEF] sm:text-4xl md:text-5xl lg:text-6xl"
+            >
+              {hub.name}
+            </h1>
+            <div className="mt-4 flex items-start gap-2 text-[#FCFAEF]/85">
+              <MapPin className="mt-1 h-5 w-5 shrink-0" aria-hidden="true" />
+              <p className="text-base sm:text-lg">
+                {hub.location}, {hub.country}
+              </p>
+            </div>
+            <p className="mt-6 max-w-2xl text-base leading-relaxed text-[#FCFAEF]/85 sm:text-lg">
+              {hub.description}
+            </p>
+          </FadeIn>
+
+          <FadeIn direction="left" delay={0.2} className="lg:col-span-5">
+            <div className="relative aspect-[4/3] overflow-hidden rounded-3xl border border-white/10 shadow-2xl">
+              <Image
+                src={hub.image}
+                alt={`${hub.name} community health hub`}
+                fill
+                priority
+                sizes="(min-width: 1024px) 42vw, 100vw"
+                className="object-cover"
+              />
+              <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-transparent" />
+            </div>
+          </FadeIn>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/community-hubs/HubInnovation.tsx
+++ b/src/components/community-hubs/HubInnovation.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { FadeIn, FadeInStagger, FadeInStaggerItem } from "@/components/animations";
+import {
+  PublicSection,
+  PublicSectionHeader,
+  PublicCta,
+  SurfaceCard,
+} from "@/components/shared/PublicPagePrimitives";
+import type { InnovationItem } from "@/lib/types";
+
+type EmptyState = {
+  title: string;
+  description: string;
+  cta: { label: string; href: string };
+};
+
+const categoryLabels: Record<InnovationItem["category"], string> = {
+  nkwapa: "Nkwapa EMR",
+  "quality-improvement": "Quality Improvement",
+  technology: "Technology Pilot",
+};
+
+type HubInnovationProps = {
+  items?: InnovationItem[];
+  emptyState: EmptyState;
+};
+
+export default function HubInnovation({ items = [], emptyState }: HubInnovationProps) {
+  const hasItems = items.length > 0;
+
+  return (
+    <PublicSection tone="cream" spacing="normal" withTexture id="hub-innovation">
+      <FadeIn>
+        <PublicSectionHeader
+          eyebrow="Innovation"
+          title="Testing What Works in Community Settings"
+          titleId="hub-innovation-heading"
+        />
+      </FadeIn>
+
+      {hasItems ? (
+        <FadeInStagger className="mt-12 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {items.map((item) => (
+            <FadeInStaggerItem key={item.id} direction="up">
+              <SurfaceCard className="h-full p-6">
+                <p className="text-xs font-semibold uppercase tracking-wide text-[#0097b2] dark:text-[#66C4DC]">
+                  {categoryLabels[item.category]}
+                </p>
+                <h3 className="mt-2 text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+                  {item.title}
+                </h3>
+                <p className="mt-3 text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
+                  {item.description}
+                </p>
+              </SurfaceCard>
+            </FadeInStaggerItem>
+          ))}
+        </FadeInStagger>
+      ) : (
+        <FadeIn className="mt-12">
+          <SurfaceCard className="mx-auto max-w-3xl p-8 text-center">
+            <h3 className="text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+              {emptyState.title}
+            </h3>
+            <p className="mt-3 text-base leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
+              {emptyState.description}
+            </p>
+            <PublicCta href={emptyState.cta.href} variant="teal" className="mt-6">
+              {emptyState.cta.label}
+            </PublicCta>
+          </SurfaceCard>
+        </FadeIn>
+      )}
+    </PublicSection>
+  );
+}

--- a/src/components/community-hubs/HubMetrics.tsx
+++ b/src/components/community-hubs/HubMetrics.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { FadeIn, FadeInStagger, FadeInStaggerItem } from "@/components/animations";
+import { AnimatedMetric } from "@/components/motion/AnimatedMetric";
+import { PublicSection, PublicSectionHeader, SurfaceCard } from "@/components/shared/PublicPagePrimitives";
+import type { CommunityHub } from "@/lib/types";
+
+const metricConfig = [
+  { key: "patientsServed" as const, label: "Community members served" },
+  { key: "studentsTrained" as const, label: "Students trained" },
+  { key: "communitiesReached" as const, label: "Communities reached" },
+  { key: "partnersEngaged" as const, label: "Partners engaged" },
+];
+
+type HubMetricsProps = {
+  hub: CommunityHub;
+};
+
+export default function HubMetrics({ hub }: HubMetricsProps) {
+  return (
+    <PublicSection tone="cream" spacing="normal" withTexture id="hub-metrics">
+      <FadeIn>
+        <PublicSectionHeader
+          eyebrow="Impact at a Glance"
+          title="Hub Metrics"
+          description={
+            hub.status === "in-development"
+              ? "This hub is in development. Metrics will grow as programs launch and community partnerships expand."
+              : "Key indicators of community reach, student leadership development, and partnership engagement at this hub."
+          }
+          titleId="hub-metrics-heading"
+        />
+      </FadeIn>
+
+      <FadeInStagger className="mt-12 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
+        {metricConfig.map(({ key, label }) => (
+          <FadeInStaggerItem key={key} direction="up">
+            <SurfaceCard className="p-6 text-center">
+              <p
+                className="text-3xl font-bold sm:text-4xl"
+                style={{ color: hub.color }}
+              >
+                <AnimatedMetric value={hub.metrics[key]} />
+              </p>
+              <p className="mt-2 text-sm font-medium text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
+                {label}
+              </p>
+            </SurfaceCard>
+          </FadeInStaggerItem>
+        ))}
+      </FadeInStagger>
+    </PublicSection>
+  );
+}

--- a/src/components/community-hubs/HubResearch.tsx
+++ b/src/components/community-hubs/HubResearch.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import Link from "next/link";
+import { FadeIn, FadeInStagger, FadeInStaggerItem } from "@/components/animations";
+import {
+  PublicSection,
+  PublicSectionHeader,
+  PublicCta,
+  SurfaceCard,
+} from "@/components/shared/PublicPagePrimitives";
+import type { ResearchItem } from "@/lib/types";
+
+type EmptyState = {
+  title: string;
+  description: string;
+  cta: { label: string; href: string };
+};
+
+type HubResearchProps = {
+  items?: ResearchItem[];
+  emptyState: EmptyState;
+};
+
+export default function HubResearch({ items = [], emptyState }: HubResearchProps) {
+  const hasItems = items.length > 0;
+
+  return (
+    <PublicSection tone="white" spacing="normal" id="hub-research">
+      <FadeIn>
+        <PublicSectionHeader
+          eyebrow="Research"
+          title="Evidence From the Community"
+          titleId="hub-research-heading"
+        />
+      </FadeIn>
+
+      {hasItems ? (
+        <FadeInStagger className="mt-12 grid gap-6 md:grid-cols-2">
+          {items.map((item) => (
+            <FadeInStaggerItem key={item.id} direction="up">
+              <SurfaceCard className="h-full p-6">
+                <p className="text-xs font-semibold uppercase tracking-wide text-[#0097b2] dark:text-[#66C4DC]">
+                  {item.status}
+                </p>
+                <h3 className="mt-2 text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+                  {item.title}
+                </h3>
+                <p className="mt-3 text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
+                  {item.description}
+                </p>
+                {item.link ? (
+                  <Link
+                    href={item.link}
+                    className="mt-4 inline-flex text-sm font-semibold text-[#0097b2] hover:text-[#eeba2b] dark:text-[#66C4DC]"
+                  >
+                    Read more
+                  </Link>
+                ) : null}
+              </SurfaceCard>
+            </FadeInStaggerItem>
+          ))}
+        </FadeInStagger>
+      ) : (
+        <FadeIn className="mt-12">
+          <SurfaceCard className="mx-auto max-w-3xl p-8 text-center">
+            <h3 className="text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+              {emptyState.title}
+            </h3>
+            <p className="mt-3 text-base leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
+              {emptyState.description}
+            </p>
+            <PublicCta href={emptyState.cta.href} variant="teal" className="mt-6">
+              {emptyState.cta.label}
+            </PublicCta>
+          </SurfaceCard>
+        </FadeIn>
+      )}
+    </PublicSection>
+  );
+}

--- a/src/components/community-hubs/HubsHero.tsx
+++ b/src/components/community-hubs/HubsHero.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import Image from "@/components/common/Image";
+import { FadeIn } from "@/components/animations";
+import { communityHubsListing } from "@/data/community-hubs";
+
+export default function HubsHero() {
+  return (
+    <section
+      className="relative overflow-hidden bg-gradient-to-r from-[#0097b2] to-[#0F4C5C] py-16 sm:py-20 md:py-28"
+      aria-labelledby="community-hubs-hero-heading"
+    >
+      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+        <div className="absolute -top-24 right-0 h-64 w-64 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
+        <div className="absolute bottom-0 -left-24 h-96 w-96 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
+      </div>
+
+      <div className="container relative z-10 mx-auto px-4 sm:px-6">
+        <div className="flex flex-col gap-12 lg:flex-row lg:items-center lg:gap-16">
+          <FadeIn className="max-w-3xl flex-1">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#F5C94D] sm:text-sm">
+              Community Learning & Care
+            </p>
+            <h1
+              id="community-hubs-hero-heading"
+              className="mt-4 text-3xl font-light leading-tight text-[#FCFAEF] sm:text-4xl md:text-5xl lg:text-6xl xl:text-7xl"
+            >
+              {communityHubsListing.headline}
+            </h1>
+            <p className="mt-6 max-w-2xl text-base leading-relaxed text-[#FCFAEF]/85 sm:text-lg md:text-xl">
+              {communityHubsListing.subheadline}
+            </p>
+          </FadeIn>
+
+          <FadeIn direction="left" delay={0.2} className="w-full lg:max-w-md xl:max-w-lg">
+            <div className="relative h-[280px] w-full overflow-hidden rounded-3xl border border-white/10 shadow-2xl sm:h-[360px] md:h-[420px] lg:h-[480px]">
+              <Image
+                src="/highlights/Akomapa-62.jpg"
+                alt="Akomapa community health hub volunteers serving community members"
+                fill
+                priority
+                sizes="(min-width: 1024px) 40vw, 100vw"
+                className="object-cover"
+              />
+              <div className="absolute inset-0 bg-gradient-to-t from-black/35 via-transparent to-transparent" />
+            </div>
+          </FadeIn>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/community-hubs/MentorshipSection.tsx
+++ b/src/components/community-hubs/MentorshipSection.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import Image from "@/components/common/Image";
+import { FadeIn, FadeInStagger, FadeInStaggerItem } from "@/components/animations";
+import {
+  PublicSection,
+  PublicSectionHeader,
+  SurfaceCard,
+} from "@/components/shared/PublicPagePrimitives";
+import type { MentorshipInfo } from "@/lib/types";
+import { getTeamMemberBySlug } from "@/data/team";
+
+type MentorshipSectionProps = {
+  mentorship?: MentorshipInfo;
+};
+
+export default function MentorshipSection({ mentorship }: MentorshipSectionProps) {
+  if (!mentorship) {
+    return null;
+  }
+
+  const mentors = mentorship.mentors
+    .map((slug) => getTeamMemberBySlug(slug))
+    .filter((member) => member !== undefined);
+
+  return (
+    <PublicSection tone="cream" spacing="normal" withTexture id="faculty-mentorship">
+      <FadeIn>
+        <PublicSectionHeader
+          eyebrow="Faculty Mentorship"
+          title="Expert Supervision, Ethical Practice"
+          description={mentorship.model}
+          titleId="faculty-mentorship-heading"
+        />
+      </FadeIn>
+
+      {mentors.length > 0 ? (
+        <FadeInStagger className="mt-12 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {mentors.map((mentor) => (
+            <FadeInStaggerItem key={mentor.slug ?? mentor.id} direction="up">
+              <SurfaceCard className="h-full overflow-hidden">
+                <div className="relative aspect-[4/3] w-full">
+                  <Image
+                    src={mentor.image}
+                    alt={mentor.name}
+                    fill
+                    sizes="(min-width: 1024px) 33vw, 100vw"
+                    className="object-cover"
+                  />
+                </div>
+                <div className="p-6">
+                  <h3 className="text-lg font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+                    {mentor.name}
+                  </h3>
+                  <p className="mt-1 text-sm font-medium text-[#0097b2] dark:text-[#66C4DC]">
+                    {mentor.title}
+                  </p>
+                  <p className="mt-3 text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
+                    {mentor.bio}
+                  </p>
+                </div>
+              </SurfaceCard>
+            </FadeInStaggerItem>
+          ))}
+        </FadeInStagger>
+      ) : null}
+    </PublicSection>
+  );
+}

--- a/src/components/community-hubs/StoriesSection.tsx
+++ b/src/components/community-hubs/StoriesSection.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { FadeIn, FadeInStagger, FadeInStaggerItem } from "@/components/animations";
+import {
+  PublicSection,
+  PublicSectionHeader,
+  PublicCta,
+  SurfaceCard,
+} from "@/components/shared/PublicPagePrimitives";
+import type { Story } from "@/lib/types";
+
+type EmptyState = {
+  title: string;
+  description: string;
+  cta: { label: string; href: string };
+};
+
+type StoriesSectionProps = {
+  title: string;
+  stories?: Story[];
+  emptyState: EmptyState;
+  sectionId: string;
+};
+
+export default function StoriesSection({
+  title,
+  stories = [],
+  emptyState,
+  sectionId,
+}: StoriesSectionProps) {
+  const hasStories = stories.length > 0;
+
+  return (
+    <PublicSection tone="white" spacing="normal" id={sectionId}>
+      <FadeIn>
+        <PublicSectionHeader title={title} titleId={`${sectionId}-heading`} />
+      </FadeIn>
+
+      {hasStories ? (
+        <FadeInStagger className="mt-12 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {stories.map((story) => (
+            <FadeInStaggerItem key={story.id} direction="up">
+              <SurfaceCard className="h-full p-6">
+                <p className="text-xs font-semibold uppercase tracking-wide text-[#0097b2] dark:text-[#66C4DC]">
+                  {story.role}
+                </p>
+                <h3 className="mt-2 text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+                  {story.title}
+                </h3>
+                <p className="mt-3 text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
+                  {story.excerpt}
+                </p>
+                <p className="mt-4 text-sm font-medium text-[#2F3332] dark:text-[#E6E7E7]">
+                  — {story.author}
+                </p>
+              </SurfaceCard>
+            </FadeInStaggerItem>
+          ))}
+        </FadeInStagger>
+      ) : (
+        <FadeIn className="mt-12">
+          <SurfaceCard className="mx-auto max-w-3xl p-8 text-center">
+            <h3 className="text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+              {emptyState.title}
+            </h3>
+            <p className="mt-3 text-base leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
+              {emptyState.description}
+            </p>
+            <PublicCta href={emptyState.cta.href} variant="teal" className="mt-6">
+              {emptyState.cta.label}
+            </PublicCta>
+          </SurfaceCard>
+        </FadeIn>
+      )}
+    </PublicSection>
+  );
+}

--- a/src/components/community-hubs/WhyHubsMatter.tsx
+++ b/src/components/community-hubs/WhyHubsMatter.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { FadeIn, FadeInStagger, FadeInStaggerItem } from "@/components/animations";
+import {
+  PublicSection,
+  PublicSectionHeader,
+  SurfaceCard,
+} from "@/components/shared/PublicPagePrimitives";
+import { whyHubsMatter } from "@/data/community-hubs";
+
+export default function WhyHubsMatter() {
+  return (
+    <PublicSection tone="teal" spacing="normal" id="why-hubs-matter">
+      <FadeIn>
+        <PublicSectionHeader
+          eyebrow="Why Our Hubs Matter"
+          title="More Than a Place to Receive Care"
+          description="Our hubs strengthen communities, develop ethical leaders, generate evidence, and pilot innovations that can scale."
+          titleId="why-hubs-matter-heading"
+          eyebrowTone="gold"
+          titleClassName="text-[#FCFAEF]"
+          descriptionClassName="text-[#FCFAEF]/85"
+        />
+      </FadeIn>
+
+      <FadeInStagger className="mt-12 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+        {whyHubsMatter.map((item) => (
+          <FadeInStaggerItem key={item.id} direction="up">
+            <SurfaceCard className="h-full border-[#FCFAEF]/15 bg-[#FCFAEF]/10 p-6 text-[#FCFAEF] backdrop-blur-sm">
+              <h3 className="text-lg font-semibold">{item.title}</h3>
+              <p className="mt-3 text-sm leading-relaxed text-[#FCFAEF]/85">
+                {item.description}
+              </p>
+            </SurfaceCard>
+          </FadeInStaggerItem>
+        ))}
+      </FadeInStagger>
+    </PublicSection>
+  );
+}

--- a/src/components/layout/Breadcrumb.tsx
+++ b/src/components/layout/Breadcrumb.tsx
@@ -4,6 +4,8 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { ChevronRight, Home } from "lucide-react";
 import { Suspense } from "react";
+import { hubBreadcrumbLabels } from "@/data/community-hubs";
+import type { HubRouteSlug } from "@/lib/types";
 
 function BreadcrumbContent() {
   const pathname = usePathname();
@@ -46,6 +48,14 @@ function BreadcrumbContent() {
     const label = (() => {
       if (segmentLabels[segment]) {
         return segmentLabels[segment];
+      }
+
+      if (
+        parentSegment === "community-hubs" &&
+        index === 1 &&
+        segment in hubBreadcrumbLabels
+      ) {
+        return hubBreadcrumbLabels[segment as HubRouteSlug];
       }
 
       if (

--- a/src/data/__tests__/rebrand-data.test.ts
+++ b/src/data/__tests__/rebrand-data.test.ts
@@ -8,7 +8,13 @@ import {
   academyOverview,
   academyTestimonials,
 } from "@/data/academy";
-import { communityHubs, hubMissions } from "@/data/community-hubs";
+import {
+  communityHubs,
+  getHubHref,
+  hubActivities,
+  hubMissions,
+  whyHubsMatter,
+} from "@/data/community-hubs";
 import {
   academyPreviewContent,
   communityHubsPreviewContent,
@@ -87,6 +93,8 @@ describe("rebrand content data", () => {
 
   it("keeps hub missions, statuses, metrics, and map locations consistent", () => {
     expect(communityHubs).toHaveLength(3);
+    expect(hubActivities).toHaveLength(8);
+    expect(whyHubsMatter).toHaveLength(5);
     expect(hubMissions.map(({ title }) => title)).toEqual([
       "Improve Community Health",
       "Develop Future Leaders",
@@ -102,6 +110,8 @@ describe("rebrand content data", () => {
 
     for (const hub of communityHubs) {
       expect(hub.missions).toHaveLength(5);
+      expect(hub.routeSlug).toMatch(/^(ucc|ug|nhp)$/);
+      expect(getHubHref(hub)).toBe(`/community-hubs/${hub.routeSlug}`);
       expect(Object.values(hub.metrics).every((value) => value >= 0)).toBe(true);
       expect(Array.isArray(hub.communityStories)).toBe(true);
       expect(Array.isArray(hub.studentStories)).toBe(true);

--- a/src/data/community-hubs.ts
+++ b/src/data/community-hubs.ts
@@ -1,4 +1,8 @@
-import type { CommunityHub, HubMission } from "@/lib/types";
+import type {
+  CommunityHub,
+  HubMission,
+  HubRouteSlug,
+} from "@/lib/types";
 
 export const hubMissions: HubMission[] = [
   {
@@ -33,10 +37,160 @@ export const hubMissions: HubMission[] = [
   },
 ];
 
+export const communityHubsListing = {
+  headline: "Student-Powered Community Health Hubs",
+  subheadline:
+    "Akomapa's Community Learning & Care Hubs bring together students, faculty, health professionals, and communities to improve access to care while developing the next generation of ethical health leaders.",
+  metadata: {
+    title: "Community Health Hubs | Akomapa",
+    description:
+      "Explore Akomapa's student-powered community health hubs — platforms for healthcare delivery, leadership development, partnership, research, and innovation.",
+  },
+} as const;
+
+export type HubActivityIcon =
+  | "Stethoscope"
+  | "ArrowRightLeft"
+  | "BookOpen"
+  | "Users"
+  | "GraduationCap"
+  | "HeartHandshake"
+  | "FlaskConical"
+  | "Lightbulb";
+
+export const hubActivities: ReadonlyArray<{
+  id: string;
+  title: string;
+  description: string;
+  icon: HubActivityIcon;
+}> = [
+  {
+    id: "screening",
+    title: "Health Screening",
+    description:
+      "Community-based prevention and early detection for NCDs and related health risks.",
+    icon: "Stethoscope",
+  },
+  {
+    id: "referrals",
+    title: "Clinical Referrals",
+    description:
+      "Pathways connecting community members to follow-up care and trusted local services.",
+    icon: "ArrowRightLeft",
+  },
+  {
+    id: "education",
+    title: "Health Education",
+    description:
+      "Workshops and outreach that build health literacy in schools, workplaces, and neighborhoods.",
+    icon: "BookOpen",
+  },
+  {
+    id: "engagement",
+    title: "Community Engagement",
+    description:
+      "Listening sessions, co-design, and ongoing partnership with local leaders and residents.",
+    icon: "Users",
+  },
+  {
+    id: "leadership",
+    title: "Leadership Training",
+    description:
+      "Structured opportunities for students to practice ethical, community-centered leadership.",
+    icon: "GraduationCap",
+  },
+  {
+    id: "mentorship",
+    title: "Student Mentorship",
+    description:
+      "Faculty and clinician mentors guiding students through supervised service and reflection.",
+    icon: "HeartHandshake",
+  },
+  {
+    id: "research",
+    title: "Research Activities",
+    description:
+      "Student-led and community-based studies that turn local learning into actionable evidence.",
+    icon: "FlaskConical",
+  },
+  {
+    id: "innovation",
+    title: "Innovation Pilots",
+    description:
+      "Testing digital tools, quality improvement, and new care models in real community settings.",
+    icon: "Lightbulb",
+  },
+];
+
+export const whyHubsMatter: ReadonlyArray<{
+  id: string;
+  title: string;
+  description: string;
+}> = [
+  {
+    id: "access",
+    title: "Healthcare Access",
+    description:
+      "Hubs bring prevention, screening, education, and referral support closer to the communities that need them most.",
+  },
+  {
+    id: "leadership",
+    title: "Leadership Development",
+    description:
+      "Students gain supervised experience practicing ethical, interprofessional leadership alongside communities.",
+  },
+  {
+    id: "partnership",
+    title: "Community Partnership",
+    description:
+      "Programs are co-designed with local leaders so services reflect community priorities and strengths.",
+  },
+  {
+    id: "research",
+    title: "Research",
+    description:
+      "Hub activity generates evidence that strengthens programs, partnerships, and health-system practice.",
+  },
+  {
+    id: "systems",
+    title: "Health Systems Strengthening",
+    description:
+      "Innovation pilots and referral networks help build more connected, responsive local health systems.",
+  },
+];
+
+export const hubEmptyStates = {
+  communityStories: {
+    title: "Community stories are coming soon",
+    description:
+      "We are gathering stories from patients, community leaders, and partners at this hub.",
+    cta: { label: "Share your story", href: "/contact" },
+  },
+  studentStories: {
+    title: "Student stories are coming soon",
+    description:
+      "Leadership journeys and reflections from students at this hub will be shared here.",
+    cta: { label: "Get involved", href: "/get-involved" },
+  },
+  research: {
+    title: "Research updates are coming soon",
+    description:
+      "Student-led and community-based research from this hub will be published here as it becomes available.",
+    cta: { label: "Explore our research", href: "/research" },
+  },
+  innovation: {
+    title: "Innovation updates are coming soon",
+    description:
+      "Technology pilots, quality improvement work, and other innovations tested at this hub will appear here.",
+    cta: { label: "Learn about Nkwapa", href: "/research" },
+  },
+} as const;
+
 export const communityHubs: CommunityHub[] = [
   {
     id: "ucc-hub",
     slug: "akomapa-ucc",
+    routeSlug: "ucc",
     name: "Akomapa–UCC Community Health Hub",
     location: "Abeadze Dominase and Abura, Central Region",
     country: "Ghana",
@@ -65,6 +219,7 @@ export const communityHubs: CommunityHub[] = [
   {
     id: "ug-hub",
     slug: "akomapa-ug",
+    routeSlug: "ug",
     name: "Akomapa–UG Community Health Hub",
     location: "Greater Accra Region",
     country: "Ghana",
@@ -93,6 +248,7 @@ export const communityHubs: CommunityHub[] = [
   {
     id: "nhp-yale-hub",
     slug: "akomapa-nhp",
+    routeSlug: "nhp",
     name: "Akomapa–NHP Yale Community Health Hub",
     location: "New Haven, Connecticut",
     country: "United States",
@@ -119,3 +275,34 @@ export const communityHubs: CommunityHub[] = [
     innovations: [],
   },
 ];
+
+export function getHubHref(hubOrId: CommunityHub | string): string {
+  const hub =
+    typeof hubOrId === "string"
+      ? communityHubs.find(({ id }) => id === hubOrId)
+      : hubOrId;
+
+  if (!hub) {
+    throw new Error(`Unknown community hub "${hubOrId}".`);
+  }
+
+  return `/community-hubs/${hub.routeSlug}`;
+}
+
+export function getHubByRouteSlug(slug: HubRouteSlug): CommunityHub {
+  const hub = communityHubs.find(({ routeSlug }) => routeSlug === slug);
+
+  if (!hub) {
+    throw new Error(`Unknown community hub route "${slug}".`);
+  }
+
+  return hub;
+}
+
+export const hubRouteSlugs = ["ucc", "ug", "nhp"] as const satisfies readonly HubRouteSlug[];
+
+export const hubBreadcrumbLabels: Record<HubRouteSlug, string> = {
+  ucc: "Akomapa–UCC Community Health Hub",
+  ug: "Akomapa–UG Community Health Hub",
+  nhp: "Akomapa–NHP Yale Community Health Hub",
+};

--- a/src/data/homepage-narrative.ts
+++ b/src/data/homepage-narrative.ts
@@ -1,5 +1,5 @@
 import { academyOverview } from "@/data/academy";
-import { communityHubs } from "@/data/community-hubs";
+import { communityHubs, getHubHref } from "@/data/community-hubs";
 
 export type NcdNarrativeMetric = {
   id: string;
@@ -92,21 +92,8 @@ export const academyPreviewContent = {
   },
 } as const;
 
-const communityHubRoutes = {
-  "ucc-hub": "/community-hubs/ucc",
-  "ug-hub": "/community-hubs/ug",
-  "nhp-yale-hub": "/community-hubs/nhp",
-} as const;
-
 function getCommunityHubRoute(hubId: string) {
-  const href =
-    communityHubRoutes[hubId as keyof typeof communityHubRoutes];
-
-  if (!href) {
-    throw new Error(`Missing homepage route for community hub "${hubId}".`);
-  }
-
-  return href;
+  return getHubHref(hubId);
 }
 
 export const communityHubsPreviewContent = {

--- a/src/data/ncd-impact.ts
+++ b/src/data/ncd-impact.ts
@@ -295,6 +295,6 @@ export const ncdFutureVisionContent = {
     })) satisfies FutureTarget[],
   ctas: [
     { label: "Join the Fight Against NCDs", href: "/get-involved", variant: "amber" as const },
-    { label: "Learn About Our Hubs", href: "/clinics", variant: "teal" as const },
+    { label: "Learn About Our Hubs", href: "/community-hubs", variant: "teal" as const },
   ],
 } as const;

--- a/src/data/team.ts
+++ b/src/data/team.ts
@@ -16,6 +16,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "2",
+    slug: "esi-berkoh",
     roleCategory: "executive",
     name: "Esi Bon Berkoh",
     title: "Co-founder and Vice President",
@@ -334,6 +335,7 @@ export const teamMembers: TeamMember[] = [
   // Advisory Board Members
   {
     id: "28",
+    slug: "derek-tuoyire",
     roleCategory: "advisor",
     name: "Dr. Derek Anamaale Tuoyire",
     title: "Head of Community Medicine - University of Cape Coast",
@@ -346,6 +348,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "29",
+    slug: "martins-ekor",
     roleCategory: "advisor",
     name: "Prof. Martins Ekor",
     title: "Provost, College of Health and Allied Sciences, University of Cape Coast",
@@ -370,6 +373,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "31",
+    slug: "jeremy-schwartz",
     roleCategory: "advisor",
     name: "Dr. Jeremy Schwartz",
     title: "Head of Chronic Care Access Lab - Yale University",
@@ -406,6 +410,7 @@ export const teamMembers: TeamMember[] = [
   },
   {
     id: "34",
+    slug: "alfred-yawson",
     roleCategory: "advisor",
     name: "Prof. Alfred Yawson",
     title: "Provost, University of Ghana College of Health Sciences",
@@ -428,4 +433,33 @@ export const teamMembers: TeamMember[] = [
       email: "#"
     }
   },
+  {
+    id: "36",
+    slug: "patrick-ampofo",
+    roleCategory: "advisor",
+    name: "Dr. Patrick Ampofo",
+    title: "UG Expansion Lead, Akomapa Health",
+    bio: "Dr. Patrick Ampofo leads the strategy and partnerships guiding Akomapa's University of Ghana hub development, bridging evidence-based approaches with community-based interventions.",
+    image: "/images/team/patrick-ampofo.jpg",
+    socialLinks: {
+      linkedin: "https://linkedin.com/in/patrick-ampofo",
+      email: "#"
+    }
+  },
+  {
+    id: "37",
+    slug: "stacy-uchendu",
+    roleCategory: "community-leader",
+    name: "Stacy Uchendu",
+    title: "Co-Director, Neighborhood Health Project",
+    bio: "Stacy Uchendu co-directs the Neighborhood Health Project, facilitating community partnerships and sustainable care delivery at the Akomapa–NHP Yale hub.",
+    image: "/images/team/placeholder.jpg",
+    socialLinks: {
+      email: "#"
+    }
+  },
 ];
+
+export function getTeamMemberBySlug(slug: string): TeamMember | undefined {
+  return teamMembers.find((member) => member.slug === slug);
+}

--- a/src/lib/__tests__/types.test.ts
+++ b/src/lib/__tests__/types.test.ts
@@ -122,6 +122,7 @@ describe("rebrand data model contracts", () => {
     const hub: CommunityHub = {
       id: "hub-ucc",
       slug: "ucc",
+      routeSlug: "ucc",
       name: "Akomapa UCC Community Hub",
       location: "Cape Coast",
       country: "Ghana",
@@ -285,8 +286,8 @@ describe("rebrand data model contracts", () => {
     expect(roleCounts).toEqual({
       executive: 15,
       faculty: 0,
-      advisor: 8,
-      "community-leader": 12,
+      advisor: 9,
+      "community-leader": 13,
       "government-leader": 0,
       "partner-institution": 0,
     });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -42,6 +42,7 @@ export interface News {
 
 export interface TeamMember {
   id: string;
+  slug?: string;
   name: string;
   title: string;
   bio: string;
@@ -117,9 +118,12 @@ export interface FacultyMember {
   };
 }
 
+export type HubRouteSlug = "ucc" | "ug" | "nhp";
+
 export interface CommunityHub {
   id: string;
   slug: string;
+  routeSlug: HubRouteSlug;
   name: string;
   location: string;
   country: string;


### PR DESCRIPTION
## Summary
- Rewrites `/community-hubs` listing page with hero, five missions, eight activities, hub cards, and value proposition sections
- Replaces UCC, UG, and NHP shell pages with full detail pages (hero, metrics, stories placeholders, mentorship, research, innovation)
- Adds shared `src/components/community-hubs/*` components wired to `community-hubs.ts` and mentor lookup via `team.ts`
- Adds E2E coverage and updates rebrand foundation heading expectation

## Test plan
- [ ] Visit `/community-hubs` — verify hero, missions, activities, hub cards, why hubs matter
- [ ] Visit `/community-hubs/ucc`, `/ug`, `/nhp` — verify metrics, mentorship, placeholder sections
- [ ] Confirm `/clinics` and `/clinics/akomapa-ucc` redirect correctly
- [ ] `npm run lint && npm run typecheck && npm run test`
- [ ] `npm run test:e2e -- e2e/community-hubs.spec.ts`

Closes #118