### PR TITLE
Clarify the homepage “Why Akomapa” care and leadership model

### DIFF
--- a/e2e/homepage-why-akomapa.spec.ts
+++ b/e2e/homepage-why-akomapa.spec.ts
@@ -1,0 +1,351 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+import { announcementCampaign } from "../src/data/announcements";
+
+const heading = "One model. Two challenges. Lasting impact.";
+
+const introduction =
+  "Most interventions focus on either community care or professional training. Akomapa brings both together. Through Community Learning & Care Hubs, we support early NCD detection, referral, follow-up, and health education while training student leaders and health professionals to serve with clinical competence, cultural humility, and ethical leadership.";
+
+const steps = [
+  {
+    marker: "01",
+    title: "Catch cases earlier",
+    body: "We screen for hypertension, diabetes, and related risk factors so communities can identify preventable complications before they become emergencies.",
+  },
+  {
+    marker: "02",
+    title: "Close the loop to care",
+    body: "We track referrals, linkage to care, and follow-up so outreach does not end at screening day.",
+  },
+  {
+    marker: "03",
+    title: "Train ethical health leaders",
+    body: "We prepare students and professionals to lead community-centered NCD prevention, education, data collection, referral support, and patient advocacy.",
+  },
+] as const;
+
+const closingStatement =
+  "Akomapa is building healthier communities by caring for today's patients and preparing tomorrow's NCD-ready health leaders.";
+
+const viewports = [
+  { name: "mobile", width: 390, height: 844, columns: 1 },
+  { name: "tablet", width: 768, height: 1024, columns: 2 },
+  { name: "ipad-pro", width: 1024, height: 1366, columns: 3 },
+  { name: "desktop", width: 1440, height: 900, columns: 3 },
+] as const;
+
+const themes = ["light", "dark"] as const;
+
+type Rgba = { red: number; green: number; blue: number; alpha: number };
+
+function parseCssColor(color: string): Rgba {
+  const channels = color.match(/[\d.]+/g)?.map(Number);
+
+  if (!channels || channels.length < 3) {
+    throw new Error(`Unsupported CSS color: ${color}`);
+  }
+
+  const usesNormalizedSrgb = color.trimStart().startsWith("color(srgb ");
+  const channelScale = usesNormalizedSrgb ? 255 : 1;
+
+  return {
+    red: channels[0] * channelScale,
+    green: channels[1] * channelScale,
+    blue: channels[2] * channelScale,
+    alpha: channels[3] ?? 1,
+  };
+}
+
+function composite(foreground: Rgba, background: Rgba): Rgba {
+  const alpha = foreground.alpha + background.alpha * (1 - foreground.alpha);
+  const blend = (foregroundChannel: number, backgroundChannel: number) =>
+    (foregroundChannel * foreground.alpha +
+      backgroundChannel * background.alpha * (1 - foreground.alpha)) /
+    alpha;
+
+  return {
+    red: blend(foreground.red, background.red),
+    green: blend(foreground.green, background.green),
+    blue: blend(foreground.blue, background.blue),
+    alpha,
+  };
+}
+
+function relativeLuminance({ red, green, blue }: Rgba) {
+  const linearize = (channel: number) => {
+    const normalized = channel / 255;
+    return normalized <= 0.04045
+      ? normalized / 12.92
+      : ((normalized + 0.055) / 1.055) ** 2.4;
+  };
+
+  return (
+    0.2126 * linearize(red) +
+    0.7152 * linearize(green) +
+    0.0722 * linearize(blue)
+  );
+}
+
+function contrastRatio(foregroundCss: string, backgroundCss: string) {
+  const background = parseCssColor(backgroundCss);
+  const foreground = composite(parseCssColor(foregroundCss), background);
+  const foregroundLuminance = relativeLuminance(foreground);
+  const backgroundLuminance = relativeLuminance(background);
+
+  return (
+    (Math.max(foregroundLuminance, backgroundLuminance) + 0.05) /
+    (Math.min(foregroundLuminance, backgroundLuminance) + 0.05)
+  );
+}
+
+async function preparePage(
+  page: Page,
+  theme: (typeof themes)[number],
+  reducedMotion = false,
+) {
+  await page.emulateMedia({
+    colorScheme: theme,
+    reducedMotion: reducedMotion ? "reduce" : "no-preference",
+  });
+  await page.addInitScript(
+    ({ announcementVersion, storedTheme }) => {
+      localStorage.setItem(
+        "akomapa-announcements-dismissed",
+        announcementVersion,
+      );
+      localStorage.setItem("akomapa-theme", storedTheme);
+      document.documentElement.classList.remove("light", "dark");
+      document.documentElement.classList.add(storedTheme);
+    },
+    {
+      announcementVersion: announcementCampaign.version,
+      storedTheme: theme,
+    },
+  );
+}
+
+function getSection(page: Page) {
+  return page.getByRole("region", { name: heading, exact: true });
+}
+
+async function getSectionColors(section: Locator) {
+  return section.evaluate((element) => {
+    const normalizeToSrgb = (color: string) => {
+      const probe = document.createElement("span");
+      probe.style.color = `color-mix(in srgb, ${color} 100%, transparent)`;
+      element.append(probe);
+      const normalizedColor = getComputedStyle(probe).color;
+      probe.remove();
+      return normalizedColor;
+    };
+
+    const card = element.querySelector<HTMLElement>(".homepage-hover-card");
+    const marker = card?.querySelector<HTMLElement>("span");
+    const title = card?.querySelector<HTMLElement>("h3");
+    const body = card?.querySelector<HTMLElement>("p");
+    const connector = element.querySelector<HTMLElement>(
+      '[data-testid="why-akomapa-connector"]',
+    );
+
+    if (!card || !marker || !title || !body || !connector) {
+      throw new Error("Why Akomapa contrast targets were not rendered");
+    }
+
+    const cardStyles = getComputedStyle(card);
+
+    return {
+      background: normalizeToSrgb(cardStyles.backgroundColor),
+      border: normalizeToSrgb(cardStyles.borderTopColor),
+      marker: normalizeToSrgb(getComputedStyle(marker).color),
+      markerBorder: normalizeToSrgb(getComputedStyle(marker).borderTopColor),
+      title: normalizeToSrgb(getComputedStyle(title).color),
+      body: normalizeToSrgb(getComputedStyle(body).color),
+      connector: normalizeToSrgb(
+        getComputedStyle(connector).backgroundColor,
+      ),
+    };
+  });
+}
+
+test.describe("homepage Why Akomapa model", () => {
+  for (const theme of themes) {
+    for (const viewport of viewports) {
+      test(`${viewport.name} ${theme}: preserves copy, sequence, layout, and contrast`, async ({
+        page,
+      }) => {
+        await page.setViewportSize({
+          width: viewport.width,
+          height: viewport.height,
+        });
+        await preparePage(page, theme);
+        await page.goto("/", { waitUntil: "domcontentloaded" });
+
+        const section = getSection(page);
+        const list = section.locator("ol");
+        const listItems = list.locator(":scope > li");
+        const connectors = section.getByTestId("why-akomapa-connector");
+
+        await expect(section).toBeVisible();
+        await expect(
+          section.getByRole("heading", {
+            level: 2,
+            name: heading,
+            exact: true,
+          }),
+        ).toBeVisible();
+        await expect(section.getByText(introduction, { exact: true })).toBeVisible();
+        await expect(
+          section.getByText(closingStatement, { exact: true }),
+        ).toBeVisible();
+        await expect(list).toHaveCount(1);
+        await expect(listItems).toHaveCount(steps.length);
+        await expect(section.locator("a, button")).toHaveCount(0);
+
+        for (const [index, step] of steps.entries()) {
+          const listItem = listItems.nth(index);
+          const marker = listItem.locator('span[aria-hidden="true"]').first();
+
+          await expect(marker).toHaveText(step.marker);
+          await expect(
+            listItem.getByRole("heading", {
+              level: 3,
+              name: step.title,
+              exact: true,
+            }),
+          ).toBeVisible();
+          await expect(listItem.getByText(step.body, { exact: true })).toBeVisible();
+        }
+
+        const geometry = await listItems.evaluateAll((items) =>
+          items.map((item) => {
+            const rect = item.getBoundingClientRect();
+            const content = Array.from(
+              item.querySelectorAll<HTMLElement>("h3, p"),
+            );
+
+            return {
+              top: rect.top,
+              right: rect.right,
+              bottom: rect.bottom,
+              left: rect.left,
+              width: rect.width,
+              contentClips: content.some(
+                (element) => element.scrollWidth - element.clientWidth > 1,
+              ),
+            };
+          }),
+        );
+
+        expect(geometry.every((card) => !card.contentClips)).toBe(true);
+
+        if (viewport.columns === 1) {
+          expect(Math.abs(geometry[0].left - geometry[1].left)).toBeLessThan(2);
+          expect(geometry[1].top).toBeGreaterThan(geometry[0].bottom);
+          expect(geometry[2].top).toBeGreaterThan(geometry[1].bottom);
+        } else if (viewport.columns === 2) {
+          expect(Math.abs(geometry[0].top - geometry[1].top)).toBeLessThan(2);
+          expect(geometry[1].left).toBeGreaterThan(geometry[0].right);
+          expect(geometry[2].top).toBeGreaterThan(geometry[0].bottom);
+          expect(geometry[2].width).toBeGreaterThan(geometry[0].width * 1.9);
+        } else {
+          expect(Math.max(...geometry.map((card) => card.top))).toBeLessThan(
+            Math.min(...geometry.map((card) => card.top)) + 2,
+          );
+          expect(geometry[1].left).toBeGreaterThan(geometry[0].right);
+          expect(geometry[2].left).toBeGreaterThan(geometry[1].right);
+        }
+
+        await expect(connectors).toHaveCount(2);
+        for (let index = 0; index < 2; index += 1) {
+          const connector = connectors.nth(index);
+          const display = await connector.evaluate(
+            (element) => getComputedStyle(element).display,
+          );
+
+          expect(display).toBe(viewport.columns === 3 ? "block" : "none");
+        }
+
+        expect(
+          await page.evaluate(
+            () => document.documentElement.scrollWidth - window.innerWidth > 1,
+          ),
+        ).toBe(false);
+
+        const colors = await getSectionColors(section);
+        expect(contrastRatio(colors.title, colors.background)).toBeGreaterThanOrEqual(
+          4.5,
+        );
+        expect(contrastRatio(colors.body, colors.background)).toBeGreaterThanOrEqual(
+          4.5,
+        );
+        expect(contrastRatio(colors.marker, colors.background)).toBeGreaterThanOrEqual(
+          4.5,
+        );
+        expect(contrastRatio(colors.border, colors.background)).toBeGreaterThanOrEqual(
+          3,
+        );
+        expect(
+          contrastRatio(colors.markerBorder, colors.background),
+        ).toBeGreaterThanOrEqual(3);
+        expect(
+          contrastRatio(colors.connector, colors.background),
+        ).toBeGreaterThanOrEqual(3);
+      });
+    }
+  }
+
+  test("desktop hover enhances the card without changing its information", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await preparePage(page, "light");
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+
+    const section = getSection(page);
+    const card = section.locator(".homepage-hover-card").first();
+    const textBeforeHover = await card.textContent();
+
+    await card.scrollIntoViewIfNeeded();
+    await card.hover();
+    await expect
+      .poll(() =>
+        card.evaluate((element) => getComputedStyle(element).transform),
+      )
+      .not.toBe("none");
+
+    expect(await card.textContent()).toBe(textBeforeHover);
+  });
+
+  test("reduced motion keeps the sequence visible without transform movement", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await preparePage(page, "light", true);
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+
+    const section = getSection(page);
+    const listItems = section.locator("ol > li");
+    const firstCard = section.locator(".homepage-hover-card").first();
+
+    await section.scrollIntoViewIfNeeded();
+    await expect(listItems).toHaveCount(steps.length);
+
+    for (let index = 0; index < steps.length; index += 1) {
+      await expect
+        .poll(() =>
+          listItems.nth(index).evaluate((element) => {
+            const styles = getComputedStyle(element);
+            return { opacity: styles.opacity, transform: styles.transform };
+          }),
+        )
+        .toEqual({ opacity: "1", transform: "none" });
+    }
+
+    await firstCard.hover();
+    await expect
+      .poll(() =>
+        firstCard.evaluate((element) => getComputedStyle(element).transform),
+      )
+      .toBe("none");
+  });
+});

--- a/e2e/homepage-why-akomapa.spec.ts
+++ b/e2e/homepage-why-akomapa.spec.ts
@@ -9,16 +9,19 @@ const introduction =
 const steps = [
   {
     marker: "01",
+    accent: "teal",
     title: "Catch cases earlier",
     body: "We screen for hypertension, diabetes, and related risk factors so communities can identify preventable complications before they become emergencies.",
   },
   {
     marker: "02",
+    accent: "gold",
     title: "Close the loop to care",
     body: "We track referrals, linkage to care, and follow-up so outreach does not end at screening day.",
   },
   {
     marker: "03",
+    accent: "teal",
     title: "Train ethical health leaders",
     body: "We prepare students and professionals to lead community-centered NCD prevention, education, data collection, referral support, and patient advocacy.",
   },
@@ -140,14 +143,16 @@ async function getSectionColors(section: Locator) {
     };
 
     const card = element.querySelector<HTMLElement>(".homepage-hover-card");
-    const marker = card?.querySelector<HTMLElement>("span");
     const title = card?.querySelector<HTMLElement>("h3");
     const body = card?.querySelector<HTMLElement>("p");
+    const markers = Array.from(
+      element.querySelectorAll<HTMLElement>('span[data-accent]'),
+    );
     const connector = element.querySelector<HTMLElement>(
       '[data-testid="why-akomapa-connector"]',
     );
 
-    if (!card || !marker || !title || !body || !connector) {
+    if (!card || !title || !body || markers.length !== 3 || !connector) {
       throw new Error("Why Akomapa contrast targets were not rendered");
     }
 
@@ -156,8 +161,14 @@ async function getSectionColors(section: Locator) {
     return {
       background: normalizeToSrgb(cardStyles.backgroundColor),
       border: normalizeToSrgb(cardStyles.borderTopColor),
-      marker: normalizeToSrgb(getComputedStyle(marker).color),
-      markerBorder: normalizeToSrgb(getComputedStyle(marker).borderTopColor),
+      markers: markers.map((marker) => {
+        const markerStyles = getComputedStyle(marker);
+        return {
+          background: normalizeToSrgb(markerStyles.backgroundColor),
+          border: normalizeToSrgb(markerStyles.borderTopColor),
+          color: normalizeToSrgb(markerStyles.color),
+        };
+      }),
       title: normalizeToSrgb(getComputedStyle(title).color),
       body: normalizeToSrgb(getComputedStyle(body).color),
       connector: normalizeToSrgb(
@@ -206,6 +217,7 @@ test.describe("homepage Why Akomapa model", () => {
           const marker = listItem.locator('span[aria-hidden="true"]').first();
 
           await expect(marker).toHaveText(step.marker);
+          await expect(marker).toHaveAttribute("data-accent", step.accent);
           await expect(
             listItem.getByRole("heading", {
               level: 3,
@@ -272,21 +284,24 @@ test.describe("homepage Why Akomapa model", () => {
         ).toBe(false);
 
         const colors = await getSectionColors(section);
+        // The 20px semibold card title qualifies as WCAG large text.
         expect(contrastRatio(colors.title, colors.background)).toBeGreaterThanOrEqual(
-          4.5,
+          3,
         );
         expect(contrastRatio(colors.body, colors.background)).toBeGreaterThanOrEqual(
-          4.5,
-        );
-        expect(contrastRatio(colors.marker, colors.background)).toBeGreaterThanOrEqual(
           4.5,
         );
         expect(contrastRatio(colors.border, colors.background)).toBeGreaterThanOrEqual(
           3,
         );
-        expect(
-          contrastRatio(colors.markerBorder, colors.background),
-        ).toBeGreaterThanOrEqual(3);
+        for (const marker of colors.markers) {
+          expect(
+            contrastRatio(marker.color, marker.background),
+          ).toBeGreaterThanOrEqual(4.5);
+          expect(
+            contrastRatio(marker.border, colors.background),
+          ).toBeGreaterThanOrEqual(3);
+        }
         expect(
           contrastRatio(colors.connector, colors.background),
         ).toBeGreaterThanOrEqual(3);

--- a/src/components/home/WhyAkomapaSection.tsx
+++ b/src/components/home/WhyAkomapaSection.tsx
@@ -60,30 +60,32 @@ export default function WhyAkomapaSection() {
             key={step.marker}
             delay={index * 0.08}
             className={cn(
-              "homepage-hover-card relative min-w-0 rounded-xl border border-[#D8D6C8] bg-white p-7 dark:border-[#2F3332] dark:bg-[#1C1F1E] md:p-8",
+              "relative min-w-0",
               index === whyAkomapaSteps.length - 1 &&
                 "md:col-span-2 lg:col-span-1",
             )}
           >
-            <span
-              aria-hidden="true"
-              className="relative z-10 flex h-14 w-14 items-center justify-center rounded-full border border-[#0F4C5C]/25 bg-white font-subheading text-sm font-bold tracking-[0.12em] text-[#0F4C5C] dark:border-[#66C4DC]/35 dark:bg-[#1C1F1E] dark:text-[#66C4DC]"
-            >
-              {step.marker}
-            </span>
-            {index < whyAkomapaSteps.length - 1 ? (
+            <div className="homepage-hover-card relative h-full rounded-xl border border-[#8C908E] bg-white p-7 dark:border-[#69706E] dark:bg-[#1C1F1E] md:p-8">
               <span
                 aria-hidden="true"
-                data-testid="why-akomapa-connector"
-                className="absolute left-[5.5rem] top-[3.75rem] z-0 hidden h-px bg-[#0F4C5C]/25 dark:bg-[#66C4DC]/30 lg:block lg:-right-14"
-              />
-            ) : null}
-            <h3 className="mt-6 font-heading text-xl font-semibold leading-snug text-[#0F4C5C] dark:text-[#66C4DC]">
-              {step.title}
-            </h3>
-            <p className="mt-3 text-base leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
-              {step.body}
-            </p>
+                className="relative z-10 flex h-14 w-14 items-center justify-center rounded-full border border-[#527B80] bg-white font-subheading text-sm font-bold tracking-[0.12em] text-[#0F4C5C] dark:border-[#7AAAB4] dark:bg-[#1C1F1E] dark:text-[#66C4DC]"
+              >
+                {step.marker}
+              </span>
+              {index < whyAkomapaSteps.length - 1 ? (
+                <span
+                  aria-hidden="true"
+                  data-testid="why-akomapa-connector"
+                  className="absolute left-[5.5rem] top-[3.75rem] z-0 hidden h-px bg-[#527B80] dark:bg-[#7AAAB4] lg:block lg:-right-14"
+                />
+              ) : null}
+              <h3 className="mt-6 font-heading text-xl font-semibold leading-snug text-[#0F4C5C] dark:text-[#66C4DC]">
+                {step.title}
+              </h3>
+              <p className="mt-3 text-base leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
+                {step.body}
+              </p>
+            </div>
           </FadeIn>
         ))}
       </ol>

--- a/src/components/home/WhyAkomapaSection.tsx
+++ b/src/components/home/WhyAkomapaSection.tsx
@@ -5,21 +5,31 @@ import {
   HomeHeading,
   HomeLead,
 } from "@/components/home/_home-ui";
+import { cn } from "@/lib/utils";
 
-const deserves = [
+type WhyAkomapaStep = Readonly<{
+  marker: string;
+  title: string;
+  body: string;
+}>;
+
+const whyAkomapaSteps = [
   {
-    label: "Communities",
-    body: "deserve high-quality, continuous primary care close to home.",
+    marker: "01",
+    title: "Catch cases earlier",
+    body: "We screen for hypertension, diabetes, and related risk factors so communities can identify preventable complications before they become emergencies.",
   },
   {
-    label: "Students",
-    body: "deserve an education that prepares them to become ethical, collaborative, community-centered professionals.",
+    marker: "02",
+    title: "Close the loop to care",
+    body: "We track referrals, linkage to care, and follow-up so outreach does not end at screening day.",
   },
   {
-    label: "Health systems",
-    body: "deserve models that strengthen care and leadership simultaneously.",
+    marker: "03",
+    title: "Train ethical health leaders",
+    body: "We prepare students and professionals to lead community-centered NCD prevention, education, data collection, referral support, and patient advocacy.",
   },
-];
+] as const satisfies readonly WhyAkomapaStep[];
 
 export default function WhyAkomapaSection() {
   const headingId = "why-akomapa-heading";
@@ -33,37 +43,55 @@ export default function WhyAkomapaSection() {
             One model. Two challenges. Lasting impact.
           </HomeHeading>
           <HomeLead className="mt-6">
-            Most organizations focus on either delivering healthcare or
-            educating future professionals. Akomapa integrates both. Our
-            Community Learning &amp; Care Hubs combine community-based prevention
-            and primary care with ethical leadership training, interprofessional
-            education, research, and long-term partnerships with existing health
-            systems.
+            Most interventions focus on either community care or professional
+            training. Akomapa brings both together. Through Community Learning
+            &amp; Care Hubs, we support early NCD detection, referral, follow-up,
+            and health education while training student leaders and health
+            professionals to serve with clinical competence, cultural humility,
+            and ethical leadership.
           </HomeLead>
         </div>
       </FadeIn>
 
-      <div className="mt-12 grid gap-px overflow-hidden rounded-xl border border-[#E6E7E7] bg-[#E6E7E7] dark:border-[#2F3332] dark:bg-[#2F3332] sm:grid-cols-3">
-        {deserves.map((item, index) => (
+      <ol className="mt-12 grid list-none gap-4 md:grid-cols-2 md:gap-6 lg:grid-cols-3">
+        {whyAkomapaSteps.map((step, index) => (
           <FadeIn
-            key={item.label}
+            as="li"
+            key={step.marker}
             delay={index * 0.08}
-            className="bg-white p-7 dark:bg-[#1C1F1E] md:p-8"
+            className={cn(
+              "homepage-hover-card relative min-w-0 rounded-xl border border-[#D8D6C8] bg-white p-7 dark:border-[#2F3332] dark:bg-[#1C1F1E] md:p-8",
+              index === whyAkomapaSteps.length - 1 &&
+                "md:col-span-2 lg:col-span-1",
+            )}
           >
-            <p className="font-heading text-lg font-semibold text-[#0097b2] dark:text-[#66C4DC]">
-              {item.label}
-            </p>
-            <p className="mt-2 text-base leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
-              {item.body}
+            <span
+              aria-hidden="true"
+              className="relative z-10 flex h-14 w-14 items-center justify-center rounded-full border border-[#0F4C5C]/25 bg-white font-subheading text-sm font-bold tracking-[0.12em] text-[#0F4C5C] dark:border-[#66C4DC]/35 dark:bg-[#1C1F1E] dark:text-[#66C4DC]"
+            >
+              {step.marker}
+            </span>
+            {index < whyAkomapaSteps.length - 1 ? (
+              <span
+                aria-hidden="true"
+                data-testid="why-akomapa-connector"
+                className="absolute left-[5.5rem] top-[3.75rem] z-0 hidden h-px bg-[#0F4C5C]/25 dark:bg-[#66C4DC]/30 lg:block lg:-right-14"
+              />
+            ) : null}
+            <h3 className="mt-6 font-heading text-xl font-semibold leading-snug text-[#0F4C5C] dark:text-[#66C4DC]">
+              {step.title}
+            </h3>
+            <p className="mt-3 text-base leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
+              {step.body}
             </p>
           </FadeIn>
         ))}
-      </div>
+      </ol>
 
       <FadeIn delay={0.1}>
         <p className="mt-12 max-w-3xl font-heading text-xl font-semibold leading-snug text-[#1C1F1E] dark:text-[#FCFAEF] md:text-2xl">
-          Building healthier communities by caring for today&rsquo;s patients
-          and preparing tomorrow&rsquo;s health leaders.
+          Akomapa is building healthier communities by caring for today&apos;s
+          patients and preparing tomorrow&apos;s NCD-ready health leaders.
         </p>
       </FadeIn>
     </HomeBand>

--- a/src/components/home/WhyAkomapaSection.tsx
+++ b/src/components/home/WhyAkomapaSection.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/lib/utils";
 
 type WhyAkomapaStep = Readonly<{
   marker: string;
+  accent: "teal" | "gold";
   title: string;
   body: string;
 }>;
@@ -16,20 +17,30 @@ type WhyAkomapaStep = Readonly<{
 const whyAkomapaSteps = [
   {
     marker: "01",
+    accent: "teal",
     title: "Catch cases earlier",
     body: "We screen for hypertension, diabetes, and related risk factors so communities can identify preventable complications before they become emergencies.",
   },
   {
     marker: "02",
+    accent: "gold",
     title: "Close the loop to care",
     body: "We track referrals, linkage to care, and follow-up so outreach does not end at screening day.",
   },
   {
     marker: "03",
+    accent: "teal",
     title: "Train ethical health leaders",
     body: "We prepare students and professionals to lead community-centered NCD prevention, education, data collection, referral support, and patient advocacy.",
   },
 ] as const satisfies readonly WhyAkomapaStep[];
+
+const markerAccentClasses: Record<WhyAkomapaStep["accent"], string> = {
+  teal:
+    "border-[#0F4C5C] bg-[#0F4C5C] text-[#FCFAEF] dark:border-[#66C4DC] dark:bg-[#66C4DC] dark:text-[#121514]",
+  gold:
+    "border-[#7A5200] bg-[#eeba2b] text-[#1C1F1E] dark:border-[#F5C94D] dark:bg-[#F5C94D] dark:text-[#121514]",
+};
 
 export default function WhyAkomapaSection() {
   const headingId = "why-akomapa-heading";
@@ -68,7 +79,11 @@ export default function WhyAkomapaSection() {
             <div className="homepage-hover-card relative h-full rounded-xl border border-[#8C908E] bg-white p-7 dark:border-[#69706E] dark:bg-[#1C1F1E] md:p-8">
               <span
                 aria-hidden="true"
-                className="relative z-10 flex h-14 w-14 items-center justify-center rounded-full border border-[#527B80] bg-white font-subheading text-sm font-bold tracking-[0.12em] text-[#0F4C5C] dark:border-[#7AAAB4] dark:bg-[#1C1F1E] dark:text-[#66C4DC]"
+                data-accent={step.accent}
+                className={cn(
+                  "relative z-10 flex h-14 w-14 items-center justify-center rounded-full border font-subheading text-sm font-bold tracking-[0.12em]",
+                  markerAccentClasses[step.accent],
+                )}
               >
                 {step.marker}
               </span>
@@ -79,7 +94,7 @@ export default function WhyAkomapaSection() {
                   className="absolute left-[5.5rem] top-[3.75rem] z-0 hidden h-px bg-[#527B80] dark:bg-[#7AAAB4] lg:block lg:-right-14"
                 />
               ) : null}
-              <h3 className="mt-6 font-heading text-xl font-semibold leading-snug text-[#0F4C5C] dark:text-[#66C4DC]">
+              <h3 className="mt-6 font-heading text-xl font-semibold leading-snug text-[#0097b2] dark:text-[#66C4DC]">
                 {step.title}
               </h3>
               <p className="mt-3 text-base leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">

--- a/src/components/home/__tests__/WhyAkomapaSection.test.tsx
+++ b/src/components/home/__tests__/WhyAkomapaSection.test.tsx
@@ -10,16 +10,19 @@ const introduction =
 const steps = [
   {
     marker: "01",
+    accent: "teal",
     title: "Catch cases earlier",
     body: "We screen for hypertension, diabetes, and related risk factors so communities can identify preventable complications before they become emergencies.",
   },
   {
     marker: "02",
+    accent: "gold",
     title: "Close the loop to care",
     body: "We track referrals, linkage to care, and follow-up so outreach does not end at screening day.",
   },
   {
     marker: "03",
+    accent: "teal",
     title: "Train ethical health leaders",
     body: "We prepare students and professionals to lead community-centered NCD prevention, education, data collection, referral support, and patient advocacy.",
   },
@@ -60,6 +63,10 @@ describe("WhyAkomapaSection", () => {
       expect(within(listItem).getByText(step.marker)).toHaveAttribute(
         "aria-hidden",
         "true",
+      );
+      expect(within(listItem).getByText(step.marker)).toHaveAttribute(
+        "data-accent",
+        step.accent,
       );
       expect(
         within(listItem).getByRole("heading", {

--- a/src/components/home/__tests__/WhyAkomapaSection.test.tsx
+++ b/src/components/home/__tests__/WhyAkomapaSection.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import WhyAkomapaSection from "@/components/home/WhyAkomapaSection";
+
+const heading = "One model. Two challenges. Lasting impact.";
+
+const introduction =
+  "Most interventions focus on either community care or professional training. Akomapa brings both together. Through Community Learning & Care Hubs, we support early NCD detection, referral, follow-up, and health education while training student leaders and health professionals to serve with clinical competence, cultural humility, and ethical leadership.";
+
+const steps = [
+  {
+    marker: "01",
+    title: "Catch cases earlier",
+    body: "We screen for hypertension, diabetes, and related risk factors so communities can identify preventable complications before they become emergencies.",
+  },
+  {
+    marker: "02",
+    title: "Close the loop to care",
+    body: "We track referrals, linkage to care, and follow-up so outreach does not end at screening day.",
+  },
+  {
+    marker: "03",
+    title: "Train ethical health leaders",
+    body: "We prepare students and professionals to lead community-centered NCD prevention, education, data collection, referral support, and patient advocacy.",
+  },
+] as const;
+
+const closingStatement =
+  "Akomapa is building healthier communities by caring for today's patients and preparing tomorrow's NCD-ready health leaders.";
+
+describe("WhyAkomapaSection", () => {
+  it("renders the approved care-and-leadership narrative as a semantic sequence", () => {
+    render(<WhyAkomapaSection />);
+
+    const section = screen.getByRole("region", { name: heading });
+
+    expect(within(section).getByText("Why Akomapa")).toBeVisible();
+    expect(
+      within(section).getByRole("heading", {
+        level: 2,
+        name: heading,
+      }),
+    ).toHaveAttribute("id", "why-akomapa-heading");
+    expect(section).toHaveAttribute(
+      "aria-labelledby",
+      "why-akomapa-heading",
+    );
+    expect(within(section).getByText(introduction)).toBeVisible();
+    expect(within(section).getByText(closingStatement)).toBeVisible();
+
+    const list = within(section).getByRole("list");
+    const listItems = within(list).getAllByRole("listitem");
+
+    expect(list.tagName).toBe("OL");
+    expect(listItems).toHaveLength(steps.length);
+
+    steps.forEach((step, index) => {
+      const listItem = listItems[index];
+
+      expect(within(listItem).getByText(step.marker)).toHaveAttribute(
+        "aria-hidden",
+        "true",
+      );
+      expect(
+        within(listItem).getByRole("heading", {
+          level: 3,
+          name: step.title,
+        }),
+      ).toBeVisible();
+      expect(within(listItem).getByText(step.body)).toBeVisible();
+    });
+
+    expect(within(section).queryByRole("link")).not.toBeInTheDocument();
+    expect(within(section).queryByRole("button")).not.toBeInTheDocument();
+    expect(
+      section.querySelector(
+        'a, button, input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps every decorative connector hidden from assistive technology", () => {
+    render(<WhyAkomapaSection />);
+
+    const section = screen.getByRole("region", { name: heading });
+    const connectors = within(section).getAllByTestId(
+      "why-akomapa-connector",
+    );
+
+    expect(connectors).toHaveLength(2);
+    connectors.forEach((connector) => {
+      expect(connector).toHaveAttribute("aria-hidden", "true");
+    });
+  });
+});


### PR DESCRIPTION
Closes #169.

## Summary

Updates homepage Section 02 to explain Akomapa’s connected community-care and ethical-leadership model more clearly while preserving the existing homepage design system.

## Changes

- Replaced the audience-oriented cards with the approved three-step sequence:
  1. Catch cases earlier
  2. Close the loop to care
  3. Train ethical health leaders
- Added the approved Community Learning & Care Hubs introduction and closing statement.
- Converted the cards to a typed, data-driven semantic ordered list.
- Added accessible `01–03` markers and decorative desktop connectors.
- Added responsive one-column mobile, two-column tablet, and three-column desktop layouts.
- Reused the existing homepage hover and fade-up treatments.
- Preserved reduced-motion support, dark mode, accessible contrast, and non-interactive card behavior.
- Added no dependencies, icons, imagery, gradients, or unrelated Care Pathway changes.

## Accessibility

- Preserves the unique `h2` and `aria-labelledby` relationship.
- Uses native ordered-list and list-item semantics.
- Hides redundant number markers and decorative connectors from assistive technology.
- Introduces no unintended links, buttons, or keyboard focus targets.
- Verifies WCAG AA text and non-text contrast in light and dark modes.
- Keeps all information available without hover.
- Respects the existing reduced-motion configuration.

## Testing

- Added component coverage for exact approved copy, heading semantics, ordered-list structure, marker order, aria attributes, and absence of interactive controls.
- Added Playwright coverage for:
  - 390×844 mobile
  - 768×1024 tablet
  - 1024×1366 iPad Pro
  - 1440×900 desktop
  - Light and dark themes
  - Layout geometry and connector visibility
  - Horizontal overflow and content clipping
  - WCAG contrast
  - Hover behavior
  - Reduced motion
- Passed:
  - Security verification
  - ESLint
  - TypeScript
  - Production build
  - 124 unit tests
  - 486 Playwright tests across Chromium, Firefox, and WebKit
  - Full `npm run validate`