### PR TITLE
perf: defer global AnnouncementModal and GlobalClickTracker (#98)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,9 +4,8 @@ import type { Metadata } from 'next';
 import { cn } from "@/lib/utils";
 import { ThemeProvider } from '@/components/theme/ThemeProvider';
 import { MotionConfigProvider } from '@/components/motion/MotionConfigProvider';
-import AnnouncementModal from '@/components/announcement/AnnouncementModal';
 import { GoogleAnalytics } from '@next/third-parties/google';
-import GlobalClickTracker from '@/components/analytics/GlobalClickTracker';
+import DeferredGlobalWidgets from '@/components/global/DeferredGlobalWidgets';
 import {
   DEFAULT_DESCRIPTION,
   DEFAULT_OG_IMAGE,
@@ -136,8 +135,7 @@ export default function RootLayout({
         <ThemeProvider defaultTheme="system" storageKey="akomapa-theme">
           <MotionConfigProvider>
             {children}
-            <AnnouncementModal />
-            <GlobalClickTracker />
+            <DeferredGlobalWidgets />
           </MotionConfigProvider>
         </ThemeProvider>
       </body>

--- a/src/components/global/DeferredGlobalWidgets.tsx
+++ b/src/components/global/DeferredGlobalWidgets.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import dynamic from "next/dynamic";
+import { announcementCampaign } from "@/data/announcements";
+
+const STORAGE_KEY = "akomapa-announcements-dismissed";
+
+const AnnouncementModal = dynamic(
+  () => import("@/components/announcement/AnnouncementModal"),
+  { ssr: false }
+);
+
+const GlobalClickTracker = dynamic(
+  () => import("@/components/analytics/GlobalClickTracker"),
+  { ssr: false }
+);
+
+function scheduleIdle(callback: () => void, fallbackMs = 1500): () => void {
+  if (typeof requestIdleCallback !== "undefined") {
+    const id = requestIdleCallback(callback, { timeout: fallbackMs });
+    return () => cancelIdleCallback(id);
+  }
+
+  const id = window.setTimeout(callback, fallbackMs);
+  return () => window.clearTimeout(id);
+}
+
+function shouldLoadAnnouncement(): boolean {
+  const { slides, version } = announcementCampaign;
+  if (slides.length === 0) return false;
+
+  try {
+    if (localStorage.getItem(STORAGE_KEY) === version) return false;
+  } catch {
+    // localStorage unavailable — show anyway
+  }
+
+  return true;
+}
+
+export default function DeferredGlobalWidgets() {
+  const [showAnnouncement, setShowAnnouncement] = useState(false);
+  const [showClickTracker, setShowClickTracker] = useState(false);
+
+  useEffect(() => {
+    return scheduleIdle(() => setShowClickTracker(true));
+  }, []);
+
+  useEffect(() => {
+    if (!shouldLoadAnnouncement()) return;
+
+    // Load the modal chunk after idle so first paint is not blocked, while
+    // keeping the modal's own 3s auto-open timer intact once mounted.
+    return scheduleIdle(() => setShowAnnouncement(true), 2000);
+  }, []);
+
+  return (
+    <>
+      {showAnnouncement && <AnnouncementModal />}
+      {showClickTracker && <GlobalClickTracker />}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Code-split `AnnouncementModal` and `GlobalClickTracker` via a new `DeferredGlobalWidgets` wrapper using `next/dynamic` with `ssr: false`
- Skip loading the announcement chunk when the campaign version is already dismissed in `localStorage`
- Mount both widgets after `requestIdleCallback` so initial hydration is not blocked

Closes #98

## Analytics duplicate review
`GlobalClickTracker` fires baseline `link_click` / `outbound_click` for every `<a>` on the page, attributed by surface (header, footer, main, etc.). Component-level `trackEvent()` calls (e.g. `donation_cta_click`, `hero_cta_click`, `news_click`, `announcement_popup_open`) provide richer typed context and intentionally fire **alongside** global link events — they are complementary, not duplicate GA event names. No deduplication applied.

Deferred `GlobalClickTracker` preserves full analytics coverage after idle mount (~1–2s after load).

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] Fresh-origin check: incognito homepage → announcement auto-opens after ~3s with body scroll lock
- [x] Dismissed campaign: modal chunk not loaded
- [x] Header/footer link clicks tracked after idle mount