### PR TITLE
fix(navigation): replace broken internal CTA links

### DIFF
--- a/e2e/cta-links.spec.ts
+++ b/e2e/cta-links.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test, type Page } from "@playwright/test";
+import { announcementCampaign } from "../src/data/announcements";
+
+async function preparePage(page: Page) {
+  await page.addInitScript((version) => {
+    localStorage.setItem("akomapa-announcements-dismissed", version);
+  }, announcementCampaign.version);
+}
+
+test.describe("Program CTA links", () => {
+  test.beforeEach(async ({ page }) => {
+    await preparePage(page);
+  });
+
+  test("GHIP Request Program Brochure CTAs point to /contact", async ({
+    page,
+  }) => {
+    await page.goto("/programs/akomapa-ghip", {
+      waitUntil: "domcontentloaded",
+    });
+
+    const brochureLinks = page.getByRole("link", {
+      name: "Request Program Brochure",
+      exact: true,
+    });
+
+    await expect(brochureLinks.first()).toBeVisible();
+    const count = await brochureLinks.count();
+    expect(count).toBeGreaterThan(0);
+
+    for (let i = 0; i < count; i += 1) {
+      await expect(brochureLinks.nth(i)).toHaveAttribute("href", "/contact");
+    }
+  });
+
+  test("GHLTP Become a Mentor CTA points to /contact", async ({ page }) => {
+    await page.goto("/programs/akomapa-ghltp", {
+      waitUntil: "domcontentloaded",
+    });
+
+    const mentorLink = page.getByRole("link", {
+      name: "Become a Mentor",
+      exact: true,
+    });
+
+    await expect(mentorLink).toBeVisible();
+    await expect(mentorLink).toHaveAttribute("href", "/contact");
+  });
+});

--- a/src/app/(main)/programs/akomapa-ghip/ClientPage.tsx
+++ b/src/app/(main)/programs/akomapa-ghip/ClientPage.tsx
@@ -205,7 +205,7 @@ export default function GHIPPage() {
                 <Link href="/get-involved">Apply Now</Link>
               </Button>
               <Button asChild className={secondaryCtaClass}>
-                <Link href="/#">Request Program Brochure</Link>
+                <Link href="/contact">Request Program Brochure</Link>
               </Button>
             </motion.div>
           </div>
@@ -611,7 +611,7 @@ export default function GHIPPage() {
                 </Link>
               </Button>
               <Button asChild className={secondaryCtaClass}>
-                <Link href="/programs" className="flex items-center">
+                <Link href="/contact" className="flex items-center">
                   Request Program Brochure
                   <ArrowRight className="ml-2 h-5 w-5" />
                 </Link>

--- a/src/app/(main)/programs/akomapa-ghltp/ClientPage.tsx
+++ b/src/app/(main)/programs/akomapa-ghltp/ClientPage.tsx
@@ -259,7 +259,7 @@ export default function GHLTPPage() {
                 <Link href="/get-involved">Apply Now</Link>
               </Button>
               <Button asChild className={secondaryCtaClass}>
-                <Link href="/#">Become a Mentor</Link>
+                <Link href="/contact">Become a Mentor</Link>
               </Button>
             </motion.div>
           </div>

--- a/src/components/home/LocationSection.tsx
+++ b/src/components/home/LocationSection.tsx
@@ -178,7 +178,7 @@ export default function LocationsSection() {
               </div>
             </div>
             <Button asChild className="bg-[#0097b2] hover:bg-[#eeba2b] text-[#FCFAEF] w-fit">
-              <Link href="/our-ucc-clinic" className="flex items-center">
+              <Link href="/community-hubs/ucc" className="flex items-center">
                 Visit Our UCC Clinic <ArrowRight size={16} className="ml-2" />
               </Link>
             </Button>


### PR DESCRIPTION
## Summary
- Point GHIP “Request Program Brochure” and GHLTP “Become a Mentor” CTAs to `/contact` (temporary until dedicated forms exist)
- Update legacy UCC clinic CTA in `LocationSection` from `/our-ucc-clinic` to `/community-hubs/ucc`
- Add e2e smoke coverage so these program CTAs cannot regress to placeholders

Closes #82

## Test plan
- [x] Grep confirms no remaining `href="/#"` or `/our-ucc-clinic` under `src/`
- [x] `npx playwright test e2e/cta-links.spec.ts --project=chromium` passes
- [x] Manually open `/programs/akomapa-ghip` and click “Request Program Brochure” → `/contact`
- [x] Manually open `/programs/akomapa-ghltp` and click “Become a Mentor” → `/contact`