### PR TITLE
a11y: add skip-to-main-content link (#93)

### DIFF
--- a/e2e/header-nav-a11y.spec.ts
+++ b/e2e/header-nav-a11y.spec.ts
@@ -15,6 +15,32 @@ async function dismissAnnouncementIfPresent(page: import("@playwright/test").Pag
   );
 }
 
+test.describe("skip to main content", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize(DESKTOP_VIEWPORT);
+    await dismissAnnouncementIfPresent(page);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+  });
+
+  test("Tab focuses skip link and Enter moves focus to main content", async ({
+    page,
+  }) => {
+    const skipLink = page.getByRole("link", { name: "Skip to main content" });
+    const main = page.locator("main#main-content");
+
+    await expect(main).toBeAttached();
+
+    // First Tab from the document should land on the skip link.
+    await page.keyboard.press("Tab");
+    await expect(skipLink).toBeFocused();
+    await expect(skipLink).toBeVisible();
+
+    await page.keyboard.press("Enter");
+    await expect(main).toBeFocused();
+  });
+});
+
 test.describe("desktop header dropdown keyboard accessibility", () => {
   test.beforeEach(async ({ page }) => {
     await page.setViewportSize(DESKTOP_VIEWPORT);

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,5 +1,6 @@
 import Header from "@/components/layout/Header";
 import Footer from "@/components/layout/Footer";
+import SkipToMainContent from "@/components/layout/SkipToMainContent";
 
 export default function MainLayout({
   children,
@@ -8,8 +9,11 @@ export default function MainLayout({
 }) {
   return (
     <div className="flex flex-col min-h-screen">
+      <SkipToMainContent />
       <Header />
-      <main className="flex-grow">{children}</main>
+      <main id="main-content" tabIndex={-1} className="flex-grow outline-none">
+        {children}
+      </main>
       <Footer />
     </div>
   );

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -5,6 +5,7 @@ import dynamic from "next/dynamic";
 import Link from "next/link";
 import Header from "@/components/layout/Header";
 import Footer from "@/components/layout/Footer";
+import SkipToMainContent from "@/components/layout/SkipToMainContent";
 import { PublicCta } from "@/components/shared/PublicPagePrimitives";
 
 // Lottie ships ~30kB of runtime. Defer it so a hard-404 doesn't pay the cost
@@ -30,8 +31,13 @@ export default function NotFound() {
 
   return (
     <div className="flex min-h-screen flex-col bg-background text-foreground">
+      <SkipToMainContent />
       <Header />
-      <main className="flex flex-1 items-center justify-center px-4 py-16 sm:py-24">
+      <main
+        id="main-content"
+        tabIndex={-1}
+        className="flex flex-1 items-center justify-center px-4 py-16 sm:py-24 outline-none"
+      >
         <div className="mx-auto max-w-lg text-center">
           {animationData !== null ? (
             <div className="mx-auto mb-8 max-w-md">

--- a/src/components/layout/SkipToMainContent.tsx
+++ b/src/components/layout/SkipToMainContent.tsx
@@ -1,0 +1,10 @@
+const skipLinkClassName =
+  "sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[100] focus:rounded-md focus:bg-[#0097b2] focus:px-4 focus:py-2 focus:font-subheading focus:font-medium focus:text-[#FCFAEF] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] focus-visible:ring-offset-2 focus-visible:ring-offset-[#FCFAEF] dark:focus:bg-[#eeba2b] dark:focus:text-[#1C1F1E] dark:focus-visible:ring-[#F5C94D] dark:focus-visible:ring-offset-[#121514]";
+
+export default function SkipToMainContent() {
+  return (
+    <a href="#main-content" className={skipLinkClassName}>
+      Skip to main content
+    </a>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #93.

Follows @nanaagyei’s disposition: **add a focus-visible skip link and main content target.**

- Add a visually hidden “Skip to main content” link that becomes visible on focus (light + dark brand styling)
- Point it at `main#main-content` with `tabIndex={-1}` so activating the link moves keyboard focus into the main landmark
- Wire it into the global marketing shell and the 404 shell (which duplicates Header/main/Footer outside `(main)` layout)
- Cover Tab → skip link → Enter → focus main in e2e

### Files
- [`src/components/layout/SkipToMainContent.tsx`](src/components/layout/SkipToMainContent.tsx) — shared skip link
- [`src/app/(main)/layout.tsx`](src/app/(main)/layout.tsx) — skip link before Header; `main#main-content`
- [`src/app/not-found.tsx`](src/app/not-found.tsx) — same target for 404
- [`e2e/header-nav-a11y.spec.ts`](e2e/header-nav-a11y.spec.ts) — keyboard coverage

## Test plan

- [x] `tsc --noEmit` / production build
- [x] `e2e/header-nav-a11y.spec.ts` (including new skip-link test)
- [x] Manual: open `/`, press Tab → skip link appears; Enter → focus in main
- [x] Manual: repeat in dark mode
- [x] Spot-check a 404 URL still has the skip link