### PR TITLE
Rebrand/build thought leadership blog page

### DIFF
--- a/src/app/(main)/blog/[slug]/page.tsx
+++ b/src/app/(main)/blog/[slug]/page.tsx
@@ -1,46 +1,67 @@
 import type { Metadata } from "next";
-import RebrandPageShell from "@/components/shared/RebrandPageShell";
+import { notFound } from "next/navigation";
+import { BlogPost } from "@/components/blog";
+import {
+  blogPosts,
+  getBlogPostBySlug,
+  getRelatedPosts,
+} from "@/data/blog";
+import { getAnnouncementPosterSrc } from "@/lib/video-utils";
 
-export const metadata: Metadata = {
-  title: "Blog Post - Akomapa Health",
-  description:
-    "Read this article from the Akomapa thought leadership blog on ethical global health and community-driven care.",
-};
-
-const highlights = [
-  {
-    title: "Ethical Leadership",
-    description:
-      "Developing leaders who approach global health with humility, accountability, and respect for community expertise.",
-  },
-  {
-    title: "Community Partnership",
-    description:
-      "Building equitable relationships where communities guide the priorities, methods, and measures of success.",
-  },
-  {
-    title: "Sustainable Impact",
-    description:
-      "Creating lasting change through long-term commitment, local ownership, and evidence-based practice.",
-  },
-] as const;
-
-export default async function BlogPostPage({
-  params,
-}: {
+interface BlogPostPageProps {
   params: Promise<{ slug: string }>;
-}) {
+}
+
+export function generateStaticParams() {
+  return blogPosts.map((post) => ({ slug: post.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: BlogPostPageProps): Promise<Metadata> {
   const { slug } = await params;
+  const post = getBlogPostBySlug(slug);
+
+  if (!post) {
+    return { title: "Article Not Found" };
+  }
+
+  const image = getAnnouncementPosterSrc({
+    image: post.image,
+    videoUrl: post.videoUrl,
+  });
+
+  return {
+    title: post.title,
+    description: post.excerpt,
+    openGraph: {
+      title: post.title,
+      description: post.excerpt,
+      type: "article",
+      publishedTime: post.date,
+      authors: [post.author],
+      ...(image ? { images: [{ url: image }] } : {}),
+    },
+  };
+}
+
+export default async function BlogPostPage({ params }: BlogPostPageProps) {
+  const { slug } = await params;
+  const post = getBlogPostBySlug(slug);
+
+  if (!post) {
+    notFound();
+  }
+
+  const related = getRelatedPosts(post.slug, post.category);
+  const hasMoreByAuthor =
+    blogPosts.filter((p) => p.author === post.author).length > 1;
 
   return (
-    <RebrandPageShell
-      eyebrow="Blog"
-      title={slug
-        .split("-")
-        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-        .join(" ")}
-      description="This article is coming soon. Check back for the full post."
-      highlights={highlights}
+    <BlogPost
+      post={post}
+      related={related}
+      hasMoreByAuthor={hasMoreByAuthor}
     />
   );
 }

--- a/src/app/(main)/blog/page.tsx
+++ b/src/app/(main)/blog/page.tsx
@@ -1,37 +1,27 @@
 import type { Metadata } from "next";
-import RebrandPageShell from "@/components/shared/RebrandPageShell";
+import { BlogListing } from "@/components/blog/BlogListing";
 
 export const metadata: Metadata = {
   title: "Thought Leadership",
   description:
     "Student essays, faculty reflections, and community voices on ethical global health leadership and community-driven care.",
+  openGraph: {
+    title: "Thought Leadership | Akomapa",
+    description:
+      "Student essays, faculty reflections, and community voices on ethical global health, community partnership, and the future of care.",
+    type: "website",
+  },
+  keywords: [
+    "ethical leadership",
+    "global health",
+    "student essays",
+    "faculty reflections",
+    "community voices",
+    "NCDs",
+    "Akomapa",
+  ],
 };
 
-const highlights = [
-  {
-    title: "Community Voices",
-    description:
-      "Stories and perspectives from the communities we partner with, highlighting local leadership and shared learning.",
-  },
-  {
-    title: "Student Reflections",
-    description:
-      "First-hand accounts from student leaders on their experiences in clinical practice, research, and ethical leadership.",
-  },
-  {
-    title: "Faculty Perspectives",
-    description:
-      "Insights from faculty mentors on global health education, community partnership, and developing the next generation of leaders.",
-  },
-] as const;
-
 export default function BlogPage() {
-  return (
-    <RebrandPageShell
-      eyebrow="Stories & Insights"
-      title="Thought Leadership"
-      description="Explore essays, reflections, and commentary from across the Akomapa network on ethical global health, community partnership, and student leadership."
-      highlights={highlights}
-    />
-  );
+  return <BlogListing />;
 }

--- a/src/components/blog/AuthorAvatar.tsx
+++ b/src/components/blog/AuthorAvatar.tsx
@@ -1,0 +1,64 @@
+import Image from "@/components/common/Image";
+import { cn } from "@/lib/utils";
+
+function getInitials(name: string): string {
+  const words = name.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return "?";
+  const first = words[0]?.[0] ?? "";
+  const second = words.length > 1 ? words[words.length - 1][0] : "";
+  return (first + second).toUpperCase();
+}
+
+type AuthorAvatarProps = {
+  name: string;
+  image?: string;
+  /** Tailwind size classes for the avatar square, e.g. "h-11 w-11". */
+  sizeClassName?: string;
+  className?: string;
+};
+
+/**
+ * Circular author avatar. Renders the author's photo when available, otherwise
+ * a brand-tinted monogram — we never fabricate a portrait.
+ */
+export function AuthorAvatar({
+  name,
+  image,
+  sizeClassName = "h-11 w-11",
+  className,
+}: AuthorAvatarProps) {
+  if (image) {
+    return (
+      <span
+        className={cn(
+          "relative overflow-hidden rounded-full ring-2 ring-white/70 dark:ring-white/10",
+          sizeClassName,
+          className,
+        )}
+      >
+        <Image
+          src={image}
+          alt={name}
+          fill
+          sizes="88px"
+          className="object-cover"
+        />
+      </span>
+    );
+  }
+
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "inline-flex shrink-0 items-center justify-center rounded-full",
+        "bg-[#0097b2]/12 font-heading text-sm font-bold text-[#036576]",
+        "dark:bg-[#0097b2]/25 dark:text-[#66C4DC]",
+        sizeClassName,
+        className,
+      )}
+    >
+      {getInitials(name)}
+    </span>
+  );
+}

--- a/src/components/blog/BlogAuthorBio.tsx
+++ b/src/components/blog/BlogAuthorBio.tsx
@@ -1,0 +1,57 @@
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import type { BlogPost } from "@/lib/types";
+import { AuthorAvatar } from "./AuthorAvatar";
+
+type BlogAuthorBioProps = {
+  post: BlogPost;
+  /** Whether the author has other posts to link to. */
+  hasMorePosts: boolean;
+};
+
+/**
+ * Author card shown at the end of an article: avatar, name, role/institution,
+ * a short bio, and — when relevant — a link to more from the same author.
+ */
+export function BlogAuthorBio({ post, hasMorePosts }: BlogAuthorBioProps) {
+  return (
+    <aside className="mx-auto mt-12 max-w-3xl rounded-2xl border border-[#0097b2]/12 bg-gradient-to-br from-[#0097b2]/5 to-[#eeba2b]/5 p-6 sm:p-8 dark:border-[#0097b2]/20 dark:from-[#0097b2]/10 dark:to-[#eeba2b]/10">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:gap-5">
+        <AuthorAvatar
+          name={post.author}
+          image={post.authorImage}
+          sizeClassName="h-16 w-16"
+          className="text-lg"
+        />
+        <div className="flex-1">
+          <p className="text-xs font-semibold uppercase tracking-wider text-[#0097b2] dark:text-[#66C4DC]">
+            About the author
+          </p>
+          <h2 className="mt-1 font-heading text-xl font-bold text-[#1C1F1E] dark:text-[#FCFAEF]">
+            {post.author}
+          </h2>
+          <p className="text-sm font-medium text-[#2F3332]/70 dark:text-[#E6E7E7]/60">
+            {post.authorRole}
+            {post.authorInstitution ? ` · ${post.authorInstitution}` : ""}
+          </p>
+
+          {post.authorBio && (
+            <p className="mt-3 text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/75">
+              {post.authorBio}
+            </p>
+          )}
+
+          {hasMorePosts && (
+            <Link
+              href={`/blog?author=${encodeURIComponent(post.author)}`}
+              className="mt-4 inline-flex items-center gap-1.5 text-sm font-semibold text-[#0097b2] transition-colors hover:text-[#005A55] dark:text-[#66C4DC] dark:hover:text-[#eeba2b]"
+            >
+              More from {post.author.split(" ")[0]}
+              <ArrowRight className="h-3.5 w-3.5" />
+            </Link>
+          )}
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/src/components/blog/BlogCard.tsx
+++ b/src/components/blog/BlogCard.tsx
@@ -1,0 +1,126 @@
+import Link from "next/link";
+import { ArrowRight, Play } from "lucide-react";
+import Image from "@/components/common/Image";
+import { cn, formatDate } from "@/lib/utils";
+import { getCategoryBadgeClass, getCategoryLabel } from "@/data/blog";
+import { getAnnouncementPosterSrc } from "@/lib/video-utils";
+import type { BlogPost } from "@/lib/types";
+import { AuthorAvatar } from "./AuthorAvatar";
+
+type BlogCardProps = {
+  post: BlogPost;
+};
+
+/**
+ * Editorial blog card: image, category badge, title, excerpt, author byline,
+ * and date. The whole card links to the article. Mirrors the site's card
+ * hover/elevation language for visual consistency with the news feed.
+ */
+export function BlogCard({ post }: BlogCardProps) {
+  const posterSrc = getAnnouncementPosterSrc({
+    image: post.image,
+    videoUrl: post.videoUrl,
+  });
+
+  return (
+    <Link
+      href={`/blog/${post.slug}`}
+      className="group block h-full rounded-2xl focus:outline-none focus-visible:ring-2 focus-visible:ring-[#0097b2] focus-visible:ring-offset-2 focus-visible:ring-offset-[#FCFAEF] dark:focus-visible:ring-offset-[#1C1F1E]"
+    >
+      <article
+        className={cn(
+          "flex h-full flex-col overflow-hidden rounded-2xl",
+          "bg-white dark:bg-[#2F3332]",
+          "border border-black/[0.04] dark:border-white/[0.06]",
+          "shadow-[0_1px_3px_rgba(0,0,0,0.04)]",
+          "transition-all duration-300 ease-out",
+          "group-hover:-translate-y-1.5 group-hover:shadow-[0_12px_32px_rgba(0,0,0,0.08)]",
+          "dark:group-hover:shadow-[0_12px_32px_rgba(0,0,0,0.3)]",
+        )}
+      >
+        {/* Image */}
+        {posterSrc && (
+          <div className="relative aspect-[16/10] overflow-hidden">
+            <Image
+              src={posterSrc}
+              alt={post.title}
+              fill
+              sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
+              className="object-cover transition-transform duration-500 ease-out group-hover:scale-[1.03]"
+            />
+            <div className="absolute inset-0 bg-gradient-to-b from-black/25 via-transparent to-transparent" />
+
+            {post.videoUrl && (
+              <span className="absolute inset-0 flex items-center justify-center">
+                <span className="flex h-12 w-12 items-center justify-center rounded-full bg-white/90 shadow-lg transition-transform duration-300 group-hover:scale-110">
+                  <Play className="ml-0.5 h-5 w-5 text-[#0097b2]" fill="currentColor" />
+                </span>
+              </span>
+            )}
+
+            <span
+              className={cn(
+                "absolute left-3 top-3 inline-block rounded-full px-3 py-1",
+                "text-[11px] font-bold uppercase tracking-wider backdrop-blur-md shadow-sm",
+                getCategoryBadgeClass(post.category),
+              )}
+            >
+              {getCategoryLabel(post.category)}
+            </span>
+          </div>
+        )}
+
+        {/* Content */}
+        <div className="flex flex-1 flex-col p-5 sm:p-6">
+          {!posterSrc && (
+            <span
+              className={cn(
+                "mb-3 inline-block w-fit rounded-full px-3 py-1",
+                "text-[11px] font-bold uppercase tracking-wider",
+                getCategoryBadgeClass(post.category),
+              )}
+            >
+              {getCategoryLabel(post.category)}
+            </span>
+          )}
+
+          <h3 className="mb-2 font-heading text-lg font-bold leading-snug text-[#1C1F1E] line-clamp-2 dark:text-[#FCFAEF]">
+            {post.title}
+          </h3>
+
+          <p className="mb-5 flex-1 text-sm leading-relaxed text-[#2F3332]/70 line-clamp-3 dark:text-[#E6E7E7]/60">
+            {post.excerpt}
+          </p>
+
+          {/* Byline */}
+          <div className="flex items-center gap-3 border-t border-black/[0.05] pt-4 dark:border-white/[0.06]">
+            <AuthorAvatar
+              name={post.author}
+              image={post.authorImage}
+              sizeClassName="h-9 w-9"
+            />
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+                {post.author}
+              </p>
+              <p className="truncate text-xs text-[#2F3332]/60 dark:text-[#E6E7E7]/50">
+                {post.authorRole}
+              </p>
+            </div>
+            <time
+              dateTime={post.date}
+              className="shrink-0 text-xs text-[#2F3332]/60 dark:text-[#E6E7E7]/50"
+            >
+              {formatDate(post.date)}
+            </time>
+          </div>
+
+          <span className="mt-4 inline-flex items-center gap-1.5 text-sm font-semibold text-[#0097b2] transition-colors duration-200 group-hover:text-[#005A55] dark:text-[#66C4DC] dark:group-hover:text-[#eeba2b]">
+            Read article
+            <ArrowRight className="h-3.5 w-3.5 transition-transform duration-200 group-hover:translate-x-0.5" />
+          </span>
+        </div>
+      </article>
+    </Link>
+  );
+}

--- a/src/components/blog/BlogCategoryFilter.tsx
+++ b/src/components/blog/BlogCategoryFilter.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+export type BlogFilterOption = {
+  value: string;
+  label: string;
+};
+
+type BlogCategoryFilterProps = {
+  options: BlogFilterOption[];
+  activeCategory: string;
+  onChange: (value: string) => void;
+};
+
+/**
+ * Pill-style category tabs for filtering the blog grid. Controlled by the
+ * parent listing page. Matches the news feed's filter styling.
+ */
+export function BlogCategoryFilter({
+  options,
+  activeCategory,
+  onChange,
+}: BlogCategoryFilterProps) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Filter articles by category"
+      className="mx-auto flex max-w-4xl flex-wrap justify-center gap-2 sm:gap-3"
+    >
+      {options.map((option) => {
+        const isActive = activeCategory === option.value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            onClick={() => onChange(option.value)}
+            className={cn(
+              "rounded-full px-4 py-2 text-sm font-medium transition-all duration-200",
+              "focus:outline-none focus-visible:ring-2 focus-visible:ring-[#0097b2] focus-visible:ring-offset-2 focus-visible:ring-offset-[#FCFAEF] dark:focus-visible:ring-offset-[#1C1F1E]",
+              isActive
+                ? "bg-[#0097b2] text-[#FCFAEF] shadow-md"
+                : "border border-black/[0.06] bg-white text-[#2F3332]/70 hover:border-[#0097b2]/30 hover:text-[#0097b2] dark:border-white/[0.08] dark:bg-[#2F3332] dark:text-[#E6E7E7]/70 dark:hover:text-[#66C4DC]",
+            )}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/blog/BlogFeaturedPost.tsx
+++ b/src/components/blog/BlogFeaturedPost.tsx
@@ -38,7 +38,7 @@ export function BlogFeaturedPost({ post }: BlogFeaturedPostProps) {
       >
         {/* Media */}
         {posterSrc && (
-          <div className="relative aspect-[16/10] overflow-hidden lg:aspect-auto lg:min-h-[360px]">
+          <div className="relative aspect-[16/10] min-w-0 overflow-hidden lg:aspect-auto lg:min-h-[360px]">
             <Image
               src={posterSrc}
               alt={post.title}
@@ -65,7 +65,7 @@ export function BlogFeaturedPost({ post }: BlogFeaturedPostProps) {
         )}
 
         {/* Content */}
-        <div className="flex flex-col justify-center p-6 sm:p-8 lg:p-10">
+        <div className="flex min-w-0 flex-col justify-center p-6 sm:p-8 lg:p-10">
           <div className="mb-4 flex flex-wrap items-center gap-3">
             <span
               className={cn(
@@ -97,7 +97,7 @@ export function BlogFeaturedPost({ post }: BlogFeaturedPostProps) {
             {post.excerpt}
           </p>
 
-          <div className="flex items-center gap-3">
+          <div className="flex min-w-0 items-center gap-3">
             <AuthorAvatar name={post.author} image={post.authorImage} />
             <div className="min-w-0">
               <p className="truncate text-sm font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">

--- a/src/components/blog/BlogFeaturedPost.tsx
+++ b/src/components/blog/BlogFeaturedPost.tsx
@@ -1,0 +1,121 @@
+import Link from "next/link";
+import { ArrowRight, Play, Star } from "lucide-react";
+import Image from "@/components/common/Image";
+import { cn, formatDate, readingTime } from "@/lib/utils";
+import { getCategoryBadgeClass, getCategoryLabel } from "@/data/blog";
+import { getAnnouncementPosterSrc } from "@/lib/video-utils";
+import type { BlogPost } from "@/lib/types";
+import { AuthorAvatar } from "./AuthorAvatar";
+
+type BlogFeaturedPostProps = {
+  post: BlogPost;
+};
+
+/**
+ * Prominent, visually-distinct featured card shown at the top of the listing.
+ * Larger than a grid card, with a hero image and a two-column layout on desktop.
+ */
+export function BlogFeaturedPost({ post }: BlogFeaturedPostProps) {
+  const posterSrc = getAnnouncementPosterSrc({
+    image: post.image,
+    videoUrl: post.videoUrl,
+  });
+
+  return (
+    <Link
+      href={`/blog/${post.slug}`}
+      className="group block rounded-3xl focus:outline-none focus-visible:ring-2 focus-visible:ring-[#0097b2] focus-visible:ring-offset-2 focus-visible:ring-offset-[#FCFAEF] dark:focus-visible:ring-offset-[#1C1F1E]"
+    >
+      <article
+        className={cn(
+          "grid overflow-hidden rounded-3xl lg:grid-cols-2",
+          "bg-white dark:bg-[#2F3332]",
+          "border border-black/[0.05] dark:border-white/[0.06]",
+          "shadow-[0_8px_30px_rgba(15,76,92,0.10)]",
+          "transition-all duration-300 ease-out",
+          "group-hover:-translate-y-1 group-hover:shadow-[0_20px_50px_rgba(15,76,92,0.18)]",
+        )}
+      >
+        {/* Media */}
+        {posterSrc && (
+          <div className="relative aspect-[16/10] overflow-hidden lg:aspect-auto lg:min-h-[360px]">
+            <Image
+              src={posterSrc}
+              alt={post.title}
+              fill
+              priority
+              sizes="(min-width: 1024px) 50vw, 100vw"
+              className="object-cover transition-transform duration-500 ease-out group-hover:scale-[1.03]"
+            />
+            <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-transparent" />
+
+            {post.videoUrl && (
+              <span className="absolute inset-0 flex items-center justify-center">
+                <span className="flex h-16 w-16 items-center justify-center rounded-full bg-white/90 shadow-xl transition-transform duration-300 group-hover:scale-110">
+                  <Play className="ml-0.5 h-7 w-7 text-[#0097b2]" fill="currentColor" />
+                </span>
+              </span>
+            )}
+
+            <span className="absolute left-4 top-4 inline-flex items-center gap-1.5 rounded-full bg-[#eeba2b] px-3 py-1 text-[11px] font-bold uppercase tracking-wider text-[#1C1F1E] shadow-sm">
+              <Star className="h-3 w-3" fill="currentColor" />
+              Featured
+            </span>
+          </div>
+        )}
+
+        {/* Content */}
+        <div className="flex flex-col justify-center p-6 sm:p-8 lg:p-10">
+          <div className="mb-4 flex flex-wrap items-center gap-3">
+            <span
+              className={cn(
+                "inline-block rounded-full px-3 py-1 text-[11px] font-bold uppercase tracking-wider",
+                getCategoryBadgeClass(post.category),
+              )}
+            >
+              {getCategoryLabel(post.category)}
+            </span>
+            <time
+              dateTime={post.date}
+              className="text-xs text-[#2F3332]/60 dark:text-[#E6E7E7]/50"
+            >
+              {formatDate(post.date)}
+            </time>
+            <span aria-hidden="true" className="text-xs text-[#2F3332]/40 dark:text-[#E6E7E7]/30">
+              •
+            </span>
+            <span className="text-xs text-[#2F3332]/60 dark:text-[#E6E7E7]/50">
+              {readingTime(post.content)}
+            </span>
+          </div>
+
+          <h2 className="mb-4 font-heading text-2xl font-bold leading-tight text-[#1C1F1E] sm:text-3xl md:text-4xl dark:text-[#FCFAEF]">
+            {post.title}
+          </h2>
+
+          <p className="mb-6 text-base leading-relaxed text-[#2F3332]/75 line-clamp-3 sm:text-lg dark:text-[#E6E7E7]/70">
+            {post.excerpt}
+          </p>
+
+          <div className="flex items-center gap-3">
+            <AuthorAvatar name={post.author} image={post.authorImage} />
+            <div className="min-w-0">
+              <p className="truncate text-sm font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+                {post.author}
+              </p>
+              <p className="truncate text-xs text-[#2F3332]/60 dark:text-[#E6E7E7]/50">
+                {post.authorRole}
+                {post.authorInstitution ? ` · ${post.authorInstitution}` : ""}
+              </p>
+            </div>
+          </div>
+
+          <span className="mt-7 inline-flex items-center gap-2 text-sm font-semibold text-[#0097b2] transition-colors duration-200 group-hover:text-[#005A55] dark:text-[#66C4DC] dark:group-hover:text-[#eeba2b]">
+            Read the full story
+            <ArrowRight className="h-4 w-4 transition-transform duration-200 group-hover:translate-x-1" />
+          </span>
+        </div>
+      </article>
+    </Link>
+  );
+}

--- a/src/components/blog/BlogGrid.tsx
+++ b/src/components/blog/BlogGrid.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import {
+  FadeInStagger,
+  FadeInStaggerItem,
+  motionDurations,
+} from "@/components/animations";
+import type { BlogPost } from "@/lib/types";
+import { BlogCard } from "./BlogCard";
+
+type BlogGridProps = {
+  posts: BlogPost[];
+  /** Re-triggers the stagger animation when the active filter changes. */
+  animationKey?: string;
+};
+
+/**
+ * Responsive grid of blog cards: 3 columns (desktop), 2 (tablet), 1 (mobile),
+ * with a staggered scroll-reveal and an empty state.
+ */
+export function BlogGrid({ posts, animationKey }: BlogGridProps) {
+  if (posts.length === 0) {
+    return (
+      <p className="mt-12 text-center text-[#2F3332]/50 dark:text-[#E6E7E7]/40">
+        No articles in this category yet — check back soon.
+      </p>
+    );
+  }
+
+  return (
+    <FadeInStagger
+      key={animationKey}
+      className="mx-auto grid max-w-6xl grid-cols-1 gap-6 sm:gap-8 md:grid-cols-2 lg:grid-cols-3"
+      staggerDelay={motionDurations.staggerContainer}
+    >
+      {posts.map((post) => (
+        <FadeInStaggerItem key={post.id} direction="up" className="h-full">
+          <BlogCard post={post} />
+        </FadeInStaggerItem>
+      ))}
+    </FadeInStagger>
+  );
+}

--- a/src/components/blog/BlogHero.tsx
+++ b/src/components/blog/BlogHero.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { PenLine } from "lucide-react";
+
+type BlogHeroProps = {
+  postCount: number;
+};
+
+/**
+ * Gradient hero for the Thought Leadership listing page. Mirrors the news
+ * hero's decorative-blur treatment while keeping an editorial, text-led layout.
+ */
+export function BlogHero({ postCount }: BlogHeroProps) {
+  return (
+    <section className="relative overflow-hidden bg-gradient-to-br from-[#0097b2] via-[#0A6B7A] to-[#0F4C5C] py-16 sm:py-20 md:py-28">
+      <div className="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden="true">
+        <div className="absolute -top-24 right-0 h-64 w-64 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
+        <div className="absolute -left-24 bottom-0 h-96 w-96 rounded-full bg-[#eeba2b]/15 blur-3xl" />
+        <div className="absolute right-1/4 top-1/2 h-40 w-40 rounded-full bg-[#F5C94D]/15 blur-2xl" />
+      </div>
+
+      <div className="container relative z-10 mx-auto px-4 sm:px-6">
+        <div className="mx-auto max-w-3xl text-center">
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5 }}
+            className="mb-6 inline-flex items-center gap-2 rounded-full border border-[#eeba2b]/30 bg-[#eeba2b]/20 px-4 py-2"
+          >
+            <PenLine className="h-4 w-4 text-[#eeba2b]" />
+            <span className="text-sm font-medium text-[#eeba2b]">
+              {postCount} {postCount === 1 ? "story" : "stories"} and counting
+            </span>
+          </motion.div>
+
+          <motion.h1
+            initial={{ opacity: 0, y: 40 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.8, ease: "easeOut" }}
+            className="mb-6 font-heading text-4xl font-bold leading-tight text-[#FCFAEF] sm:text-5xl md:text-6xl"
+          >
+            Thought{" "}
+            <span className="text-[#eeba2b]">Leadership</span>
+          </motion.h1>
+
+          <motion.p
+            initial={{ opacity: 0, y: 40 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.15, duration: 0.8, ease: "easeOut" }}
+            className="mx-auto max-w-2xl text-base font-light leading-relaxed text-[#FCFAEF]/85 sm:text-lg md:text-xl"
+          >
+            Student essays, faculty reflections, and community voices on ethical
+            global health, community partnership, and the future of care.
+          </motion.p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/blog/BlogListing.tsx
+++ b/src/components/blog/BlogListing.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { Suspense, useMemo, useState } from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { ArrowRight, X } from "lucide-react";
+import Breadcrumb from "@/components/layout/Breadcrumb";
+import { FadeIn, motionDurations } from "@/components/animations";
+import {
+  BlogCategoryFilter,
+  BlogFeaturedPost,
+  BlogGrid,
+  BlogHero,
+  type BlogFilterOption,
+} from "@/components/blog";
+import {
+  getActiveCategories,
+  getAllBlogPosts,
+  getFeaturedPost,
+} from "@/data/blog";
+
+const ALL = "all";
+
+const allPosts = getAllBlogPosts();
+const featuredPost = getFeaturedPost();
+
+const filterOptions: BlogFilterOption[] = [
+  { value: ALL, label: "All" },
+  ...getActiveCategories().map((category) => ({
+    value: category.value,
+    label: category.filterLabel,
+  })),
+];
+
+function BlogListingContent() {
+  const searchParams = useSearchParams();
+  const authorFilter = searchParams.get("author");
+  const [activeCategory, setActiveCategory] = useState<string>(ALL);
+
+  // Author view: everything by a single author, no category pills.
+  const authorPosts = useMemo(
+    () =>
+      authorFilter
+        ? allPosts.filter((post) => post.author === authorFilter)
+        : [],
+    [authorFilter],
+  );
+
+  const gridPosts = useMemo(() => {
+    if (activeCategory === ALL) {
+      return featuredPost
+        ? allPosts.filter((post) => post.id !== featuredPost.id)
+        : allPosts;
+    }
+    return allPosts.filter((post) => post.category === activeCategory);
+  }, [activeCategory]);
+
+  const showFeatured = activeCategory === ALL && Boolean(featuredPost);
+
+  if (authorFilter) {
+    return (
+      <>
+        <div className="container mx-auto">
+          <Breadcrumb />
+        </div>
+        <BlogHero postCount={allPosts.length} />
+        <section className="bg-[#FCFAEF] py-16 md:py-24 dark:bg-[#1C1F1E]">
+          <div className="container mx-auto px-4 sm:px-6">
+            <FadeIn
+              className="mx-auto mb-10 max-w-3xl text-center"
+              duration={motionDurations.enter}
+            >
+              <p className="mb-2 text-base font-bold text-[#F5C94D] sm:text-lg">
+                AUTHOR
+              </p>
+              <h2 className="mb-4 font-heading text-2xl font-bold text-[#1C1F1E] sm:text-3xl md:text-4xl dark:text-[#FCFAEF]">
+                Stories by {authorFilter}
+              </h2>
+              <Link
+                href="/blog"
+                className="inline-flex items-center gap-1.5 text-sm font-semibold text-[#0097b2] transition-colors hover:text-[#005A55] dark:text-[#66C4DC] dark:hover:text-[#eeba2b]"
+              >
+                <X className="h-4 w-4" />
+                Clear author filter
+              </Link>
+            </FadeIn>
+            <BlogGrid posts={authorPosts} animationKey={authorFilter} />
+          </div>
+        </section>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div className="container mx-auto">
+        <Breadcrumb />
+      </div>
+
+      <BlogHero postCount={allPosts.length} />
+
+      {/* Featured */}
+      {showFeatured && featuredPost && (
+        <section className="bg-[#FCFAEF] pt-14 md:pt-20 dark:bg-[#1C1F1E]">
+          <div className="container mx-auto px-4 sm:px-6">
+            <FadeIn
+              className="mx-auto max-w-6xl"
+              duration={motionDurations.enter}
+            >
+              <BlogFeaturedPost post={featuredPost} />
+            </FadeIn>
+          </div>
+        </section>
+      )}
+
+      {/* Grid + filter */}
+      <section className="bg-[#FCFAEF] py-14 md:py-20 dark:bg-[#1C1F1E]">
+        <div className="container mx-auto px-4 sm:px-6">
+          <FadeIn
+            className="mx-auto mb-8 max-w-3xl text-center"
+            duration={motionDurations.enter}
+          >
+            <p className="mb-2 text-base font-bold text-[#F5C94D] sm:text-lg">
+              ALL ARTICLES
+            </p>
+            <h2 className="mb-4 font-heading text-2xl font-bold text-[#1C1F1E] sm:text-3xl md:text-4xl dark:text-[#FCFAEF]">
+              Explore by category
+            </h2>
+            <p className="mx-auto max-w-2xl text-base leading-relaxed text-[#2F3332]/70 sm:text-lg dark:text-[#E6E7E7]/60">
+              Perspectives from students, faculty, and communities across the
+              Akomapa network.
+            </p>
+          </FadeIn>
+
+          <FadeIn className="mb-10" duration={motionDurations.enter}>
+            <BlogCategoryFilter
+              options={filterOptions}
+              activeCategory={activeCategory}
+              onChange={setActiveCategory}
+            />
+          </FadeIn>
+
+          <BlogGrid posts={gridPosts} animationKey={activeCategory} />
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="relative overflow-hidden bg-gradient-to-r from-[#0097b2] via-[#0F4C5C] to-[#031C3A] py-16 text-[#FCFAEF] md:py-24">
+        <div className="pointer-events-none absolute inset-0" aria-hidden="true">
+          <div className="absolute -left-32 -top-28 h-72 w-72 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
+          <div className="absolute bottom-0 right-0 h-80 w-80 rounded-full bg-[#F5C94D]/10 blur-3xl" />
+        </div>
+        <div className="container relative mx-auto px-4 sm:px-6">
+          <div className="mx-auto max-w-3xl space-y-6 text-center">
+            <h2 className="font-heading text-2xl font-bold sm:text-3xl md:text-4xl">
+              Have a story to tell?
+            </h2>
+            <p className="mx-auto max-w-2xl text-base leading-relaxed text-[#FCFAEF]/85 sm:text-lg">
+              We welcome essays, reflections, and voices from students, faculty,
+              and the communities we partner with.
+            </p>
+            <div className="flex flex-col justify-center gap-4 pt-2 sm:flex-row">
+              <Link
+                href="/get-involved"
+                className="inline-flex items-center justify-center gap-2 rounded-full bg-[#eeba2b] px-8 py-3 text-sm font-semibold text-[#1C1F1E] transition-colors hover:bg-[#FCFAEF]"
+              >
+                Get Involved
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+              <Link
+                href="/news"
+                className="inline-flex items-center justify-center gap-2 rounded-full border border-[#FCFAEF]/30 px-8 py-3 text-sm font-semibold text-[#FCFAEF] transition-colors hover:bg-[#FCFAEF]/10"
+              >
+                Read the latest news
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}
+
+/**
+ * Client-side blog listing: hero, featured post, category filter, and the
+ * responsive post grid. Wrapped in Suspense because it reads search params.
+ */
+export function BlogListing() {
+  return (
+    <Suspense fallback={null}>
+      <BlogListingContent />
+    </Suspense>
+  );
+}

--- a/src/components/blog/BlogPost.tsx
+++ b/src/components/blog/BlogPost.tsx
@@ -1,0 +1,340 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { motion } from "framer-motion";
+import {
+  ArrowLeft,
+  ArrowRight,
+  Calendar,
+  Check,
+  ChevronRight,
+  Clock,
+  Home,
+  Link2,
+  Linkedin,
+  Play,
+} from "lucide-react";
+import Image from "@/components/common/Image";
+import { FadeIn, motionDurations } from "@/components/animations";
+import { cn, formatDate, readingTime } from "@/lib/utils";
+import { getCategoryBadgeClass, getCategoryLabel } from "@/data/blog";
+import { getAnnouncementPosterSrc, parseVideoUrl } from "@/lib/video-utils";
+import type { BlogPost as BlogPostType } from "@/lib/types";
+import { AuthorAvatar } from "./AuthorAvatar";
+import { BlogAuthorBio } from "./BlogAuthorBio";
+import { BlogRelatedPosts } from "./BlogRelatedPosts";
+
+type BlogPostProps = {
+  post: BlogPostType;
+  related: BlogPostType[];
+  hasMoreByAuthor: boolean;
+};
+
+/**
+ * Full editorial article view: header, hero media, prose body, share row,
+ * author bio, and related posts. Renders trusted, first-party HTML content.
+ */
+export function BlogPost({ post, related, hasMoreByAuthor }: BlogPostProps) {
+  const [videoPlaying, setVideoPlaying] = useState(false);
+  const [shareUrl, setShareUrl] = useState("");
+  const [copied, setCopied] = useState(false);
+
+  const posterSrc = getAnnouncementPosterSrc({
+    image: post.image,
+    videoUrl: post.videoUrl,
+  });
+
+  useEffect(() => {
+    setShareUrl(window.location.href);
+  }, []);
+
+  const handleCopy = async () => {
+    if (!shareUrl) return;
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard unavailable — silently ignore.
+    }
+  };
+
+  const encodedUrl = encodeURIComponent(shareUrl);
+  const encodedTitle = encodeURIComponent(post.title);
+
+  return (
+    <>
+      {/* Breadcrumb */}
+      <nav
+        aria-label="Breadcrumb"
+        className="container mx-auto px-4 py-4 sm:px-6"
+      >
+        <ol className="flex flex-wrap items-center text-sm text-[#2F3332]/70 dark:text-[#FCFAEF]/70">
+          <li className="flex items-center">
+            <Link
+              href="/"
+              className="flex items-center transition-colors hover:text-[#eeba2b] dark:hover:text-[#F5C94D]"
+            >
+              <Home className="h-4 w-4" />
+              <span className="sr-only">Home</span>
+            </Link>
+          </li>
+          <li className="flex items-center">
+            <ChevronRight className="mx-2 h-4 w-4 text-[#2F3332]/50 dark:text-[#FCFAEF]/50" />
+            <Link
+              href="/blog"
+              className="transition-colors hover:text-[#eeba2b] dark:hover:text-[#F5C94D]"
+            >
+              Thought Leadership
+            </Link>
+          </li>
+          <li className="flex min-w-0 items-center">
+            <ChevronRight className="mx-2 h-4 w-4 shrink-0 text-[#2F3332]/50 dark:text-[#FCFAEF]/50" />
+            <span className="truncate font-medium text-[#2F3332] dark:text-[#FCFAEF]">
+              {post.title}
+            </span>
+          </li>
+        </ol>
+      </nav>
+
+      <article className="flex flex-col">
+        {/* Header */}
+        <header className="relative overflow-hidden bg-gradient-to-br from-[#0097b2] via-[#0A6B7A] to-[#0F4C5C] py-16 sm:py-20 md:py-24">
+          <div className="pointer-events-none absolute inset-0" aria-hidden="true">
+            <div className="absolute right-0 top-0 h-72 w-72 -translate-y-1/3 translate-x-1/3 rounded-full bg-[#FCFAEF]/8 blur-3xl" />
+            <div className="absolute bottom-0 left-0 h-96 w-96 -translate-x-1/3 translate-y-1/2 rounded-full bg-[#eeba2b]/10 blur-3xl" />
+          </div>
+
+          <div className="container relative z-10 mx-auto px-4 sm:px-6">
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5 }}
+            >
+              <Link
+                href="/blog"
+                className="mb-8 inline-flex items-center gap-2 text-sm font-medium text-[#FCFAEF]/70 transition-colors hover:text-[#FCFAEF]"
+              >
+                <ArrowLeft className="h-4 w-4" />
+                Back to Thought Leadership
+              </Link>
+            </motion.div>
+
+            <div className="mx-auto max-w-3xl text-center">
+              <motion.div
+                initial={{ opacity: 0, y: 16 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.5, delay: 0.05 }}
+              >
+                <span
+                  className={cn(
+                    "mb-5 inline-block rounded-full px-3.5 py-1.5",
+                    "text-xs font-bold uppercase tracking-wider shadow-sm backdrop-blur-md",
+                    getCategoryBadgeClass(post.category),
+                  )}
+                >
+                  {getCategoryLabel(post.category)}
+                </span>
+              </motion.div>
+
+              <motion.h1
+                initial={{ opacity: 0, y: 30 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.7, delay: 0.1, ease: "easeOut" }}
+                className="mb-6 font-heading text-3xl font-bold leading-tight text-[#FCFAEF] sm:text-4xl md:text-5xl"
+              >
+                {post.title}
+              </motion.h1>
+
+              {/* Author + meta */}
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6, delay: 0.2 }}
+                className="flex flex-col items-center gap-4"
+              >
+                <div className="flex items-center gap-3">
+                  <AuthorAvatar name={post.author} image={post.authorImage} />
+                  <div className="text-left">
+                    <p className="text-sm font-semibold text-[#FCFAEF]">
+                      {post.author}
+                    </p>
+                    <p className="text-xs text-[#FCFAEF]/70">
+                      {post.authorRole}
+                      {post.authorInstitution
+                        ? ` · ${post.authorInstitution}`
+                        : ""}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 text-sm text-[#FCFAEF]/70">
+                  <span className="inline-flex items-center gap-1.5">
+                    <Calendar className="h-3.5 w-3.5" />
+                    {formatDate(post.date)}
+                  </span>
+                  <span className="inline-flex items-center gap-1.5">
+                    <Clock className="h-3.5 w-3.5" />
+                    {readingTime(post.content)}
+                  </span>
+                </div>
+              </motion.div>
+            </div>
+          </div>
+        </header>
+
+        {/* Hero media — overlaps header */}
+        {posterSrc && (
+          <div className="relative z-10 -mt-8 mb-4 sm:-mt-12 md:-mt-16">
+            <div className="container mx-auto px-4 sm:px-6">
+              <motion.div
+                initial={{ opacity: 0, y: 30, scale: 0.98 }}
+                animate={{ opacity: 1, y: 0, scale: 1 }}
+                transition={{ duration: 0.7, delay: 0.3, ease: "easeOut" }}
+                className="mx-auto max-w-4xl"
+              >
+                <div className="relative aspect-[16/9] overflow-hidden rounded-2xl shadow-2xl ring-1 ring-black/5 sm:rounded-3xl dark:ring-white/5">
+                  {post.videoUrl && videoPlaying ? (
+                    <iframe
+                      src={parseVideoUrl(post.videoUrl)?.embedUrl}
+                      className="absolute inset-0 h-full w-full"
+                      allow="autoplay; encrypted-media; picture-in-picture"
+                      allowFullScreen
+                      title={post.title}
+                    />
+                  ) : (
+                    <>
+                      <Image
+                        src={posterSrc}
+                        alt={post.title}
+                        fill
+                        priority
+                        sizes="(min-width: 1024px) 56rem, 100vw"
+                        className="object-cover"
+                      />
+                      <div className="absolute inset-0 bg-gradient-to-t from-black/20 via-transparent to-transparent" />
+                      {post.videoUrl && (
+                        <button
+                          type="button"
+                          onClick={() => setVideoPlaying(true)}
+                          className="absolute inset-0 flex items-center justify-center"
+                          aria-label="Play video"
+                        >
+                          <span className="flex h-20 w-20 items-center justify-center rounded-full bg-white/90 shadow-xl transition-transform duration-200 hover:scale-110 sm:h-24 sm:w-24">
+                            <Play
+                              className="ml-1 h-9 w-9 text-[#0097b2] sm:h-10 sm:w-10"
+                              fill="currentColor"
+                            />
+                          </span>
+                        </button>
+                      )}
+                    </>
+                  )}
+                </div>
+              </motion.div>
+            </div>
+          </div>
+        )}
+
+        {/* Body */}
+        <section className="bg-[#FCFAEF] py-10 md:py-14 dark:bg-[#1C1F1E]">
+          <div className="container mx-auto px-4 sm:px-6">
+            <FadeIn
+              className="mx-auto max-w-3xl"
+              duration={motionDurations.enter}
+            >
+              <div
+                className="prose prose-lg max-w-none prose-headings:font-heading prose-headings:text-[#1C1F1E] prose-p:text-[#2F3332] prose-a:text-[#0097b2] prose-blockquote:border-[#0097b2] prose-blockquote:text-[#1C1F1E] prose-strong:text-[#1C1F1E] dark:prose-invert dark:prose-p:text-[#E6E7E7]/90 dark:prose-a:text-[#66C4DC] dark:prose-blockquote:border-[#66C4DC] dark:prose-headings:text-[#FCFAEF] dark:prose-strong:text-[#FCFAEF]"
+                // Content is static, first-party authored HTML — no user input.
+                dangerouslySetInnerHTML={{ __html: post.content }}
+              />
+
+              {/* Tags */}
+              {post.tags.length > 0 && (
+                <div className="mt-10 flex flex-wrap gap-2 border-t border-black/[0.06] pt-6 dark:border-white/[0.08]">
+                  {post.tags.map((tag) => (
+                    <span
+                      key={tag}
+                      className="rounded-full bg-[#0097b2]/8 px-3 py-1 text-xs font-medium text-[#036576] dark:bg-[#0097b2]/20 dark:text-[#66C4DC]"
+                    >
+                      #{tag}
+                    </span>
+                  ))}
+                </div>
+              )}
+
+              {/* Share row */}
+              <div className="mt-8 flex flex-wrap items-center gap-3">
+                <span className="text-sm font-semibold text-[#2F3332]/70 dark:text-[#E6E7E7]/60">
+                  Share:
+                </span>
+                <a
+                  href={`https://twitter.com/intent/tweet?url=${encodedUrl}&text=${encodedTitle}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Share on X"
+                  className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-black/[0.08] bg-white text-[#2F3332] transition-colors hover:border-[#0097b2]/30 hover:text-[#0097b2] dark:border-white/[0.1] dark:bg-[#2F3332] dark:text-[#E6E7E7] dark:hover:text-[#66C4DC]"
+                >
+                  <svg className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                    <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+                  </svg>
+                </a>
+                <a
+                  href={`https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Share on LinkedIn"
+                  className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-black/[0.08] bg-white text-[#2F3332] transition-colors hover:border-[#0097b2]/30 hover:text-[#0097b2] dark:border-white/[0.1] dark:bg-[#2F3332] dark:text-[#E6E7E7] dark:hover:text-[#66C4DC]"
+                >
+                  <Linkedin className="h-4 w-4" />
+                </a>
+                <button
+                  type="button"
+                  onClick={handleCopy}
+                  className="inline-flex items-center gap-1.5 rounded-full border border-black/[0.08] bg-white px-3 py-1.5 text-xs font-medium text-[#2F3332] transition-colors hover:border-[#0097b2]/30 hover:text-[#0097b2] dark:border-white/[0.1] dark:bg-[#2F3332] dark:text-[#E6E7E7] dark:hover:text-[#66C4DC]"
+                >
+                  {copied ? (
+                    <>
+                      <Check className="h-3.5 w-3.5" />
+                      Copied
+                    </>
+                  ) : (
+                    <>
+                      <Link2 className="h-3.5 w-3.5" />
+                      Copy link
+                    </>
+                  )}
+                </button>
+              </div>
+
+              {/* Author bio */}
+              <BlogAuthorBio post={post} hasMorePosts={hasMoreByAuthor} />
+
+              {/* CTA */}
+              <div className="mx-auto mt-12 max-w-3xl rounded-2xl bg-gradient-to-r from-[#0097b2] to-[#0F4C5C] p-8 text-center text-[#FCFAEF] sm:p-10">
+                <h2 className="font-heading text-2xl font-bold sm:text-3xl">
+                  Join the conversation
+                </h2>
+                <p className="mx-auto mt-3 max-w-xl text-sm leading-relaxed text-[#FCFAEF]/85 sm:text-base">
+                  Become part of a movement of students, faculty, and communities
+                  building a more ethical future for global health.
+                </p>
+                <Link
+                  href="/get-involved"
+                  className="mt-6 inline-flex items-center gap-2 rounded-full bg-[#eeba2b] px-6 py-3 text-sm font-semibold text-[#1C1F1E] transition-colors hover:bg-[#FCFAEF]"
+                >
+                  Get Involved
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+              </div>
+            </FadeIn>
+          </div>
+        </section>
+
+        {/* Related */}
+        <BlogRelatedPosts posts={related} />
+      </article>
+    </>
+  );
+}

--- a/src/components/blog/BlogRelatedPosts.tsx
+++ b/src/components/blog/BlogRelatedPosts.tsx
@@ -1,0 +1,48 @@
+import {
+  FadeIn,
+  FadeInStagger,
+  FadeInStaggerItem,
+  motionDurations,
+} from "@/components/animations";
+import type { BlogPost } from "@/lib/types";
+import { BlogCard } from "./BlogCard";
+
+type BlogRelatedPostsProps = {
+  posts: BlogPost[];
+};
+
+/**
+ * "Continue reading" grid of 2–3 related posts shown at the end of an article.
+ */
+export function BlogRelatedPosts({ posts }: BlogRelatedPostsProps) {
+  if (posts.length === 0) return null;
+
+  return (
+    <section className="border-t border-black/[0.04] bg-white py-16 md:py-24 dark:border-white/[0.04] dark:bg-[#2F3332]/30">
+      <div className="container mx-auto px-4 sm:px-6">
+        <FadeIn
+          className="mx-auto mb-12 max-w-3xl text-center"
+          duration={motionDurations.enter}
+        >
+          <p className="mb-2 text-base font-bold text-[#F5C94D] sm:text-lg">
+            KEEP READING
+          </p>
+          <h2 className="font-heading text-2xl font-bold text-[#1C1F1E] sm:text-3xl md:text-4xl dark:text-[#FCFAEF]">
+            More from the blog
+          </h2>
+        </FadeIn>
+
+        <FadeInStagger
+          className="mx-auto grid max-w-6xl grid-cols-1 gap-6 sm:gap-8 md:grid-cols-2 lg:grid-cols-3"
+          staggerDelay={motionDurations.staggerContainer}
+        >
+          {posts.map((post) => (
+            <FadeInStaggerItem key={post.id} direction="up" className="h-full">
+              <BlogCard post={post} />
+            </FadeInStaggerItem>
+          ))}
+        </FadeInStagger>
+      </div>
+    </section>
+  );
+}

--- a/src/components/blog/index.ts
+++ b/src/components/blog/index.ts
@@ -1,0 +1,10 @@
+export { AuthorAvatar } from "./AuthorAvatar";
+export { BlogAuthorBio } from "./BlogAuthorBio";
+export { BlogCard } from "./BlogCard";
+export { BlogCategoryFilter } from "./BlogCategoryFilter";
+export type { BlogFilterOption } from "./BlogCategoryFilter";
+export { BlogFeaturedPost } from "./BlogFeaturedPost";
+export { BlogGrid } from "./BlogGrid";
+export { BlogHero } from "./BlogHero";
+export { BlogPost } from "./BlogPost";
+export { BlogRelatedPosts } from "./BlogRelatedPosts";

--- a/src/components/layout/Breadcrumb.tsx
+++ b/src/components/layout/Breadcrumb.tsx
@@ -43,6 +43,7 @@ function BreadcrumbContent() {
       "ncd-impact": "NCD Impact",
       "community-hubs": "Community Health Hubs",
       "get-involved": "Get Involved",
+      blog: "Thought Leadership",
     };
 
     const label = (() => {

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -105,6 +105,11 @@ export default function Footer() {
                 </Link>
               </li>
               <li>
+                <Link href="/blog" className={footerLinkClass}>
+                  Thought Leadership
+                </Link>
+              </li>
+              <li>
                 <Link href="/get-involved" className={footerLinkClass}>
                   Get Involved
                 </Link>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -19,6 +19,7 @@ const navigation = [
       { name: "Our Story", href: "/about" },
       { name: "Our Team", href: "/about/team" },
       { name: "Our Philosophy", href: "/philosophy" },
+      { name: "Thought Leadership", href: "/blog" },
     ],
   },
   { name: "Academy", href: "/academy" },

--- a/src/data/blog.ts
+++ b/src/data/blog.ts
@@ -1,0 +1,275 @@
+import type { BlogPost } from "@/lib/types";
+
+type BlogCategory = BlogPost["category"];
+
+/**
+ * Single source of truth for blog categories: display label, short filter
+ * label, and the brand-tinted badge classes used on cards and article headers.
+ * Ordered as they should appear in the category filter.
+ */
+export const BLOG_CATEGORIES: {
+  value: BlogCategory;
+  label: string;
+  filterLabel: string;
+  badgeClassName: string;
+}[] = [
+  {
+    value: "student-essay",
+    label: "Student Essay",
+    filterLabel: "Student Essays",
+    badgeClassName:
+      "bg-[#0097b2]/12 text-[#036576] dark:bg-[#0097b2]/25 dark:text-[#66C4DC]",
+  },
+  {
+    value: "faculty-reflection",
+    label: "Faculty Reflection",
+    filterLabel: "Faculty Reflections",
+    badgeClassName:
+      "bg-[#eeba2b]/20 text-[#8a6a09] dark:bg-[#eeba2b]/20 dark:text-[#F5C94D]",
+  },
+  {
+    value: "article",
+    label: "Article",
+    filterLabel: "Articles",
+    badgeClassName:
+      "bg-[#0F4C5C]/12 text-[#0F4C5C] dark:bg-[#0F4C5C]/40 dark:text-[#8fd6e4]",
+  },
+  {
+    value: "community-voice",
+    label: "Community Voice",
+    filterLabel: "Community Voices",
+    badgeClassName:
+      "bg-[#b4552d]/12 text-[#a1481f] dark:bg-[#b4552d]/25 dark:text-[#e9a986]",
+  },
+  {
+    value: "recorded-talk",
+    label: "Recorded Talk",
+    filterLabel: "Recorded Talks",
+    badgeClassName:
+      "bg-[#2F3332]/10 text-[#2F3332] dark:bg-white/12 dark:text-[#E6E7E7]",
+  },
+  {
+    value: "conference-session",
+    label: "Conference Session",
+    filterLabel: "Conference Sessions",
+    badgeClassName:
+      "bg-[#7a5195]/12 text-[#654183] dark:bg-[#7a5195]/28 dark:text-[#cbb4de]",
+  },
+];
+
+const CATEGORY_BY_VALUE = new Map(
+  BLOG_CATEGORIES.map((category) => [category.value, category]),
+);
+
+/** Resolve the display label for a category value (e.g. "Student Essay"). */
+export function getCategoryLabel(value: BlogCategory): string {
+  return CATEGORY_BY_VALUE.get(value)?.label ?? value;
+}
+
+/** Resolve the badge classes for a category value. */
+export function getCategoryBadgeClass(value: BlogCategory): string {
+  return CATEGORY_BY_VALUE.get(value)?.badgeClassName ?? "";
+}
+
+export const blogPosts: BlogPost[] = [
+  {
+    id: "1",
+    slug: "what-ethical-leadership-means-to-me",
+    title: "What Ethical Leadership Means to Me",
+    excerpt:
+      "A first-year scholar reflects on the moment a blood-pressure cuff taught her more about leadership than any lecture ever had.",
+    author: "Ama Serwaa Boateng",
+    authorRole: "Academy Scholar",
+    authorInstitution: "University of Cape Coast",
+    authorBio:
+      "Ama is a third-year medical student at the University of Cape Coast and a scholar in the Akomapa Ethical Leadership Academy. She helps coordinate the UCC Community Health Hub and writes about the everyday practice of care.",
+    category: "student-essay",
+    tags: ["ethical-leadership", "student-perspective", "academy"],
+    image: "/highlights/Akomapa-20.jpg",
+    date: "2026-05-24",
+    featured: true,
+    content: `
+<p>I used to think leadership was something you were given — a title, a badge, a seat at the front of the room. My first afternoon at the community hub taught me otherwise.</p>
+<p>A man in his sixties sat down across from me. He had walked forty minutes to reach us, not because he felt unwell, but because a neighbour had told him we would "check the pressure of the blood." When the cuff tightened around his arm, he looked away, embarrassed, and said quietly that no one had ever measured it before.</p>
+<h2>Care begins with listening</h2>
+<p>Nothing in my coursework had prepared me for that quiet. The number on the monitor mattered — it was high, and it needed attention — but what he needed first was to be taken seriously. To be asked about his work, his sleep, the salt in his soup. To be treated as a partner in his own health rather than a problem to be solved.</p>
+<blockquote>Ethical leadership is not the authority to act on people's behalf. It is the discipline to act <em>with</em> them.</blockquote>
+<h2>The habits we practice</h2>
+<p>Over the following weeks I began to notice the small disciplines that separated good intentions from good care:</p>
+<ul>
+  <li>Explaining a diagnosis in the language someone actually speaks at home.</li>
+  <li>Asking permission before touching, measuring, or advising.</li>
+  <li>Following up — because a referral no one can afford to reach is not a plan.</li>
+</ul>
+<p>None of these are dramatic. None of them will appear on an exam. But together they are the difference between a service that arrives and a partnership that lasts.</p>
+<p>I am still learning what ethical leadership means. What I know now is that it is built in these ordinary moments — one honest conversation, one kept promise at a time.</p>
+`.trim(),
+  },
+  {
+    id: "2",
+    slug: "good-intentions-are-not-enough",
+    title: "Good Intentions Are Not Enough: Rethinking Global Health Education",
+    excerpt:
+      "For decades we have sent well-meaning people into communities without asking whether the model itself was sound. A faculty mentor makes the case for a different approach.",
+    author: "Dr. Kwabena Mensah",
+    authorRole: "Faculty Mentor, Public Health",
+    authorInstitution: "University of Ghana",
+    authorBio:
+      "Dr. Mensah is a public health physician and faculty mentor with the Akomapa Ethical Leadership Academy. His work focuses on community-based models for non-communicable disease care and the ethics of global health training.",
+    category: "faculty-reflection",
+    tags: ["ethical-leadership", "global-health", "education"],
+    image: "/highlights/Akomapa-40.jpg",
+    date: "2026-04-18",
+    featured: false,
+    content: `
+<p>Every year, thousands of students travel across borders in the name of global health. They arrive with energy, compassion, and a genuine wish to help. And every year, a quieter question goes unasked: what happens to the community after they leave?</p>
+<h2>The limits of goodwill</h2>
+<p>Goodwill is necessary, but it is not a method. A short-term project that screens hundreds of people and then disappears can do real harm — raising expectations it cannot meet, and teaching communities that outsiders come, take their photographs, and go.</p>
+<p>The problem is rarely the people. It is the design. We have built an entire ecosystem of global health experience around the needs of the visitor rather than the health of the visited.</p>
+<blockquote>If a program cannot survive the departure of the students who started it, it was never really about the community.</blockquote>
+<h2>Designing for what remains</h2>
+<p>A different approach starts from a single commitment: build things that stay. At Akomapa that means three disciplines we ask every scholar to hold:</p>
+<ul>
+  <li><strong>Continuity</strong> — care that follows a patient across months, not a single afternoon.</li>
+  <li><strong>Local ownership</strong> — communities and partner institutions who lead, not simply host.</li>
+  <li><strong>Reciprocity</strong> — students who expect to learn as much as they contribute.</li>
+</ul>
+<p>None of this diminishes the idealism that brings young people to this work. It gives that idealism a structure worthy of it. Good intentions are where we begin. They are not where we are allowed to stop.</p>
+`.trim(),
+  },
+  {
+    id: "3",
+    slug: "the-silent-epidemic-ncds-new-model-of-care",
+    title: "The Silent Epidemic: Why NCDs Demand a New Model of Care",
+    excerpt:
+      "Hypertension and diabetes now kill more people than infectious disease in much of the world — yet the systems built to catch them were designed for a different era.",
+    author: "Akomapa Research Team",
+    authorRole: "Research & Innovation",
+    authorInstitution: "Akomapa Health",
+    authorBio:
+      "The Akomapa Research & Innovation team studies how student-powered community hubs can improve the detection and long-term management of non-communicable diseases.",
+    category: "article",
+    tags: ["ncds", "hypertension", "diabetes", "health-systems"],
+    image: "/highlights/Akomapa-28.jpg",
+    date: "2026-03-09",
+    featured: false,
+    content: `
+<p>They rarely announce themselves. A raised blood pressure produces no fever, no cough, no pain — until, years later, it produces a stroke. This is why non-communicable diseases, or NCDs, are so often called the silent epidemic.</p>
+<h2>A quiet reversal</h2>
+<p>Across much of sub-Saharan Africa, the leading causes of death have quietly shifted. Conditions like hypertension, diabetes, and heart disease now sit alongside — and increasingly ahead of — the infectious diseases that health systems were built to fight.</p>
+<p>The infrastructure has not caught up. Clinics designed for acute, episodic illness struggle with conditions that require patience, continuity, and trust over years.</p>
+<blockquote>You cannot treat a lifelong condition with a system built for a single visit.</blockquote>
+<h2>What a community model changes</h2>
+<p>A community-based model answers the specific shape of the NCD problem:</p>
+<ul>
+  <li><strong>Prevention and screening</strong> reach people where they are, before symptoms force a crisis.</li>
+  <li><strong>Referral</strong> connects the newly diagnosed to facilities equipped to confirm and treat.</li>
+  <li><strong>Longitudinal care</strong> keeps a relationship alive between visits, so a diagnosis becomes a plan rather than a scare.</li>
+</ul>
+<p>Students, working alongside faculty and community partners, are uniquely suited to this work. They have the time to listen, the training to measure, and — crucially — the continuity of a hub that returns week after week.</p>
+<p>The epidemic is silent. Our response does not have to be.</p>
+`.trim(),
+  },
+  {
+    id: "4",
+    slug: "what-partnership-really-means-a-community-elder",
+    title: "What Partnership Really Means: A Community Elder Speaks",
+    excerpt:
+      "\"We have had visitors before,\" she told us. \"You are the first who asked what we wanted.\" A conversation about trust, memory, and being treated as a partner.",
+    author: "Naa Adjeley Ankrah",
+    authorRole: "Community Leader",
+    authorInstitution: "Partner Community, Cape Coast",
+    authorBio:
+      "Naa Adjeley Ankrah is a community elder and organiser who has helped host and shape the Akomapa Community Health Hub in her neighbourhood.",
+    category: "community-voice",
+    tags: ["community-partnership", "trust", "reciprocal-learning"],
+    image: "/gallery/gallery-pic-6.jpg",
+    date: "2026-02-14",
+    featured: false,
+    content: `
+<p>When the students first came to speak with us, I did not expect much. We have had visitors before. They measure things, they take photographs, and then the road is quiet again.</p>
+<h2>A different first question</h2>
+<p>But these ones began differently. Before they set up a single table, they sat with us and asked what <em>we</em> wanted. Not what they had come to give — what we needed. That is a small thing to say and a large thing to do.</p>
+<blockquote>You are the first who asked what we wanted. That is why we opened our doors.</blockquote>
+<p>Partnership is not a word you can put on a banner. It is whether you return. It is whether the young woman who checked my neighbour's sugar remembers his name the following month. It is whether, when we raise a concern, anything actually changes.</p>
+<h2>What we offer in return</h2>
+<p>People imagine a community only receives. That is not how it works here. We teach these students things no classroom can:</p>
+<ul>
+  <li>How to speak to an elder so that he will listen.</li>
+  <li>Which households are struggling and which will quietly go without.</li>
+  <li>How trust is built slowly and lost in a single broken promise.</li>
+</ul>
+<p>If they keep coming, and keep listening, they will leave here better healers than they arrived. That is the exchange. That is partnership.</p>
+`.trim(),
+  },
+  {
+    id: "5",
+    slug: "reciprocal-learning-in-practice",
+    title: "Reciprocal Learning in Practice",
+    excerpt:
+      "A recorded conversation between faculty and scholars on what it means to learn from the communities we serve — and why the direction of that learning matters.",
+    author: "Akomapa Academy",
+    authorRole: "Ethical Leadership Academy",
+    authorInstitution: "Akomapa Health",
+    authorBio:
+      "The Akomapa Ethical Leadership Academy trains students and emerging health professionals to lead through community partnership, reflection, and reciprocal learning.",
+    category: "recorded-talk",
+    tags: ["reciprocal-learning", "academy", "ethical-leadership"],
+    image: "/highlights/Akomapa-47.jpg",
+    videoUrl: "https://www.youtube.com/watch?v=ysz5S6PUM-U",
+    date: "2026-01-20",
+    featured: false,
+    content: `
+<p>In this recorded session, Academy faculty and scholars sit down to unpack one of the ideas at the heart of the Akomapa model: that learning in global health should move in both directions.</p>
+<h2>The conversation in brief</h2>
+<p>Too often, "training" describes a one-way transfer — expertise flowing from the institution to the community. Reciprocal learning insists on something harder and more honest: that the community is also a teacher, and that the student who cannot learn from it is not yet ready to serve it.</p>
+<blockquote>The question is not only what we bring to a community, but what we are willing to be changed by.</blockquote>
+<h2>What you will hear</h2>
+<ul>
+  <li>How scholars describe the moments that reshaped how they practice.</li>
+  <li>Why faculty treat humility as a clinical skill, not a personality trait.</li>
+  <li>Practical ways hubs build reflection into every visit.</li>
+</ul>
+<p>Watch the full conversation above, and read the companion essays from our scholars to see these ideas at work in the field.</p>
+`.trim(),
+  },
+];
+
+/** All posts, newest first. */
+export function getAllBlogPosts(): BlogPost[] {
+  return [...blogPosts].sort(
+    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+  );
+}
+
+/** The most recent featured post, or the most recent post as a fallback. */
+export function getFeaturedPost(): BlogPost | undefined {
+  const sorted = getAllBlogPosts();
+  return sorted.find((post) => post.featured) ?? sorted[0];
+}
+
+/** Find a single post by its slug. */
+export function getBlogPostBySlug(slug: string): BlogPost | undefined {
+  return blogPosts.find((post) => post.slug === slug);
+}
+
+/**
+ * Related posts for a given slug: same category first (newest first),
+ * backfilled with other recent posts up to `limit`.
+ */
+export function getRelatedPosts(
+  slug: string,
+  category: BlogCategory,
+  limit = 3,
+): BlogPost[] {
+  const others = getAllBlogPosts().filter((post) => post.slug !== slug);
+  const sameCategory = others.filter((post) => post.category === category);
+  const rest = others.filter((post) => post.category !== category);
+  return [...sameCategory, ...rest].slice(0, limit);
+}
+
+/** Ordered categories that actually appear in the current post set. */
+export function getActiveCategories() {
+  const present = new Set(blogPosts.map((post) => post.category));
+  return BLOG_CATEGORIES.filter((category) => present.has(category.value));
+}

--- a/src/lib/__tests__/types.test.ts
+++ b/src/lib/__tests__/types.test.ts
@@ -254,7 +254,7 @@ describe("rebrand data model contracts", () => {
       "futureValue" | "futureYear" | "icon"
     >();
     expectTypeOf<OptionalKeys<BlogPost>>().toEqualTypeOf<
-      "authorImage" | "image" | "videoUrl"
+      "authorInstitution" | "authorBio" | "authorImage" | "image" | "videoUrl"
     >();
   });
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -268,6 +268,10 @@ export interface BlogPost {
   content: string;
   author: string;
   authorRole: string;
+  /** Institution or community the author is affiliated with (shown in bylines). */
+  authorInstitution?: string;
+  /** Short author biography rendered in the article's author section. */
+  authorBio?: string;
   authorImage?: string;
   category:
     | "student-essay"

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -19,3 +19,15 @@ export function formatDate(dateString: string): string {
     day: 'numeric'
   }).format(date);
 }
+
+/**
+ * Estimates reading time from an HTML (or plain-text) string.
+ * Strips tags, counts words, and assumes ~200 words per minute.
+ * Returns a label like "4 min read" (always at least 1 minute).
+ */
+export function readingTime(content: string): string {
+  const text = content.replace(/<[^>]*>/g, ' ');
+  const words = text.split(/\s+/).filter(Boolean).length;
+  const minutes = Math.max(1, Math.round(words / 200));
+  return `${minutes} min read`;
+}


### PR DESCRIPTION
### Summary
Replaces the placeholder /blog and /blog/[slug] shells with a real, data-driven Thought Leadership section for publishing student essays, faculty reflections, articles, community voices, and recorded talks. The feature mirrors the existing news system's architecture, brand tokens, and motion conventions so it feels native to the site — part of the broader rebrand toward "a student-powered movement developing ethical global health leaders."

### What's included
Listing page (/blog)

- Gradient hero with headline/subheadline and live post count
- Prominent, visually distinct featured post (2-column card with hero image, category, date, reading time, author byline)
- Category filter pills (All, Student Essays, Faculty Reflections, Articles, Community Voices, Recorded Talks) with client-side filtering and aria-selected tabs
- Responsive card grid — 3 columns (desktop) / 2 (tablet) / 1 (mobile) — with staggered scroll-reveal and an empty state
- Optional ?author= view linking "more from this author," and a closing CTA band

Article page (/blog/[slug])

- Centered editorial header: category badge, title, author (avatar + role + institution), date, reading time
- Full-width hero image (with YouTube embed for recorded talks)
- Rich body via Tailwind Typography (prose dark:prose-invert) supporting headings, lists, blockquotes, and images
- Tags, share row (X, LinkedIn, copy-link), author bio, related posts (same category first), and "Join the conversation" → /get-involved
- generateStaticParams (all slugs pre-rendered), article OpenGraph metadata, and notFound() for unknown slugs

Navigation

"Thought Leadership" added to the About dropdown (desktop + mobile) and footer initiatives
Breadcrumb labels the blog segment "Thought Leadership"
Technical notes
Builds on the existing BlogPost type (added optional authorInstitution / authorBio); single source-of-truth category config with brand-tinted badges in src/data/blog.ts
Article content is trusted, first-party authored HTML rendered in a prose container — no markdown-parser dependency added
New readingTime() util in src/lib/utils.ts — no new packages
Author avatars use a brand monogram fallback (no fabricated portraits); imagery reuses existing real photos via the ImageKit Image wrapper
Listing kept SEO-friendly: server page exports metadata and renders a client BlogListing (Suspense-wrapped for useSearchParams)
Reuses shared primitives: FadeIn/FadeInStagger, getAnnouncementPosterSrc/parseVideoUrl, formatDate, cn

Files
New: src/data/blog.ts; src/components/blog/* (Hero, FeaturedPost, CategoryFilter, Grid, Card, Post, AuthorBio, RelatedPosts, AuthorAvatar, BlogListing, barrel)
Rewritten: src/app/(main)/blog/page.tsx, src/app/(main)/blog/[slug]/page.tsx
Edited: src/lib/types.ts, src/lib/utils.ts, src/lib/__tests__/types.test.ts, Header.tsx, Footer.tsx, Breadcrumb.tsx

Verification
tsc --noEmit — clean
next lint — 0 warnings/errors
next build — 57 static pages; /blog static, all 5 article slugs pre-rendered
Runtime: /blog and valid slugs → 200, unknown slug → 404
vitest run — 61/61 passing
Responsive (3/2/1 grid, stacking featured card, scaling hero) and full dark-mode coverage verified across cards, badges, prose, and CTAs

Closes #115 