### PR TITLE
perf: lazy-load Stripe on donation surfaces (#97)

### DIFF
--- a/e2e/stripe-lazy-loading.spec.ts
+++ b/e2e/stripe-lazy-loading.spec.ts
@@ -1,0 +1,111 @@
+import { expect, test, type Page } from "@playwright/test";
+
+function trackStripeRequests(page: Page) {
+  const stripeRequests: string[] = [];
+
+  page.on("request", (request) => {
+    if (request.url().includes("js.stripe.com")) {
+      stripeRequests.push(request.url());
+    }
+  });
+
+  return stripeRequests;
+}
+
+async function dismissAnnouncements(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem("akomapa-announcements-dismissed", "2026-04-v2");
+  });
+}
+
+test.describe("Stripe lazy loading", () => {
+  test.beforeEach(async ({ page }) => {
+    await dismissAnnouncements(page);
+  });
+
+  test("does not load Stripe.js when visiting a community hub page with donate links", async ({
+    page,
+  }) => {
+    const stripeRequests = trackStripeRequests(page);
+
+    await page.goto("/community-hubs/ucc", { waitUntil: "networkidle" });
+    await page.waitForTimeout(1500);
+
+    expect(stripeRequests).toHaveLength(0);
+  });
+
+  test("does not load Stripe.js on donate page when using Mobile Money only", async ({ page }) => {
+    const stripeRequests = trackStripeRequests(page);
+
+    await page.goto("/donate", { waitUntil: "networkidle" });
+
+    await page.getByRole("radio", { name: /Mobile Money/i }).first().click();
+    await page.getByRole("button", { name: "Pay with Mobile Money" }).first().click();
+    await expect(page.getByText("+233 54 111 1111")).toBeVisible();
+    await page.waitForTimeout(1500);
+
+    expect(stripeRequests).toHaveLength(0);
+  });
+
+  test("loads Stripe.js only after the card payment step begins", async ({ page }) => {
+    const stripeRequests = trackStripeRequests(page);
+
+    await page.goto("/donate", { waitUntil: "domcontentloaded" });
+    expect(stripeRequests).toHaveLength(0);
+
+    await page.getByRole("button", { name: /\$100/i }).click();
+    await page.getByRole("radio", { name: /Credit\/Debit Card/i }).click();
+    expect(stripeRequests).toHaveLength(0);
+
+    await page.getByRole("button", { name: "Become a Partner" }).click();
+    await expect(page.getByText("Please provide your details")).toBeVisible();
+    expect(stripeRequests).toHaveLength(0);
+
+    await page.locator("#donorName").fill("Test Donor");
+    await page.locator("#donorEmail").fill("test@example.com");
+
+    await expect(
+      page.getByRole("button", { name: /Pay \$[\d.]+ Monthly/i })
+    ).toBeVisible({ timeout: 15000 });
+
+    await page.waitForTimeout(2000);
+
+    const stripeNotConfigured = await page
+      .getByText("Stripe is not configured")
+      .isVisible()
+      .catch(() => false);
+
+    if (stripeNotConfigured) {
+      expect(stripeRequests).toHaveLength(0);
+      return;
+    }
+
+    expect(stripeRequests.length).toBeGreaterThan(0);
+  });
+
+  test("shows a recoverable error when Stripe.js is blocked", async ({ page }) => {
+    await page.route("**/*js.stripe.com/**", (route) => route.abort());
+
+    await page.goto("/donate", { waitUntil: "domcontentloaded" });
+
+    await page.getByRole("button", { name: /\$100/i }).click();
+    await page.getByRole("radio", { name: /Credit\/Debit Card/i }).click();
+    await page.getByRole("button", { name: "Become a Partner" }).click();
+    await page.locator("#donorName").fill("Test Donor");
+    await page.locator("#donorEmail").fill("test@example.com");
+
+    const stripeNotConfigured = await page
+      .getByText("Stripe is not configured")
+      .isVisible()
+      .catch(() => false);
+
+    test.skip(stripeNotConfigured, "Stripe publishable key is not configured in this build");
+
+    await expect(
+      page.getByText(/Card payments are unavailable|Failed to load Stripe/i)
+    ).toBeVisible({ timeout: 15000 });
+
+    await page.getByRole("radio", { name: /Mobile Money/i }).click();
+    await expect(page.getByRole("button", { name: "Pay with Mobile Money" })).toBeVisible();
+  });
+});

--- a/src/app/(main)/donate/ClientPage.tsx
+++ b/src/app/(main)/donate/ClientPage.tsx
@@ -8,17 +8,10 @@ import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { CreditCard, Smartphone, Info, ArrowRight, DollarSign, Calendar, Heart, Sparkles } from "lucide-react";
 import Image from "@/components/common/Image";
-import { Elements } from "@stripe/react-stripe-js";
-import { loadStripe } from "@stripe/stripe-js";
-import StripePayment from "@/components/payments/StripePayment";
+import StripeCheckout from "@/components/payments/StripeCheckout";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { AlertCircle, CheckCircle2 } from "lucide-react";
 import Breadcrumb from "@/components/layout/Breadcrumb";
-
-// Initialize Stripe
-const stripePromise = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
-  ? loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY)
-  : null;
 
 // Payment method options
 const paymentMethods = [
@@ -590,16 +583,14 @@ export default function PartnerPage() {
 
                   {/* Payment Form */}
                   {selectedMethod === "card" && showDonorForm && donorName && donorEmail && (
-                    <Elements stripe={stripePromise}>
-                      <StripePayment
-                        amount={getDonationAmount()}
-                        onSuccess={handlePaymentSuccess}
-                        onError={handlePaymentError}
-                        frequency="monthly"
-                        donorName={donorName}
-                        donorEmail={donorEmail}
-                      />
-                    </Elements>
+                    <StripeCheckout
+                      amount={getDonationAmount()}
+                      onSuccess={handlePaymentSuccess}
+                      onError={handlePaymentError}
+                      frequency="monthly"
+                      donorName={donorName}
+                      donorEmail={donorEmail}
+                    />
                   )}
 
                   {/* Pay Button for Card Payments */}
@@ -921,16 +912,14 @@ export default function PartnerPage() {
 
                   {/* Payment Form */}
                   {selectedMethod === "card" && showDonorForm && donorName && donorEmail && (
-                    <Elements stripe={stripePromise}>
-                      <StripePayment
-                        amount={getDonationAmount()}
-                        onSuccess={handlePaymentSuccess}
-                        onError={handlePaymentError}
-                        frequency={selectedFrequency}
-                        donorName={donorName}
-                        donorEmail={donorEmail}
-                      />
-                    </Elements>
+                    <StripeCheckout
+                      amount={getDonationAmount()}
+                      onSuccess={handlePaymentSuccess}
+                      onError={handlePaymentError}
+                      frequency={selectedFrequency}
+                      donorName={donorName}
+                      donorEmail={donorEmail}
+                    />
                   )}
 
                   {/* Pay Button for Card Payments */}

--- a/src/components/donate/DonationForm.tsx
+++ b/src/components/donate/DonationForm.tsx
@@ -1,23 +1,17 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { Elements } from "@stripe/react-stripe-js";
-import { loadStripe } from "@stripe/stripe-js";
 import { CheckCircle2, Info } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
-import StripePayment from "@/components/payments/StripePayment";
+import StripeCheckout from "@/components/payments/StripeCheckout";
 import AmountSelector from "@/components/donate/AmountSelector";
 import FrequencyToggle from "@/components/donate/FrequencyToggle";
 import { DonationFrequency, paymentMethods, PaymentMethod } from "@/data/donation";
 import { cn } from "@/lib/utils";
 import { trackEvent } from "@/lib/analytics";
-
-const stripePromise = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
-  ? loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY)
-  : null;
 
 export default function DonationForm() {
   const [frequency, setFrequency] = useState<DonationFrequency>("monthly");
@@ -117,31 +111,23 @@ export default function DonationForm() {
 
               {method === "card" && (
                 <div className="rounded-xl border border-[#E6E7E7] p-4 dark:border-[#4F5554]">
-                  {!stripePromise && (
-                    <Alert variant="destructive">
-                      <AlertDescription>Stripe is not configured. Set `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`.</AlertDescription>
-                    </Alert>
-                  )}
-                  {stripePromise && canProcessCard && (
-                    <Elements stripe={stripePromise}>
-                      <StripePayment
-                        amount={amount}
-                        onSuccess={() => {
-                          trackEvent({
-                            name: "donation_cta_click",
-                            location: "donation_form_stripe_success",
-                            amount,
-                          });
-                          setStatus({ type: "success", message: "Thank you. Your donation was successful." });
-                        }}
-                        onError={(error) => setStatus({ type: "error", message: error })}
-                        frequency={paymentFrequency}
-                        donorName={donorName}
-                        donorEmail={donorEmail}
-                      />
-                    </Elements>
-                  )}
-                  {stripePromise && !canProcessCard && (
+                  {canProcessCard ? (
+                    <StripeCheckout
+                      amount={amount}
+                      onSuccess={() => {
+                        trackEvent({
+                          name: "donation_cta_click",
+                          location: "donation_form_stripe_success",
+                          amount,
+                        });
+                        setStatus({ type: "success", message: "Thank you. Your donation was successful." });
+                      }}
+                      onError={(error) => setStatus({ type: "error", message: error })}
+                      frequency={paymentFrequency}
+                      donorName={donorName}
+                      donorEmail={donorEmail}
+                    />
+                  ) : (
                     <Alert>
                       <Info className="h-4 w-4" />
                       <AlertDescription>Please choose an amount and add your name and email to continue.</AlertDescription>

--- a/src/components/payments/StripeCheckout.tsx
+++ b/src/components/payments/StripeCheckout.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useEffect, useState, type ComponentType } from "react";
+import type { Stripe } from "@stripe/stripe-js";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { AlertCircle, Loader2 } from "lucide-react";
+import {
+  getStripePromise,
+  isStripeConfigured,
+  StripeLoadError,
+} from "@/lib/stripe-client";
+import type StripePayment from "@/components/payments/StripePayment";
+
+interface StripeCheckoutProps {
+  amount: number;
+  onSuccess: () => void;
+  onError: (error: string) => void;
+  frequency?: string;
+  donorName?: string;
+  donorEmail?: string;
+}
+
+type StripeElementsComponent = ComponentType<{
+  stripe: Promise<Stripe | null> | null;
+  children: React.ReactNode;
+}>;
+
+type StripePaymentComponent = ComponentType<React.ComponentProps<typeof StripePayment>>;
+
+type CheckoutState =
+  | { status: "loading" }
+  | { status: "not_configured" }
+  | { status: "error"; message: string }
+  | {
+      status: "ready";
+      stripePromise: Promise<Stripe | null>;
+      Elements: StripeElementsComponent;
+      StripePayment: StripePaymentComponent;
+    };
+
+const STRIPE_UNAVAILABLE_MESSAGE =
+  "Card payments are unavailable right now. Please use Mobile Money or try again later.";
+
+export default function StripeCheckout(props: StripeCheckoutProps) {
+  const [state, setState] = useState<CheckoutState>({ status: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function initializeStripeCheckout() {
+      if (!isStripeConfigured()) {
+        if (!cancelled) {
+          setState({ status: "not_configured" });
+        }
+        return;
+      }
+
+      const promise = getStripePromise();
+      if (!promise) {
+        if (!cancelled) {
+          setState({ status: "not_configured" });
+        }
+        return;
+      }
+
+      try {
+        const [{ Elements }, { default: StripePayment }] = await Promise.all([
+          import("@stripe/react-stripe-js"),
+          import("@/components/payments/StripePayment"),
+        ]);
+
+        if (cancelled) {
+          return;
+        }
+
+        setState({
+          status: "ready",
+          stripePromise: promise,
+          Elements: Elements as StripeElementsComponent,
+          StripePayment: StripePayment as StripePaymentComponent,
+        });
+      } catch (error) {
+        if (!cancelled) {
+          setState({
+            status: "error",
+            message:
+              error instanceof StripeLoadError
+                ? error.message
+                : STRIPE_UNAVAILABLE_MESSAGE,
+          });
+        }
+      }
+
+      promise.catch((error: unknown) => {
+        if (cancelled) {
+          return;
+        }
+
+        setState({
+          status: "error",
+          message:
+            error instanceof StripeLoadError
+              ? error.message
+              : STRIPE_UNAVAILABLE_MESSAGE,
+        });
+      });
+    }
+
+    void initializeStripeCheckout();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (state.status === "loading") {
+    return (
+      <div
+        className="flex items-center justify-center gap-2 py-6 text-sm text-[#2F3332] dark:text-[#E6E7E7]"
+        aria-live="polite"
+        aria-busy="true"
+      >
+        <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+        Loading secure card payment…
+      </div>
+    );
+  }
+
+  if (state.status === "not_configured") {
+    return (
+      <Alert variant="destructive">
+        <AlertCircle className="h-4 w-4" />
+        <AlertDescription>
+          Stripe is not configured. Set `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (state.status === "error") {
+    return (
+      <Alert variant="destructive">
+        <AlertCircle className="h-4 w-4" />
+        <AlertDescription>{state.message}</AlertDescription>
+      </Alert>
+    );
+  }
+
+  const { Elements, StripePayment, stripePromise } = state;
+
+  return (
+    <Elements stripe={stripePromise}>
+      <StripePayment {...props} />
+    </Elements>
+  );
+}

--- a/src/lib/__tests__/stripe-client.test.ts
+++ b/src/lib/__tests__/stripe-client.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadStripeMock = vi.fn();
+
+vi.mock("@stripe/stripe-js", () => ({
+  loadStripe: (...args: unknown[]) => loadStripeMock(...args),
+}));
+
+describe("stripe-client", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    loadStripeMock.mockReset();
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("does not call loadStripe when the module is imported", async () => {
+    vi.stubEnv("NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY", "pk_test_example");
+
+    await import("@/lib/stripe-client");
+
+    expect(loadStripeMock).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the publishable key is missing", async () => {
+    const { getStripePromise } = await import("@/lib/stripe-client");
+
+    expect(getStripePromise()).toBeNull();
+    expect(loadStripeMock).not.toHaveBeenCalled();
+  });
+
+  it("lazy-loads Stripe only after getStripePromise is called", async () => {
+    vi.stubEnv("NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY", "pk_test_example");
+    loadStripeMock.mockResolvedValue({ id: "stripe-instance" });
+
+    const { getStripePromise } = await import("@/lib/stripe-client");
+    const promise = getStripePromise();
+
+    expect(promise).toBeInstanceOf(Promise);
+    await promise;
+
+    expect(loadStripeMock).toHaveBeenCalledTimes(1);
+    expect(loadStripeMock).toHaveBeenCalledWith("pk_test_example");
+    await expect(promise).resolves.toEqual({ id: "stripe-instance" });
+  });
+
+  it("reuses the cached promise across repeated calls", async () => {
+    vi.stubEnv("NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY", "pk_test_example");
+    loadStripeMock.mockResolvedValue({ id: "stripe-instance" });
+
+    const { getStripePromise } = await import("@/lib/stripe-client");
+    const first = getStripePromise();
+    const second = getStripePromise();
+
+    expect(first).toBe(second);
+    await first;
+
+    expect(loadStripeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces load failures as StripeLoadError without leaving unhandled rejections", async () => {
+    vi.stubEnv("NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY", "pk_test_example");
+    loadStripeMock.mockRejectedValue(new Error("Failed to load Stripe.js"));
+
+    const { getStripePromise, StripeLoadError } = await import("@/lib/stripe-client");
+    const promise = getStripePromise();
+
+    await expect(promise).rejects.toBeInstanceOf(StripeLoadError);
+    await expect(promise).rejects.toMatchObject({
+      message: "Failed to load Stripe.js",
+    });
+  });
+
+  it("allows a retry after a failed load", async () => {
+    vi.stubEnv("NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY", "pk_test_example");
+    loadStripeMock
+      .mockRejectedValueOnce(new Error("Failed to load Stripe.js"))
+      .mockResolvedValueOnce({ id: "stripe-instance" });
+
+    const { getStripePromise, resetStripeClientForTests } = await import(
+      "@/lib/stripe-client"
+    );
+
+    await expect(getStripePromise()).rejects.toThrow("Failed to load Stripe.js");
+
+    resetStripeClientForTests();
+
+    await expect(getStripePromise()).resolves.toEqual({ id: "stripe-instance" });
+    expect(loadStripeMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/stripe-client.ts
+++ b/src/lib/stripe-client.ts
@@ -1,0 +1,46 @@
+import type { Stripe } from "@stripe/stripe-js";
+
+export class StripeLoadError extends Error {
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = "StripeLoadError";
+    if (cause !== undefined) {
+      this.cause = cause;
+    }
+  }
+}
+
+let stripePromise: Promise<Stripe | null> | null = null;
+
+function getPublishableKey(): string | undefined {
+  return process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY;
+}
+
+export function isStripeConfigured(): boolean {
+  return Boolean(getPublishableKey());
+}
+
+export function getStripePromise(): Promise<Stripe | null> | null {
+  const key = getPublishableKey();
+  if (!key) {
+    return null;
+  }
+
+  if (!stripePromise) {
+    stripePromise = import("@stripe/stripe-js")
+      .then(({ loadStripe }) => loadStripe(key))
+      .catch((error: unknown) => {
+        stripePromise = null;
+        const message =
+          error instanceof Error ? error.message : "Failed to load Stripe.js";
+        throw new StripeLoadError(message, error);
+      });
+  }
+
+  return stripePromise;
+}
+
+/** @internal Test-only reset for module-level Stripe loader cache. */
+export function resetStripeClientForTests(): void {
+  stripePromise = null;
+}


### PR DESCRIPTION
## Summary

- Removes module-scope `loadStripe()` from donation surfaces so route prefetch (e.g. from community hub pages linking to `/donate`) no longer eagerly loads `js.stripe.com` or triggers unhandled rejections when Stripe is blocked.
- Introduces a shared `getStripePromise()` loader and a `StripeCheckout` client island that dynamically imports Stripe only when the user reaches the card payment step.
- Adds unit and Playwright regression tests covering non-payment routes, Mobile Money-only flows, deferred card loading, and recoverable errors when Stripe.js is blocked.

Closes #97.

**Note:** The original issue targeted the Partner page, which is already resolved on `dev` (`/partner` → `/partnerships`, Server Component with no Stripe). This PR addresses the remaining donation/payment surfaces per the Sentry evidence in the issue thread.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` (includes `stripe-client` unit tests)
- [x] `npm run build`
- [x] `npm run test:e2e -- e2e/stripe-lazy-loading.spec.ts e2e/donate.spec.ts`
- [ ] Manual: visit `/community-hubs/ucc` — no `js.stripe.com` in Network tab
- [ ] Manual: `/donate` Mobile Money flow — no Stripe requests
- [ ] Manual: `/donate` card flow through donor details — Stripe form loads at payment step