### PR TITLE
a11y(forms): improve labels and live error announcements

### DIFF
--- a/src/components/contact/ContactForm.tsx
+++ b/src/components/contact/ContactForm.tsx
@@ -129,7 +129,7 @@ function ContactFormContent() {
       </div>
 
       {error && (
-        <div className="mb-6 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
+        <div role="alert" className="mb-6 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
           <p className="text-red-600 dark:text-red-400 text-sm">{error}</p>
         </div>
       )}
@@ -189,7 +189,7 @@ function ContactFormContent() {
             Partnership Type
           </Label>
           <Select value={formData.partnershipType} onValueChange={handleSelectChange}>
-            <SelectTrigger className="mt-2 w-full border-[#0097b2] focus:border-[#eeba2b] dark:border-[#66C4DC] dark:focus:border-[#F5C94D] bg-[#FCFAEF] dark:bg-[#1C1F1E] hover:bg-white dark:hover:bg-[#1C1F1E] cursor-pointer">
+            <SelectTrigger id="partnershipType" className="mt-2 w-full border-[#0097b2] focus:border-[#eeba2b] dark:border-[#66C4DC] dark:focus:border-[#F5C94D] bg-[#FCFAEF] dark:bg-[#1C1F1E] hover:bg-white dark:hover:bg-[#1C1F1E] cursor-pointer">
               <SelectValue placeholder="Select partnership type" className="text-[#1C1F1E] dark:text-[#FCFAEF]" />
             </SelectTrigger>
             <SelectContent className="bg-[#FCFAEF] dark:bg-[#1C1F1E] text-[#1C1F1E] dark:text-[#FCFAEF]">

--- a/src/components/donate/DonationForm.tsx
+++ b/src/components/donate/DonationForm.tsx
@@ -6,6 +6,7 @@ import { loadStripe } from "@stripe/stripe-js";
 import { CheckCircle2, Info } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import StripePayment from "@/components/payments/StripePayment";
 import AmountSelector from "@/components/donate/AmountSelector";
@@ -68,8 +69,29 @@ export default function DonationForm() {
 
               <div className="space-y-3">
                 <p className="text-sm font-medium text-[#2F3332] dark:text-[#E6E7E7]">Your details</p>
-                <Input placeholder="Full name" value={donorName} onChange={(event) => setDonorName(event.target.value)} />
-                <Input placeholder="Email address" type="email" value={donorEmail} onChange={(event) => setDonorEmail(event.target.value)} />
+                <div className="space-y-1">
+                  <Label htmlFor="donor-name" className="text-sm text-[#2F3332] dark:text-[#E6E7E7]">
+                    Full name
+                  </Label>
+                  <Input
+                    id="donor-name"
+                    placeholder="Full name"
+                    value={donorName}
+                    onChange={(event) => setDonorName(event.target.value)}
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="donor-email" className="text-sm text-[#2F3332] dark:text-[#E6E7E7]">
+                    Email address
+                  </Label>
+                  <Input
+                    id="donor-email"
+                    placeholder="Email address"
+                    type="email"
+                    value={donorEmail}
+                    onChange={(event) => setDonorEmail(event.target.value)}
+                  />
+                </div>
               </div>
             </div>
 

--- a/src/components/payments/StripePayment.tsx
+++ b/src/components/payments/StripePayment.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { CardElement, useStripe, useElements } from "@stripe/react-stripe-js";
 import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { AlertCircle } from "lucide-react";
 
@@ -121,8 +122,12 @@ export default function StripePayment({
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
       <div className="space-y-4">
-        <div className="p-4 border rounded-lg bg-white dark:bg-[#2F3332]">
-          <CardElement
+        <div className="space-y-2">
+          <Label htmlFor="card-element" className="sr-only">
+            Card details
+          </Label>
+          <div id="card-element" className="p-4 border rounded-lg bg-white dark:bg-[#2F3332]">
+            <CardElement
             options={{
               style: {
                 base: {
@@ -137,6 +142,7 @@ export default function StripePayment({
               hidePostalCode: false,
             }}
           />
+          </div>
         </div>
 
         {error && (

--- a/src/components/shared/NewsLetter.tsx
+++ b/src/components/shared/NewsLetter.tsx
@@ -6,7 +6,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Form, FormControl, FormField, FormItem, FormMessage } from "@/components/ui/form";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { CheckCircle2, ArrowRight, Loader2, AlertCircle } from "lucide-react";
 import { trackEvent } from "@/lib/analytics";
 
@@ -144,18 +144,21 @@ export default function Newsletter() {
                   name="email"
                   render={({ field, fieldState }) => (
                     <FormItem className="min-w-0 flex-1">
+                      <FormLabel className="sr-only">Email address</FormLabel>
                       <FormControl>
                         <Input
                           type="email"
                           autoComplete="email"
-                          aria-label="Email address"
                           placeholder="Enter your email address"
                           {...field}
                           disabled={isLoading}
                           className="h-12 border-[#FCFAEF]/30 bg-[#FCFAEF] text-[#2F3332] placeholder:text-[#2F3332]/60 focus-visible:border-[#eeba2b] focus-visible:ring-[#eeba2b]/40 dark:border-[#FCFAEF]/30 dark:bg-[#FCFAEF] dark:text-[#2F3332] dark:placeholder:text-[#2F3332]/60"
                         />
                       </FormControl>
-                      <FormMessage className="font-body text-sm text-[#F5C94D]">
+                      <FormMessage
+                        role="alert"
+                        className="font-body text-sm text-[#F5C94D]"
+                      >
                         {fieldState.error?.message}
                       </FormMessage>
                     </FormItem>


### PR DESCRIPTION
## Summary

Fixes #94 by adding accessible labels and live error announcements to the remaining form offenders identified in the issue

The live `/donate` page already had labeled donor fields and `Alert`-based payment status; this PR targets the narrower remaining gaps: orphaned `DonationForm`, contact form error/select wiring, newsletter validation announcements, and Stripe card field labeling.

## Changes

| File | Fix |
|------|-----|
| `DonationForm.tsx` | Visible `Label` + `id`/`htmlFor` for donor name and email (replacing placeholder-only inputs) |
| `ContactForm.tsx` | `role="alert"` on API error block; `id="partnershipType"` on `SelectTrigger` to wire Radix Select to its label |
| `NewsLetter.tsx` | `FormLabel` (sr-only) replaces `aria-label`; `FormMessage` uses `role="alert"` for validation errors |
| `StripePayment.tsx` | sr-only “Card details” label for the Stripe `CardElement` container |

## Out of scope

- `donate/page.tsx` (already compliant)
- Deleting unused `DonationForm.tsx`
- New dedicated a11y E2E spec

## Test plan

- [ ] Visit `/contact` — trigger a submission error; confirm error region has `role="alert"` in DevTools
- [ ] Click “Partnership Type” label — focus moves to the select trigger
- [ ] Footer newsletter — submit invalid email; validation message has `role="alert"`; field accessible name remains “Email address”
- [ ] `/donate` card flow — card field has sr-only “Card details” label
- [x] `npm run lint`, `npm run typecheck`, `npm run build`
- [x] `npm run test:e2e -- e2e/rebrand-foundation.spec.ts -g newsletter`

Closes #94