### PR TITLE
ux(get-involved): align copy and CTAs after /join removal

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -15,15 +15,23 @@ The test suite (`pages-render.spec.ts`) performs basic smoke tests on all main p
 - `/` (Home)
 - `/about`
 - `/about/team`
+- `/philosophy`
+- `/academy`
 - `/programs`
-- `/clinics`
+- `/community-hubs` (legacy `/clinics` redirects here)
+- `/ncd-impact`
+- `/impact`
 - `/research`
 - `/contact`
 - `/donate`
-- `/join`
-- `/partner`
+- `/get-involved` (legacy `/join` redirects here)
+- `/partnerships` (legacy `/partner` redirects here)
 - `/roadmap`
 - `/resources`
+- `/news`
+- `/blog`
+- `/privacy`
+- `/terms`
 
 ## Running Tests
 

--- a/src/app/(main)/get-involved/page.tsx
+++ b/src/app/(main)/get-involved/page.tsx
@@ -18,8 +18,8 @@ export const metadata: Metadata = {
   },
   keywords: [
     "get involved",
-    "volunteer",
     "student leadership",
+    "engagement pathways",
     "faculty mentorship",
     "global health research",
     "partnerships",

--- a/src/data/get-involved.ts
+++ b/src/data/get-involved.ts
@@ -10,10 +10,10 @@ import { LEADERSHIP_APP_FORM_URL } from "@/config/links";
 // ---------------------------------------------------------------------------
 
 export const getInvolvedHero = {
-  eyebrow: "Join the Movement",
+  eyebrow: "Engagement Pathways",
   title: "Get Involved",
   subtitle:
-    "Join Akomapa and help build a new model for ethical global health leadership. There are many ways to contribute.",
+    "Choose a pathway that matches your goals — student leadership, Academy training, faculty mentorship, research, partnerships, or financial support.",
   image: {
     src: "/highlights/Akomapa-62.jpg",
     alt: "Akomapa student leaders and clinicians serving community members",


### PR DESCRIPTION
## Summary
- Audit `/get-involved` pathway copy and CTA alignment after the legacy `/join` page was removed
- Update hero subtitle to describe distinct engagement pathways
- Refresh SEO keywords and sync `e2e/README.md` with current routes (`/get-involved`, `/partnerships`, etc.)

## Test plan
- [x] Visit `/get-involved` — hero copy and pathway CTAs are consistent
- [x] Visit `/join` — redirects to `/get-involved`
- [x] Review updated e2e docs page list

Closes #91