### PR TITLE
Rebrand/site wide language audit and terminology replacement

### DIFF
--- a/src/app/(main)/about/team/page.tsx
+++ b/src/app/(main)/about/team/page.tsx
@@ -102,7 +102,7 @@ const executiveTeam: SpotlightMember[] = [
     image: "/images/team/esi-bon-berkoh.jpg",
     email: "esibberkoh@gmail.com",
     linkedin: "https://linkedin.com/in/esiberkoh",
-    bio: "Esi Berkoh is a final-year medical student at the University of Cape Coast School of Medical Sciences. She holds a BSc in Biology from Mount Holyoke College and an MSc in Infection, Immunity & Human Disease from the University of Leeds. As Vice President and co-founder of Akomapa Health, she coordinates clinic operations, supports leadership, and organizes outreach programs to serve underserved communities while gaining hands-on experience and leadership training."
+    bio: "Esi Berkoh is a final-year medical student at the University of Cape Coast School of Medical Sciences. She holds a BSc in Biology from Mount Holyoke College and an MSc in Infection, Immunity & Human Disease from the University of Leeds. As Vice President and co-founder of Akomapa Health, she coordinates clinic operations, supports leadership, and organizes community engagement programs to serve underserved communities while gaining hands-on experience and leadership training."
   },
   // {
   //   name: "Bismark Amoh",

--- a/src/app/(main)/about/team/page.tsx
+++ b/src/app/(main)/about/team/page.tsx
@@ -548,7 +548,7 @@ export default function TeamPage() {
             </h1>
             <p className="text-base sm:text-lg lg:text-sm xl:text-base 2xl:text-lg text-[#FCFAEF]/80 mb-6 sm:mb-8">
               From Cape Coast to Yale and UCLA, Akomapa leaders blend academic rigor, community roots,
-              and relentless hope to build a student-run model of care that is ethical, joyful, and
+              and relentless hope to build a student-powered model of care that is ethical, joyful, and
               unstoppable.
             </p>
             <FadeInStagger className="grid grid-cols-1 sm:grid-cols-3 gap-3 sm:gap-4 lg:gap-3 xl:gap-4 mb-6 sm:mb-8" staggerDelay={0.1}>

--- a/src/app/(main)/clinics/akomapa-ucc/page.tsx
+++ b/src/app/(main)/clinics/akomapa-ucc/page.tsx
@@ -12,7 +12,7 @@ import { Button } from "@/components/ui/button";
 const impactHighlights = [
   {
     value: "1,000+",
-    label: "Patients Served",
+    label: "Community Members Reached",
     description:
       "Neighbors receiving free screening, counseling, and follow-up through our community-based clinics.",
     accentColor: "#0097b2"

--- a/src/app/(main)/clinics/akomapa-ucc/page.tsx
+++ b/src/app/(main)/clinics/akomapa-ucc/page.tsx
@@ -297,7 +297,7 @@ export default function UCCClinicPage() {
               transition={{ delay: 0.2, duration: 0.8, ease: "easeOut" }}
               className="text-base sm:text-lg md:text-2xl text-[#FCFAEF]/85 font-light max-w-3xl"
             >
-              The Akomapa Student-Run Clinic at the University of Cape Coast is the first in a
+              The Akomapa Student-Powered Clinic at the University of Cape Coast is the first in a
               growing global network of student-powered, expert-supervised primary care clinics
               delivering free, community-based screening and education for chronic diseases.
             </motion.p>

--- a/src/app/(main)/clinics/akomapa-ug/page.tsx
+++ b/src/app/(main)/clinics/akomapa-ug/page.tsx
@@ -425,7 +425,7 @@ export default function UGClinicPage() {
               </h2>
               <div className="space-y-5 text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed">
                 <p>
-                  The Akomapa Student-Run Clinic at the University of Ghana brings our community-based
+                  The Akomapa Student-Powered Clinic at the University of Ghana brings our community-based
                   preventative care model to the Greater Accra Region, expanding access for patients and
                   creating transformative learning for students.
                 </p>

--- a/src/app/(main)/clinics/page.tsx
+++ b/src/app/(main)/clinics/page.tsx
@@ -63,8 +63,8 @@ const impactMetrics = [
   {
     value: 1000,
     suffix: "+",
-    label: "Patients Served",
-    description: "Neighbors receiving chronic disease screening, counseling, and follow-up through our free community clinics.",
+    label: "Community Members Reached",
+    description: "Community members receiving chronic disease screening, counseling, and follow-up through our free community health hubs.",
     color: "#0097b2"
   },
   {

--- a/src/app/(main)/donate/page.tsx
+++ b/src/app/(main)/donate/page.tsx
@@ -334,7 +334,7 @@ export default function PartnerPage() {
                       className="bg-gradient-to-br from-[#eeba2b]/20 to-[#eeba2b]/10 dark:from-[#eeba2b]/30 dark:to-[#eeba2b]/20 rounded-xl p-4 sm:p-6 text-center border border-[#eeba2b]/30"
                     >
                       <div className="text-3xl sm:text-4xl md:text-5xl font-bold text-[#eeba2b] dark:text-[#F5C94D] mb-2">50+</div>
-                      <div className="text-xs sm:text-sm text-[#2F3332] dark:text-[#E6E7E7] font-medium">Patients Served Monthly</div>
+                      <div className="text-xs sm:text-sm text-[#2F3332] dark:text-[#E6E7E7] font-medium">Community Members Reached Monthly</div>
                     </motion.div>
                     <motion.div
                       initial={{ opacity: 0, scale: 0.9 }}

--- a/src/app/(main)/partnerships/corporate-sponsorship/page.tsx
+++ b/src/app/(main)/partnerships/corporate-sponsorship/page.tsx
@@ -19,7 +19,7 @@ const highlights = [
       "Support the Akomapa Academy and leadership development programs that prepare the next generation of ethical health professionals.",
   },
   {
-    title: "Community Outreach",
+    title: "Community Engagement",
     description:
       "Enable health education, NCD screening campaigns, and community engagement initiatives across our partner sites.",
   },

--- a/src/app/(main)/programs/akomapa-foods/page.tsx
+++ b/src/app/(main)/programs/akomapa-foods/page.tsx
@@ -227,7 +227,7 @@ export default function FoodsPage() {
                   Health starts in kitchens, markets, and farms. When communities grow and sell nutritious food, they also strengthen the very clinics that care for them.
                 </p>
                 <p>
-                  By linking agriculture and nutrition to student-run clinics, Akomapa ensures communities receive care and co-own the means to sustain it for generations.
+                  By linking agriculture and nutrition to student-powered community health hubs, Akomapa ensures communities receive care and co-own the means to sustain it for generations.
                 </p>
               </div>
             </motion.div>

--- a/src/app/(main)/programs/akomapa-ghip/page.tsx
+++ b/src/app/(main)/programs/akomapa-ghip/page.tsx
@@ -58,7 +58,7 @@ const learningComponents = [
 
 const whatToExpect = [
   {
-    title: "Student-Run Clinics",
+    title: "Student-Powered Community Health Hubs",
     description: "Join Akomapa clinics delivering free screenings, counseling, and health education alongside local student teams.",
     accentColor: "#0097b2"
   },

--- a/src/app/(main)/programs/akomapa-ghltp/page.tsx
+++ b/src/app/(main)/programs/akomapa-ghltp/page.tsx
@@ -87,7 +87,7 @@ const learningBenefits = [
   {
     id: "benefit-2",
     title: "Case-Based Learning",
-    description: "Case-based learning from active student-run clinics",
+    description: "Case-based learning from active student-powered community health hubs",
     color: "#eeba2b"
   },
   {

--- a/src/app/(main)/programs/akomapa-network/page.tsx
+++ b/src/app/(main)/programs/akomapa-network/page.tsx
@@ -107,7 +107,7 @@ const partnerClinics = [
   {
     name: "Neighborhood Health Project",
     location: "New Haven, USA",
-    description: "A longstanding student-run organization advancing community health equity in Connecticut.",
+    description: "A longstanding student-powered organization advancing community health equity in Connecticut.",
     href: "https://nhp.sites.yale.edu/",
     logo: "/images/partners/nhp-logo.png",
     accentColor: "#eeba2b",
@@ -183,7 +183,7 @@ export default function AkomapaNetworkPage() {
               transition={{ delay: 0.2, duration: 0.8, ease: "easeOut" }}
               className="text-base sm:text-lg md:text-2xl text-[#FCFAEF]/85 font-light max-w-3xl"
             >
-              A global community of student-run clinics, universities, and mentors working together to reimagine how healthcare is delivered and taught.
+              A global community of student-powered clinics, universities, and mentors working together to reimagine how healthcare is delivered and taught.
             </motion.p>
             <motion.div
             initial={{ opacity: 0, y: 40 }}
@@ -236,7 +236,7 @@ export default function AkomapaNetworkPage() {
               </h2>
               <div className="space-y-5 text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed">
                 <p>
-                  The Akomapa Network is a global community of student-run clinics, universities, and mentors working together to reimagine how healthcare is delivered and taught.
+                  The Akomapa Network is a global community of student-powered clinics, universities, and mentors working together to reimagine how healthcare is delivered and taught.
                 </p>
                 <p>
                   We connect student-powered, expert-supervised clinics from across Africa and the United States — uniting them through shared learning, leadership training, and collaborative innovation.
@@ -287,7 +287,7 @@ export default function AkomapaNetworkPage() {
                 Our Vision
               </h2>
               <p className="text-lg md:text-xl text-[#FCFAEF]/90 leading-relaxed">
-                To build a global learning ecosystem where student-run clinics don&apos;t work in isolation but as part of a connected movement — sharing data, stories, and strategies that strengthen both care delivery and education.
+                To build a global learning ecosystem where student-powered clinics don&apos;t work in isolation but as part of a connected movement — sharing data, stories, and strategies that strengthen both care delivery and education.
               </p>
               <p className="text-base md:text-lg text-[#FCFAEF]/85 leading-relaxed">
                 We envision a world where a student team in Ghana can learn from one in Chicago, where a New Haven community project can inspire a rural screening model, and where young leaders everywhere are equipped to bridge the gap between knowledge and action.
@@ -521,7 +521,7 @@ export default function AkomapaNetworkPage() {
                 Every clinic becomes both a site of care and a site of learning, where students grow as clinicians, leaders, and changemakers while improving the health of their communities.
               </p>
               <p className="font-semibold text-[#FCFAEF]">
-                By linking student-run clinics into one connected system, we&apos;re making community care smarter, stronger, and sustainable — driven by evidence, compassion, and shared purpose.
+                By linking student-powered clinics into one connected system, we&apos;re making community care smarter, stronger, and sustainable — driven by evidence, compassion, and shared purpose.
               </p>
             </motion.div>
           </div>

--- a/src/app/(main)/programs/page.tsx
+++ b/src/app/(main)/programs/page.tsx
@@ -27,7 +27,7 @@ const programs: Program[] = [
   {
     id: 1,
     title: "Akomapa Clinics",
-    description: "We establish interprofessional, expert-supervised clinics built in partnership with local health authorities, traditional leaders, and community members. These student-run clinics deliver free, community-based care focused on the early detection and management of non-communicable diseases (NCDs), serving as both real-world classrooms for students and lifelines for underserved communities.",
+    description: "We establish interprofessional, expert-supervised clinics built in partnership with local health authorities, traditional leaders, and community members. These student-powered community health hubs deliver free, community-based care focused on the early detection and management of non-communicable diseases (NCDs), serving as both real-world classrooms for students and lifelines for underserved communities.",
     details: [
       "Interprofessional student teams coordinate care across medical, nursing, pharmacy, nutrition, and public health disciplines",
       "Expert supervision ensures every patient encounter meets the highest clinical and ethical standards",
@@ -50,9 +50,9 @@ const programs: Program[] = [
   {
     id: 2,
     title: "The Akomapa Network",
-    description: "Our global community of practice connects Akomapa chapters with partner student-run clinics around the world—like SHAWCO, South Side SRFC, and Yale's Neighborhood Health Project—to share best practices, mentorship, and collaborative research. Together, we're turning local innovations into global impact.",
+    description: "Our global community of practice connects Akomapa chapters with partner student-powered clinics around the world—like SHAWCO, South Side SRFC, and Yale's Neighborhood Health Project—to share best practices, mentorship, and collaborative research. Together, we're turning local innovations into global impact.",
     details: [
-      "Connects student-run clinics across continents to share innovations and learnings",
+      "Connects student-powered clinics across continents to share innovations and learnings",
       "Facilitates mentorship exchanges between experienced and emerging clinic leaders",
       "Enables collaborative research that strengthens evidence for student-powered care",
       "Builds a global movement of health professionals committed to equity and access"
@@ -142,7 +142,7 @@ const programs: Program[] = [
   {
     id: 6,
     title: "Akomapa Foods & Stores",
-    description: "The Akomapa Foods & Stores Initiative is the sustainability arm of the Akomapa Health model—connecting food security, economic empowerment, and healthcare access into one self-sustaining ecosystem. We believe that health doesn't start in hospitals; it starts in homes, kitchens, and markets. By linking agriculture and nutrition to our student-run clinics, Akomapa creates a cycle where communities not only receive care but also co-own the means to sustain it.",
+    description: "The Akomapa Foods & Stores Initiative is the sustainability arm of the Akomapa Health model—connecting food security, economic empowerment, and healthcare access into one self-sustaining ecosystem. We believe that health doesn't start in hospitals; it starts in homes, kitchens, and markets. By linking agriculture and nutrition to our student-powered community health hubs, Akomapa creates a cycle where communities not only receive care but also co-own the means to sustain it.",
     details: [
       "Community farms and food stores that make healthy, affordable food accessible to families",
       "Revenue from food sales directly supports clinic operations, creating a self-sustaining model",
@@ -176,7 +176,7 @@ const impactMetrics = [
     value: 15,
     suffix: "+",
     label: "Partner Clinics",
-    description: "Student-run clinics connected through the Akomapa Network worldwide",
+    description: "Student-powered clinics connected through the Akomapa Network worldwide",
     color: "#eeba2b"
   },
   {
@@ -222,7 +222,7 @@ export default function ProgramsPage() {
               transition={{ delay: 0.15, duration: 0.8, ease: "easeOut" }}
               className="text-base sm:text-lg md:text-2xl text-[#FCFAEF]/80 font-light max-w-3xl"
             >
-              At Akomapa, we&apos;re reimagining how the next generation of health professionals learn, lead, and serve. Through our integrated programs, we build student-run clinics, leadership pathways, and global partnerships that make care more accessible—while preparing students to transform the health systems of tomorrow.
+              At Akomapa, we&apos;re reimagining how the next generation of health professionals learn, lead, and serve. Through our integrated programs, we build student-powered community health hubs, leadership pathways, and global partnerships that make care more accessible—while preparing students to transform the health systems of tomorrow.
             </motion.p>
           </div>
 

--- a/src/components/community-hubs/HubCard.tsx
+++ b/src/components/community-hubs/HubCard.tsx
@@ -83,7 +83,7 @@ export default function HubCard({ hub }: HubCardProps) {
             <div>
               <dt className="text-[#2F3332]/60 dark:text-[#E6E7E7]/60">Served</dt>
               <dd className="font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
-                {hub.metrics.patientsServed.toLocaleString()}
+                {hub.metrics.communityMembersServed.toLocaleString()}
               </dd>
             </div>
             <div>

--- a/src/components/community-hubs/HubMetrics.tsx
+++ b/src/components/community-hubs/HubMetrics.tsx
@@ -6,7 +6,7 @@ import { PublicSection, PublicSectionHeader, SurfaceCard } from "@/components/sh
 import type { CommunityHub } from "@/lib/types";
 
 const metricConfig = [
-  { key: "patientsServed" as const, label: "Community members served" },
+  { key: "communityMembersServed" as const, label: "Community members served" },
   { key: "studentsTrained" as const, label: "Students trained" },
   { key: "communitiesReached" as const, label: "Communities reached" },
   { key: "partnersEngaged" as const, label: "Partners engaged" },

--- a/src/components/contact/ContactForm.tsx
+++ b/src/components/contact/ContactForm.tsx
@@ -29,7 +29,7 @@ function ContactFormContent() {
     const type = searchParams.get('type');
     if (type) {
       const partnershipTypes = {
-        'outreach': 'Host Outreach Programs',
+        'outreach': 'Host Community Engagement Programs',
         'partnership': 'Strategic Partnerships',
         'donation': 'Monetary Sponsorship'
       };
@@ -194,7 +194,7 @@ function ContactFormContent() {
             </SelectTrigger>
             <SelectContent className="bg-[#FCFAEF] dark:bg-[#1C1F1E] text-[#1C1F1E] dark:text-[#FCFAEF]">
               <SelectItem value="Monetary Sponsorship" className="cursor-pointer">Monetary Sponsorship</SelectItem>
-              <SelectItem value="Host Outreach Programs" className="cursor-pointer">Host Outreach Programs</SelectItem>
+              <SelectItem value="Host Community Engagement Programs" className="cursor-pointer">Host Community Engagement Programs</SelectItem>
               <SelectItem value="Strategic Partnerships" className="cursor-pointer">Strategic Partnerships</SelectItem>
               <SelectItem value="General Inquiry" className="cursor-pointer">General Inquiry</SelectItem>
             </SelectContent>

--- a/src/components/donate/CorporateCTA.tsx
+++ b/src/components/donate/CorporateCTA.tsx
@@ -13,7 +13,7 @@ export default function CorporateCTA() {
           <p className="mb-2 font-semibold text-[#F5C94D]">CORPORATE PARTNERSHIPS</p>
           <h2 className="mb-3 text-3xl font-bold">Scale your impact with Akomapa</h2>
           <p className="mb-6 text-[#FCFAEF]/85">
-            Partner with us through financial support, medication donations, and outreach collaborations that expand equitable care.
+            Partner with us through financial support, medication donations, and community engagement collaborations that expand equitable care.
           </p>
           <Button asChild variant="amber">
             <Link

--- a/src/components/home/LocationSection.tsx
+++ b/src/components/home/LocationSection.tsx
@@ -68,7 +68,7 @@ export default function LocationsSection() {
             Local Impact with National Potential
           </h3>
           <p className="text-lg text-[#2F3332] dark:text-[#E6E7E7]">
-            We&apos;re piloting our first student-run clinics in Abeadze Domenase and Abura in partnership 
+            We&apos;re piloting our first student-powered community health hubs in Abeadze Domenase and Abura in partnership 
             with the University of Cape Coast College of Health Sciences. These sites serve as 
             epicenters for innovation, care, and training.
           </p>
@@ -213,7 +213,7 @@ export default function LocationsSection() {
         <div className="text-center mt-12">
           <p className="text-[#2F3332] dark:text-[#E6E7E7] mb-6 max-w-2xl mx-auto">
             With successful implementation in our pilot locations, we aim to expand our model across Ghana, 
-            creating a network of student-run clinics that serve communities and train the next generation of healthcare leaders.
+            creating a network of student-powered community health hubs that serve communities and train the next generation of healthcare leaders.
           </p>
           {/* <Button className="bg-[#eeba2b] hover:bg-[#0097b2] text-[#FCFAEF]">
             <Link href="/about/expansion" className="flex items-center">

--- a/src/components/home/PartnersSection.tsx
+++ b/src/components/home/PartnersSection.tsx
@@ -61,7 +61,7 @@ export default function PartnersSection() {
         </HomeHeading>
         <p className="mx-auto mt-5 max-w-xl text-base leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80 md:text-lg">
           We work with leading universities, ministries of health, and
-          student-run clinics worldwide to generate the evidence that powers
+          student-powered clinics worldwide to generate the evidence that powers
           Akomapa&rsquo;s model.
         </p>
       </div>

--- a/src/components/home/ResearchSection.tsx
+++ b/src/components/home/ResearchSection.tsx
@@ -109,7 +109,7 @@ export default function ResearchSection() {
           eyebrow="Our Research & Academic Partners"
           eyebrowTone="gold"
           title="Designed with Evidence. Driven by Collaboration."
-          description="In collaboration with leading universities, health systems, and student-run clinics worldwide, we generate the research and real-world evidence that powers Akomapa's model."
+          description="In collaboration with leading universities, health systems, and student-powered clinics worldwide, we generate the research and real-world evidence that powers Akomapa's model."
           className="mb-16"
           titleClassName="text-[#FCFAEF] dark:text-[#FCFAEF] md:text-4xl"
           descriptionClassName="text-[#FCFAEF]/85"

--- a/src/data/community-hubs.ts
+++ b/src/data/community-hubs.ts
@@ -201,7 +201,7 @@ export const communityHubs: CommunityHub[] = [
     status: "active",
     missions: hubMissions,
     metrics: {
-      patientsServed: 3000,
+      communityMembersServed: 3000,
       studentsTrained: 250,
       communitiesReached: 2,
       partnersEngaged: 3,
@@ -230,7 +230,7 @@ export const communityHubs: CommunityHub[] = [
     status: "in-development",
     missions: hubMissions,
     metrics: {
-      patientsServed: 0,
+      communityMembersServed: 0,
       studentsTrained: 50,
       communitiesReached: 0,
       partnersEngaged: 4,
@@ -259,7 +259,7 @@ export const communityHubs: CommunityHub[] = [
     status: "future",
     missions: hubMissions,
     metrics: {
-      patientsServed: 0,
+      communityMembersServed: 0,
       studentsTrained: 0,
       communitiesReached: 0,
       partnersEngaged: 3,

--- a/src/data/donation.ts
+++ b/src/data/donation.ts
@@ -36,18 +36,18 @@ export const impactHighlights = [
     icon: "training",
   },
   {
-    title: "Research and Outreach",
+    title: "Research and Community Engagement",
     description:
-      "Every contribution strengthens research-backed outreach programs that scale preventive care.",
+      "Every contribution strengthens research-backed community engagement programs that scale preventive care.",
     icon: "research",
   },
 ];
 
 export const transparencyAllocations: TransparencyAllocation[] = [
   {
-    label: "Clinics",
+    label: "Community Health Hubs",
     percentage: 60,
-    description: "Patient screenings, medications, and clinic-day operations",
+    description: "Community screenings, medications, and hub operations",
     colorClass: "text-lapis dark:text-[#66C4DC]",
     barClass: "bg-lapis",
   },

--- a/src/lib/__tests__/types.test.ts
+++ b/src/lib/__tests__/types.test.ts
@@ -113,7 +113,7 @@ describe("rebrand data model contracts", () => {
     };
 
     const metrics: HubMetrics = {
-      patientsServed: 100,
+      communityMembersServed: 100,
       studentsTrained: 25,
       communitiesReached: 6,
       partnersEngaged: 4,
@@ -186,8 +186,8 @@ describe("rebrand data model contracts", () => {
     };
 
     const impactMetric: ImpactMetric = {
-      id: "patients-served",
-      label: "Patients served",
+      id: "community-members-reached",
+      label: "Community members reached",
       currentValue: "100+",
     };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -178,7 +178,7 @@ export interface InnovationItem {
 }
 
 export interface HubMetrics {
-  patientsServed: number;
+  communityMembersServed: number;
   studentsTrained: number;
   communitiesReached: number;
   partnersEngaged: number;


### PR DESCRIPTION
### Summary
- Replace patientsServed interface property with communityMembersServed across the HubMetrics type, data files, and all consuming components
- Replace all "Patients Served" user-facing labels with "Community Members Reached" on clinics and donate pages
- Replace 21 instances of "student-run" with "student-powered" across programs, clinics, team, and home component pages (preserving the proper noun "South Side Student-Run Free Clinic")
- Replace "outreach" with "community engagement" in organizational contexts (donation categories, corporate sponsorship, contact form, team bios)
- Update donation transparency label from "Clinics" to "Community Health Hubs"

### Files Changed (22 files)
Types & Data:

- src/lib/types.ts — Rename patientsServed → communityMembersServed in HubMetrics interface
- src/data/community-hubs.ts — Update all 3 hub data instances
- src/data/donation.ts — "Research and Outreach" → "Research and Community Engagement"; "Clinics" → "Community Health Hubs"

### Components:

- src/components/community-hubs/HubMetrics.tsx — Update metric config key
- src/components/community-hubs/HubCard.tsx — Update property access
- src/components/home/PartnersSection.tsx — "student-run" → "student-powered"
- src/components/home/ResearchSection.tsx — "student-run" → "student-powered"
- src/components/home/LocationSection.tsx — "student-run clinics" → "student-powered community health hubs" (2 instances)
- src/components/contact/ContactForm.tsx — "Host Outreach Programs" → "Host Community Engagement Programs"
- src/components/donate/CorporateCTA.tsx — "outreach collaborations" → "community engagement collaborations"

### Pages:

- src/app/(main)/programs/page.tsx — 6 "student-run" → "student-powered" replacements
- src/app/(main)/programs/akomapa-network/page.tsx — 5 replacements
- src/app/(main)/programs/akomapa-ghltp/page.tsx — 1 replacement
- src/app/(main)/programs/akomapa-ghip/page.tsx — "Student-Run Clinics" → "Student-Powered Community Health Hubs"
- src/app/(main)/programs/akomapa-foods/page.tsx — 1 replacement
- src/app/(main)/clinics/page.tsx — "Patients Served" → "Community Members Reached"
- src/app/(main)/clinics/akomapa-ucc/page.tsx — Label + "Student-Run" → "Student-Powered"
- src/app/(main)/clinics/akomapa-ug/page.tsx — "Student-Run" → "Student-Powered"
- src/app/(main)/donate/page.tsx — "Patients Served Monthly" → "Community Members Reached Monthly"
- src/app/(main)/about/team/page.tsx — "student-run" → "student-powered" + "outreach" → "community engagement"
- src/app/(main)/partnerships/corporate-sponsorship/page.tsx — "Community Outreach" → "Community Engagement"

### Tests:

- src/lib/__tests__/types.test.ts — Update test data for renamed property and label

#### Acceptance Criteria Verified
- Zero instances of "student-run clinic" (only proper noun "South Side Student-Run Free Clinic" remains)
- Zero instances of patientsServed
- Zero instances of "Patients Served" / "patients served"
- Zero instances of "volunteerism", "mission work", "giving back", "less fortunate", "service trip"
- "Outreach" replaced with "community engagement" where it refers to Akomapa's organizational work
- "Student-powered" remains visible and prominent
- No accidental replacements in technical/code contexts
- npm run build passes
- npx tsc --noEmit passes
- npm run lint passes (zero warnings)
- npm run test passes (17 test files, 65 tests)

#### Test Plan
- TypeScript compiles without errors
- ESLint passes with --max-warnings 0
- All 65 unit tests pass
- Next.js production build succeeds (55 static pages generated)
- Grep verification confirms no deprecated terms remain
- Visual review of key pages: /, /programs, /community-hubs, /donate, /about/team, /clinics
- Verify contact form dropdown shows "Host Community Engagement Programs"
- Verify donation page shows "Community Members Reached Monthly" and "Community Health Hubs" allocation

Closes #120 