### PR TITLE
fix(a11y): use Button asChild for link-styled CTAs

### DIFF
--- a/src/app/(main)/roadmap/page.tsx
+++ b/src/app/(main)/roadmap/page.tsx
@@ -299,36 +299,33 @@ export default function RoadmapPage() {
               Whether you&apos;re a donor, global health ally, or community partner — we invite you to walk this road with us.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Button 
+              <Button
+                asChild
                 size="lg"
                 className="bg-[#FCFAEF] text-[#0097b2] hover:bg-[#FCFAEF]/90 font-semibold"
               >
-                <Link href="/partnerships">
-                  <span className="flex items-center">
-                    Partner With Us <ArrowRight size={20} className="ml-2" />
-                  </span>
+                <Link href="/partnerships" className="flex items-center">
+                  Partner With Us <ArrowRight size={20} className="ml-2" />
                 </Link>
               </Button>
-              <Button 
+              <Button
+                asChild
                 size="lg"
                 className="bg-[#eeba2b] text-[#FCFAEF] hover:bg-[#F5C94D] font-semibold"
               >
-                <Link href="/partnerships">
-                  <span className="flex items-center">
-                    Donate <Heart size={20} className="ml-2" />
-                  </span>
+                <Link href="/partnerships" className="flex items-center">
+                  Donate <Heart size={20} className="ml-2" />
                 </Link>
               </Button>
-              <Button 
+              <Button
+                asChild
                 size="lg"
-                variant="outline" 
+                variant="outline"
                 className="border-[#FCFAEF] text-[#FCFAEF] bg-transparent hover:bg-[#FCFAEF] hover:text-[#0097b2] font-semibold"
               >
-                <Link href="mailto:akomapahealth@gmail.com">
-                  <span className="flex items-center">
-                    Contact Us <ChevronRight size={20} className="ml-2" />
-                  </span>
-                </Link>
+                <a href="mailto:akomapahealth@gmail.com" className="flex items-center">
+                  Contact Us <ChevronRight size={20} className="ml-2" />
+                </a>
               </Button>
             </div>
           </motion.div>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -65,19 +65,27 @@ export default function NotFound() {
               Back to Homepage
             </PublicCta>
           </div>
-        ) : null}
-        <h2 className="text-3xl font-bold text-gray-800 mt-8 mb-4">Page Not Found</h2>
-        <p className="text-gray-600 mb-8 max-w-md mx-auto">
-          We couldn&apos;t find the page you&apos;re looking for. The page might have been moved, deleted, 
-          or maybe the URL was mistyped.
-        </p>
-        <Button asChild className="bg-[#0097b2] hover:bg-[#0097b2]/80 text-[#FCFAEF]">
-          <Link href="/" className="flex items-center">
-            <HomeIcon className="h-4 w-4 mr-2" />
-            Back to Homepage
-          </Link>
-        </Button>
-      </div>
+
+          <nav className="mt-10" aria-label="Helpful links">
+            <p className="text-sm font-medium text-foreground">
+              Try one of these instead
+            </p>
+            <ul className="mt-4 flex flex-wrap justify-center gap-x-6 gap-y-3">
+              {recoveryLinks.map(({ href, label }) => (
+                <li key={href}>
+                  <Link
+                    href={href}
+                    className="text-sm font-medium text-[#0097b2] underline-offset-4 transition-colors hover:text-[#eeba2b] hover:underline dark:text-[#66C4DC] dark:hover:text-[#F5C94D]"
+                  >
+                    {label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        </div>
+      </main>
+      <Footer />
     </div>
   );
 }

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -37,7 +37,7 @@ export default function NotFound() {
           We couldn&apos;t find the page you&apos;re looking for. The page might have been moved, deleted, 
           or maybe the URL was mistyped.
         </p>
-        <Button className="bg-[#0097b2] hover:bg-[#0097b2]/80 text-[#FCFAEF]">
+        <Button asChild className="bg-[#0097b2] hover:bg-[#0097b2]/80 text-[#FCFAEF]">
           <Link href="/" className="flex items-center">
             <HomeIcon className="h-4 w-4 mr-2" />
             Back to Homepage

--- a/src/components/common/CardWithButton.tsx
+++ b/src/components/common/CardWithButton.tsx
@@ -38,7 +38,7 @@ export default function CardWithButton({
         <p className="text-onyx-600 dark:text-floralwhite/90 mb-4 font-body">
           {description}
         </p>
-        <Button className="bg-lapis text-floralwhite hover:bg-amber hover:text-floralwhite w-full">
+        <Button asChild className="bg-lapis text-floralwhite hover:bg-amber hover:text-floralwhite w-full">
           <Link href={linkHref}>{linkText}</Link>
         </Button>
       </div>

--- a/src/components/common/ContentSection.tsx
+++ b/src/components/common/ContentSection.tsx
@@ -44,7 +44,7 @@ export default function ContentSection({
             <p className="text-lg text-onyx-600 dark:text-floralwhite/90 mb-6 font-body">
               {description}
             </p>
-            <Button className="bg-skobeloff text-floralwhite hover:bg-amber hover:text-floralwhite">
+            <Button asChild className="bg-skobeloff text-floralwhite hover:bg-amber hover:text-floralwhite">
               <Link href={linkHref}>{linkText}</Link>
             </Button>
           </div>

--- a/src/components/home/FeaturedNews.tsx
+++ b/src/components/home/FeaturedNews.tsx
@@ -24,7 +24,7 @@ export default function FeaturedNews() {
               Stay updated with our recent activities and achievements
             </p>
           </div>
-          <Button variant="outline" className="mt-4 md:mt-0 bg-[#0097b2] hover:bg-[#eeba2b] text-[#FCFAEF]">
+          <Button asChild variant="outline" className="mt-4 md:mt-0 bg-[#0097b2] hover:bg-[#eeba2b] text-[#FCFAEF]">
             <Link href="/news" className="flex items-center">
               View All News <ArrowRight size={16} className="ml-2" />
             </Link>

--- a/src/components/home/HealthCrisisSection.tsx
+++ b/src/components/home/HealthCrisisSection.tsx
@@ -133,7 +133,7 @@ export default function HealthCrisisSection() {
         </div>
 
         <div className="text-center mt-12 md:mt-14">
-          <Button className="h-14 rounded-full px-8 text-base font-semibold bg-[#FCFAEF] text-[#0097b2] hover:bg-[#F5C94D] hover:text-[#1C1F1E] transition-colors cursor-pointer md:h-16 md:px-10 md:text-lg">
+          <Button asChild className="h-14 rounded-full px-8 text-base font-semibold bg-[#FCFAEF] text-[#0097b2] hover:bg-[#F5C94D] hover:text-[#1C1F1E] transition-colors cursor-pointer md:h-16 md:px-10 md:text-lg">
             <Link href="/research" className="flex items-center">
               Explore Our Science <ArrowRight size={20} className="ml-2.5" />
             </Link>

--- a/src/components/home/LocationSection.tsx
+++ b/src/components/home/LocationSection.tsx
@@ -177,7 +177,7 @@ export default function LocationsSection() {
                 </div>
               </div>
             </div>
-            <Button className="bg-[#0097b2] hover:bg-[#eeba2b] text-[#FCFAEF] w-fit">
+            <Button asChild className="bg-[#0097b2] hover:bg-[#eeba2b] text-[#FCFAEF] w-fit">
               <Link href="/our-ucc-clinic" className="flex items-center">
                 Visit Our UCC Clinic <ArrowRight size={16} className="ml-2" />
               </Link>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -114,6 +114,7 @@ function HeaderContent() {
             {/* Donate button and Theme Toggle */}
             <div className="flex items-center gap-2.5">
               <Button
+                asChild
                 className="bg-[#0097b2] px-4 text-[#FCFAEF] hover:bg-[#0097b2]/80 hover:text-[#FCFAEF] font-subheading font-medium"
               >
                 <Link href="/donate">Donate</Link>

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -106,7 +106,8 @@ function MobileNavContent({ isOpen, onClose, navigation }: MobileNavProps) {
                 ))}
                 
                 <div className="mt-4 space-y-3 border-t border-[#E6E7E7] pt-4 dark:border-[#757A79]">
-                  <Button 
+                  <Button
+                    asChild
                     className="min-h-12 w-full bg-[#0097b2] text-[#FCFAEF] hover:bg-[#0097b2]/80 hover:text-[#FCFAEF] font-subheading font-medium"
                   >
                     <Link href="/donate" onClick={onClose}>Donate</Link>


### PR DESCRIPTION
## Summary

Fixes #83 by converting remaining link-styled CTAs from invalid `<button><a>` nesting to a single interactive element using `Button asChild` with Radix `Slot`.

Several CTAs were rendering a native `<button>` wrapping a Next.js `Link`, which is invalid HTML and causes inconsistent keyboard focus, screen reader output, and click behavior. Most of the codebase already used the correct pattern; this PR cleans up the remaining offenders called out in the issue and re-validated by nanaagyei (header Donate, 404 homepage CTA).

## Changes

Added `asChild` to **11 CTAs across 9 files**:

| Area | File | CTAs |
|------|------|------|
| Layout | `Header.tsx`, `MobileNav.tsx` | Donate (`/donate`) |
| 404 | `not-found.tsx` | Back to Homepage (`/`) |
| Home | `HealthCrisisSection.tsx`, `FeaturedNews.tsx`, `LocationSection.tsx` | Research, news, clinic links |
| Shared | `CardWithButton.tsx`, `ContentSection.tsx` | Dynamic link buttons (fixes all call sites) |
| Roadmap | `roadmap/page.tsx` | Partner / Donate CTAs; mailto contact uses `<a>` instead of `Link` |

**Pattern applied:**

```tsx
<Button asChild className="...">
  <Link href="...">...</Link>
</Button>
```

Visual styling is unchanged — Button classes are merged onto the child link via `asChild`.

## Out of scope

- CTAs already using `asChild` (e.g. `PublicCta`, hero slides, program pages)
- Unrelated href issues (e.g. roadmap "Donate" still points to `/partnerships`)

## Test plan

- [ ] Inspect Donate in desktop header and mobile drawer — single `<a>`, no nested `<button>`
- [ ] Visit a bad URL (e.g. `/does-not-exist`) — "Back to Homepage" is a single focusable link
- [ ] Visit `/roadmap` — all three footer CTAs render as single interactive elements
- [ ] Tab through affected CTAs and activate with Enter
- [ ] `npm run lint`, `npm run typecheck`, and `npm run build` pass

Closes #83