### PR TITLE
Homepage add a care outcomes pathway and retire unverified impact metrics

### DIFF
--- a/e2e/footer-editorial.spec.ts
+++ b/e2e/footer-editorial.spec.ts
@@ -1,0 +1,141 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+import { announcementCampaign } from "../src/data/announcements";
+
+const viewports = [
+  { name: "mobile", width: 375, height: 812, columns: 1 },
+  { name: "tablet", width: 768, height: 1024, columns: 2 },
+  { name: "ipad-pro", width: 1024, height: 1366, columns: 4 },
+  { name: "desktop", width: 1440, height: 900, columns: 4 },
+] as const;
+
+const themes = ["light", "dark"] as const;
+
+async function preparePage(
+  page: Page,
+  theme: (typeof themes)[number],
+) {
+  await page.emulateMedia({ colorScheme: theme });
+  await page.addInitScript(
+    ({ announcementVersion, storedTheme }) => {
+      localStorage.setItem(
+        "akomapa-announcements-dismissed",
+        announcementVersion,
+      );
+      localStorage.setItem("akomapa-theme", storedTheme);
+      document.documentElement.classList.remove("light", "dark");
+      document.documentElement.classList.add(storedTheme);
+    },
+    {
+      announcementVersion: announcementCampaign.version,
+      storedTheme: theme,
+    },
+  );
+}
+
+async function boxesFor(locator: Locator) {
+  return locator.evaluateAll((elements) =>
+    elements.map((element) => {
+      const rect = element.getBoundingClientRect();
+      return {
+        x: rect.x,
+        y: rect.y,
+        width: rect.width,
+        height: rect.height,
+      };
+    }),
+  );
+}
+
+test.describe("editorial site footer", () => {
+  for (const theme of themes) {
+    for (const viewport of viewports) {
+      test(`${viewport.name} ${theme}: preserves hierarchy and responsive layout`, async ({
+        page,
+      }) => {
+        await page.setViewportSize({
+          width: viewport.width,
+          height: viewport.height,
+        });
+        await preparePage(page, theme);
+        await page.goto("/", { waitUntil: "domcontentloaded" });
+
+        const footer = page.locator("[data-site-footer]");
+        const grid = footer.locator("[data-footer-grid]");
+        const newsletter = footer.locator("[data-newsletter]");
+        const newsletterCopy = newsletter.locator("[data-newsletter-copy]");
+        const newsletterForm = newsletter.locator("[data-newsletter-form]");
+        const legal = footer.locator("[data-footer-legal]");
+
+        await footer.scrollIntoViewIfNeeded();
+        await expect(footer).toBeVisible();
+        await expect(newsletter).toBeVisible();
+        await expect(footer).toHaveCSS(
+          "background-color",
+          theme === "light" ? "rgb(252, 250, 239)" : "rgb(18, 21, 20)",
+        );
+        await expect(newsletter).toHaveCSS(
+          "background-color",
+          "rgb(15, 76, 92)",
+        );
+
+        const columnCount = await grid.evaluate(
+          (element) =>
+            getComputedStyle(element).gridTemplateColumns.split(" ").length,
+        );
+        expect(columnCount).toBe(viewport.columns);
+
+        const gridBoxes = await boxesFor(grid.locator(":scope > div"));
+        expect(gridBoxes).toHaveLength(4);
+        if (viewport.columns === 1) {
+          expect(gridBoxes[1].y).toBeGreaterThan(gridBoxes[0].y);
+        } else if (viewport.columns === 2) {
+          expect(Math.abs(gridBoxes[0].y - gridBoxes[1].y)).toBeLessThan(2);
+          expect(gridBoxes[2].y).toBeGreaterThan(gridBoxes[0].y);
+        } else {
+          for (const box of gridBoxes.slice(1)) {
+            expect(Math.abs(gridBoxes[0].y - box.y)).toBeLessThan(2);
+          }
+        }
+
+        const [newsletterCopyBox, newsletterFormBox, legalBox] =
+          await Promise.all([
+            newsletterCopy.boundingBox(),
+            newsletterForm.boundingBox(),
+            legal.boundingBox(),
+          ]);
+
+        expect(newsletterCopyBox).not.toBeNull();
+        expect(newsletterFormBox).not.toBeNull();
+        expect(legalBox).not.toBeNull();
+        if (!newsletterCopyBox || !newsletterFormBox || !legalBox) {
+          throw new Error("Footer geometry was not rendered");
+        }
+
+        if (viewport.width < 1024) {
+          expect(newsletterFormBox.y).toBeGreaterThanOrEqual(
+            newsletterCopyBox.y + newsletterCopyBox.height,
+          );
+        } else {
+          expect(newsletterFormBox.x).toBeGreaterThanOrEqual(
+            newsletterCopyBox.x + newsletterCopyBox.width,
+          );
+        }
+
+        const socialLinks = footer.locator(
+          "[aria-label='Follow Akomapa Health'] > a",
+        );
+        await expect(socialLinks).toHaveCount(4);
+        for (const box of await boxesFor(socialLinks)) {
+          expect(box.width).toBeGreaterThanOrEqual(40);
+          expect(box.height).toBeGreaterThanOrEqual(40);
+        }
+
+        expect(
+          await page.evaluate(
+            () => document.documentElement.scrollWidth - window.innerWidth > 1,
+          ),
+        ).toBe(false);
+      });
+    }
+  }
+});

--- a/e2e/homepage-care-pathway.spec.ts
+++ b/e2e/homepage-care-pathway.spec.ts
@@ -160,37 +160,29 @@ async function getSectionColors(section: Locator) {
       return normalizedColor;
     };
 
-    const stages = Array.from(
-      element.querySelectorAll<HTMLElement>(
-        "[data-care-pathway-bands] > li",
-      ),
+    const ledger = element.querySelector<HTMLElement>(
+      "[data-care-pathway-ledger]",
+    );
+    const title = ledger?.querySelector<HTMLElement>("h3");
+    const body = ledger?.querySelector<HTMLElement>("p");
+    const marker = ledger?.querySelector<HTMLElement>(
+      "[data-care-pathway-marker]",
     );
 
-    if (stages.length === 0) {
+    if (!ledger || !title || !body || !marker) {
       throw new Error("Care pathway contrast targets were not rendered");
     }
 
-    return stages.map((stage) => {
-      const title = stage.querySelector<HTMLElement>("h3");
-      const body = stage.querySelector<HTMLElement>("p");
-      const marker = stage.querySelector<HTMLElement>(
-        "[data-care-pathway-marker]",
-      );
+    const sectionStyles = getComputedStyle(element);
+    const ledgerStyles = getComputedStyle(ledger);
 
-      if (!title || !body || !marker) {
-        throw new Error("Care pathway stage content was not rendered");
-      }
-
-      const stageStyles = getComputedStyle(stage);
-
-      return {
-        background: normalizeToSrgb(stageStyles.backgroundColor),
-        border: normalizeToSrgb(stageStyles.borderBottomColor),
-        marker: normalizeToSrgb(getComputedStyle(marker).color),
-        title: normalizeToSrgb(getComputedStyle(title).color),
-        body: normalizeToSrgb(getComputedStyle(body).color),
-      };
-    });
+    return {
+      sectionBackground: normalizeToSrgb(sectionStyles.backgroundColor),
+      ledgerRule: normalizeToSrgb(ledgerStyles.borderTopColor),
+      marker: normalizeToSrgb(getComputedStyle(marker).color),
+      title: normalizeToSrgb(getComputedStyle(title).color),
+      body: normalizeToSrgb(getComputedStyle(body).color),
+    };
   });
 }
 
@@ -223,7 +215,7 @@ test.describe("homepage care outcomes pathway", () => {
         await expect(section.getByText("What We Measure", { exact: true })).toBeVisible();
         await expect(section.getByText(introduction, { exact: true })).toBeVisible();
         await expect(list).toHaveCount(1);
-        await expect(list).toHaveAttribute("data-care-pathway-bands");
+        await expect(list).toHaveAttribute("data-care-pathway-ledger");
         await expect(listItems).toHaveCount(steps.length);
         await expect(section.locator(".homepage-hover-card")).toHaveCount(0);
         await expect(
@@ -310,21 +302,19 @@ test.describe("homepage care outcomes pathway", () => {
           ),
         ).toBe(false);
 
-        const stageColors = await getSectionColors(section);
-        for (const colors of stageColors) {
-          expect(
-            contrastRatio(colors.title, colors.background),
-          ).toBeGreaterThanOrEqual(4.5);
-          expect(
-            contrastRatio(colors.body, colors.background),
-          ).toBeGreaterThanOrEqual(4.5);
-          expect(
-            contrastRatio(colors.border, colors.background),
-          ).toBeGreaterThanOrEqual(3);
-          expect(
-            contrastRatio(colors.marker, colors.background),
-          ).toBeGreaterThanOrEqual(3);
-        }
+        const colors = await getSectionColors(section);
+        expect(
+          contrastRatio(colors.title, colors.sectionBackground),
+        ).toBeGreaterThanOrEqual(4.5);
+        expect(
+          contrastRatio(colors.body, colors.sectionBackground),
+        ).toBeGreaterThanOrEqual(4.5);
+        expect(
+          contrastRatio(colors.ledgerRule, colors.sectionBackground),
+        ).toBeGreaterThanOrEqual(3);
+        expect(
+          contrastRatio(colors.marker, colors.sectionBackground),
+        ).toBeGreaterThanOrEqual(3);
       });
     }
   }

--- a/e2e/homepage-care-pathway.spec.ts
+++ b/e2e/homepage-care-pathway.spec.ts
@@ -160,25 +160,30 @@ async function getSectionColors(section: Locator) {
       return normalizedColor;
     };
 
-    const ledger = element.querySelector<HTMLElement>(
-      "[data-care-pathway-ledger]",
+    const staircase = element.querySelector<HTMLElement>(
+      "[data-care-pathway-staircase]",
     );
-    const title = ledger?.querySelector<HTMLElement>("h3");
-    const body = ledger?.querySelector<HTMLElement>("p");
-    const marker = ledger?.querySelector<HTMLElement>(
+    const firstStep = staircase?.querySelector<HTMLElement>(":scope > li");
+    const title = firstStep?.querySelector<HTMLElement>("h3");
+    const body = firstStep?.querySelector<HTMLElement>("p");
+    const marker = firstStep?.querySelector<HTMLElement>(
       "[data-care-pathway-marker]",
     );
 
-    if (!ledger || !title || !body || !marker) {
+    if (!staircase || !firstStep || !title || !body || !marker) {
       throw new Error("Care pathway contrast targets were not rendered");
     }
 
     const sectionStyles = getComputedStyle(element);
-    const ledgerStyles = getComputedStyle(ledger);
+    const stepStyles = getComputedStyle(firstStep);
+    const stepRule =
+      stepStyles.borderTopWidth === "0px"
+        ? stepStyles.borderBottomColor
+        : stepStyles.borderTopColor;
 
     return {
       sectionBackground: normalizeToSrgb(sectionStyles.backgroundColor),
-      ledgerRule: normalizeToSrgb(ledgerStyles.borderTopColor),
+      stepRule: normalizeToSrgb(stepRule),
       marker: normalizeToSrgb(getComputedStyle(marker).color),
       title: normalizeToSrgb(getComputedStyle(title).color),
       body: normalizeToSrgb(getComputedStyle(body).color),
@@ -215,7 +220,7 @@ test.describe("homepage care outcomes pathway", () => {
         await expect(section.getByText("What We Measure", { exact: true })).toBeVisible();
         await expect(section.getByText(introduction, { exact: true })).toBeVisible();
         await expect(list).toHaveCount(1);
-        await expect(list).toHaveAttribute("data-care-pathway-ledger");
+        await expect(list).toHaveAttribute("data-care-pathway-staircase");
         await expect(listItems).toHaveCount(steps.length);
         await expect(section.locator(".homepage-hover-card")).toHaveCount(0);
         await expect(
@@ -226,7 +231,7 @@ test.describe("homepage care outcomes pathway", () => {
 
         for (const [index, step] of steps.entries()) {
           const listItem = listItems.nth(index);
-          const marker = listItem.locator('span[aria-hidden="true"]').first();
+          const marker = listItem.locator("[data-care-pathway-marker]");
 
           await expect(marker).toHaveText(step.marker);
           await expect(
@@ -286,12 +291,12 @@ test.describe("homepage care outcomes pathway", () => {
             }
           }
         } else {
-          expect(Math.max(...geometry.map((item) => item.top))).toBeLessThan(
-            Math.min(...geometry.map((item) => item.top)) + 2,
-          );
           for (let index = 1; index < geometry.length; index += 1) {
             expect(geometry[index].left).toBeGreaterThanOrEqual(
               geometry[index - 1].right,
+            );
+            expect(geometry[index].top).toBeGreaterThan(
+              geometry[index - 1].top,
             );
           }
         }
@@ -310,7 +315,7 @@ test.describe("homepage care outcomes pathway", () => {
           contrastRatio(colors.body, colors.sectionBackground),
         ).toBeGreaterThanOrEqual(4.5);
         expect(
-          contrastRatio(colors.ledgerRule, colors.sectionBackground),
+          contrastRatio(colors.stepRule, colors.sectionBackground),
         ).toBeGreaterThanOrEqual(3);
         expect(
           contrastRatio(colors.marker, colors.sectionBackground),

--- a/e2e/homepage-care-pathway.spec.ts
+++ b/e2e/homepage-care-pathway.spec.ts
@@ -1,0 +1,410 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+import { announcementCampaign } from "../src/data/announcements";
+
+const heading = "From screening numbers to care outcomes.";
+
+const introduction =
+  "Akomapa measures success beyond the number of people reached. Our goal is to understand whether people at risk are identified, referred, connected to care, and supported over time.";
+
+const steps = [
+  {
+    marker: "01",
+    title: "Screened",
+    description:
+      "Community members screened for blood pressure, glucose, BMI, and related risk factors.",
+  },
+  {
+    marker: "02",
+    title: "Identified",
+    description:
+      "New suspected hypertension, diabetes, or high-risk cases detected.",
+  },
+  {
+    marker: "03",
+    title: "Referred",
+    description:
+      "Patients referred to clinics, providers, or partner facilities.",
+  },
+  {
+    marker: "04",
+    title: "Linked to care",
+    description:
+      "Referred patients who complete a care visit or verified follow-up.",
+  },
+  {
+    marker: "05",
+    title: "Followed up",
+    description:
+      "Patients contacted after outreach to encourage continuity of care.",
+  },
+  {
+    marker: "06",
+    title: "Leaders trained",
+    description:
+      "Student leaders and health professionals trained in NCD prevention, ethical leadership, referral support, and community-based care.",
+  },
+] as const;
+
+const viewports = [
+  { name: "mobile", width: 390, height: 844, columns: 1 },
+  { name: "tablet", width: 768, height: 1024, columns: 2 },
+  { name: "ipad-pro", width: 1024, height: 1366, columns: 2 },
+  { name: "desktop", width: 1440, height: 900, columns: 6 },
+] as const;
+
+const themes = ["light", "dark"] as const;
+
+type Rgba = { red: number; green: number; blue: number; alpha: number };
+
+function parseCssColor(color: string): Rgba {
+  const channels = color.match(/[\d.]+/g)?.map(Number);
+
+  if (!channels || channels.length < 3) {
+    throw new Error(`Unsupported CSS color: ${color}`);
+  }
+
+  const usesNormalizedSrgb = color.trimStart().startsWith("color(srgb ");
+  const channelScale = usesNormalizedSrgb ? 255 : 1;
+
+  return {
+    red: channels[0] * channelScale,
+    green: channels[1] * channelScale,
+    blue: channels[2] * channelScale,
+    alpha: channels[3] ?? 1,
+  };
+}
+
+function composite(foreground: Rgba, background: Rgba): Rgba {
+  const alpha = foreground.alpha + background.alpha * (1 - foreground.alpha);
+  const blend = (foregroundChannel: number, backgroundChannel: number) =>
+    (foregroundChannel * foreground.alpha +
+      backgroundChannel * background.alpha * (1 - foreground.alpha)) /
+    alpha;
+
+  return {
+    red: blend(foreground.red, background.red),
+    green: blend(foreground.green, background.green),
+    blue: blend(foreground.blue, background.blue),
+    alpha,
+  };
+}
+
+function relativeLuminance({ red, green, blue }: Rgba) {
+  const linearize = (channel: number) => {
+    const normalized = channel / 255;
+    return normalized <= 0.04045
+      ? normalized / 12.92
+      : ((normalized + 0.055) / 1.055) ** 2.4;
+  };
+
+  return (
+    0.2126 * linearize(red) +
+    0.7152 * linearize(green) +
+    0.0722 * linearize(blue)
+  );
+}
+
+function contrastRatio(foregroundCss: string, backgroundCss: string) {
+  const background = parseCssColor(backgroundCss);
+  const foreground = composite(parseCssColor(foregroundCss), background);
+  const foregroundLuminance = relativeLuminance(foreground);
+  const backgroundLuminance = relativeLuminance(background);
+
+  return (
+    (Math.max(foregroundLuminance, backgroundLuminance) + 0.05) /
+    (Math.min(foregroundLuminance, backgroundLuminance) + 0.05)
+  );
+}
+
+async function preparePage(
+  page: Page,
+  theme: (typeof themes)[number],
+  reducedMotion = false,
+) {
+  await page.emulateMedia({
+    colorScheme: theme,
+    reducedMotion: reducedMotion ? "reduce" : "no-preference",
+  });
+  await page.addInitScript(
+    ({ announcementVersion, storedTheme }) => {
+      localStorage.setItem(
+        "akomapa-announcements-dismissed",
+        announcementVersion,
+      );
+      localStorage.setItem("akomapa-theme", storedTheme);
+      document.documentElement.classList.remove("light", "dark");
+      document.documentElement.classList.add(storedTheme);
+    },
+    {
+      announcementVersion: announcementCampaign.version,
+      storedTheme: theme,
+    },
+  );
+}
+
+function getSection(page: Page) {
+  return page.getByRole("region", { name: heading, exact: true });
+}
+
+async function getSectionColors(section: Locator) {
+  return section.evaluate((element) => {
+    const normalizeToSrgb = (color: string) => {
+      const probe = document.createElement("span");
+      probe.style.color = `color-mix(in srgb, ${color} 100%, transparent)`;
+      element.append(probe);
+      const normalizedColor = getComputedStyle(probe).color;
+      probe.remove();
+      return normalizedColor;
+    };
+
+    const card = element.querySelector<HTMLElement>(".homepage-hover-card");
+    const title = card?.querySelector<HTMLElement>("h3");
+    const body = card?.querySelector<HTMLElement>("p");
+    const marker = card?.querySelector<HTMLElement>(
+      'span[aria-hidden="true"]',
+    );
+    const connector = element.querySelector<HTMLElement>(
+      '[data-testid^="care-pathway-"][data-testid$="-connector"]',
+    );
+
+    if (!card || !title || !body || !marker || !connector) {
+      throw new Error("Care pathway contrast targets were not rendered");
+    }
+
+    const cardStyles = getComputedStyle(card);
+    const markerStyles = getComputedStyle(marker);
+
+    return {
+      cardBackground: normalizeToSrgb(cardStyles.backgroundColor),
+      cardBorder: normalizeToSrgb(cardStyles.borderTopColor),
+      connector: normalizeToSrgb(getComputedStyle(connector).backgroundColor),
+      markerBackground: normalizeToSrgb(markerStyles.backgroundColor),
+      markerColor: normalizeToSrgb(markerStyles.color),
+      title: normalizeToSrgb(getComputedStyle(title).color),
+      body: normalizeToSrgb(getComputedStyle(body).color),
+    };
+  });
+}
+
+test.describe("homepage care outcomes pathway", () => {
+  for (const theme of themes) {
+    for (const viewport of viewports) {
+      test(`${viewport.name} ${theme}: preserves copy, order, layout, and contrast`, async ({
+        page,
+      }) => {
+        await page.setViewportSize({
+          width: viewport.width,
+          height: viewport.height,
+        });
+        await preparePage(page, theme);
+        await page.goto("/", { waitUntil: "domcontentloaded" });
+
+        const section = getSection(page);
+        const list = section.locator("ol");
+        const listItems = list.locator(":scope > li");
+        const mobileConnectors = section.getByTestId(
+          "care-pathway-mobile-connector",
+        );
+        const desktopConnectors = section.getByTestId(
+          "care-pathway-desktop-connector",
+        );
+
+        await expect(page.locator("html")).toHaveClass(new RegExp(theme));
+        await expect(section).toBeVisible();
+        await expect(
+          section.getByRole("heading", {
+            level: 2,
+            name: heading,
+            exact: true,
+          }),
+        ).toBeVisible();
+        await expect(section.getByText("What We Measure", { exact: true })).toBeVisible();
+        await expect(section.getByText(introduction, { exact: true })).toBeVisible();
+        await expect(list).toHaveCount(1);
+        await expect(listItems).toHaveCount(steps.length);
+        await expect(section).not.toContainText("3,000+");
+        await expect(section).not.toContainText("95%");
+
+        for (const [index, step] of steps.entries()) {
+          const listItem = listItems.nth(index);
+          const marker = listItem.locator('span[aria-hidden="true"]').first();
+
+          await expect(marker).toHaveText(step.marker);
+          await expect(
+            listItem.getByRole("heading", {
+              level: 3,
+              name: step.title,
+              exact: true,
+            }),
+          ).toBeVisible();
+          await expect(
+            listItem.getByText(step.description, { exact: true }),
+          ).toBeVisible();
+        }
+
+        const geometry = await listItems.evaluateAll((items) =>
+          items.map((item) => {
+            const rect = item.getBoundingClientRect();
+            const content = Array.from(
+              item.querySelectorAll<HTMLElement>("h3, p"),
+            );
+
+            return {
+              top: rect.top,
+              right: rect.right,
+              bottom: rect.bottom,
+              left: rect.left,
+              contentClips: content.some(
+                (element) => element.scrollWidth - element.clientWidth > 1,
+              ),
+            };
+          }),
+        );
+
+        expect(geometry.every((item) => !item.contentClips)).toBe(true);
+
+        if (viewport.columns === 1) {
+          for (let index = 1; index < geometry.length; index += 1) {
+            expect(Math.abs(geometry[index].left - geometry[0].left)).toBeLessThan(
+              2,
+            );
+            expect(geometry[index].top).toBeGreaterThan(
+              geometry[index - 1].bottom,
+            );
+          }
+        } else if (viewport.columns === 2) {
+          for (let row = 0; row < 3; row += 1) {
+            const first = geometry[row * 2];
+            const second = geometry[row * 2 + 1];
+
+            expect(Math.abs(first.top - second.top)).toBeLessThan(2);
+            expect(second.left).toBeGreaterThan(first.right);
+
+            if (row > 0) {
+              expect(first.top).toBeGreaterThan(geometry[(row - 1) * 2].bottom);
+            }
+          }
+        } else {
+          expect(Math.max(...geometry.map((item) => item.top))).toBeLessThan(
+            Math.min(...geometry.map((item) => item.top)) + 2,
+          );
+          for (let index = 1; index < geometry.length; index += 1) {
+            expect(geometry[index].left).toBeGreaterThan(
+              geometry[index - 1].right,
+            );
+          }
+        }
+
+        await expect(mobileConnectors).toHaveCount(steps.length - 1);
+        await expect(desktopConnectors).toHaveCount(steps.length - 1);
+        for (let index = 0; index < steps.length - 1; index += 1) {
+          const mobileDisplay = await mobileConnectors
+            .nth(index)
+            .evaluate((element) => getComputedStyle(element).display);
+          const desktopDisplay = await desktopConnectors
+            .nth(index)
+            .evaluate((element) => getComputedStyle(element).display);
+
+          expect(mobileDisplay).toBe(
+            viewport.columns === 1 ? "block" : "none",
+          );
+          expect(desktopDisplay).toBe(
+            viewport.columns === 6 ? "block" : "none",
+          );
+        }
+
+        expect(
+          await page.evaluate(
+            () => document.documentElement.scrollWidth - window.innerWidth > 1,
+          ),
+        ).toBe(false);
+
+        const colors = await getSectionColors(section);
+        expect(
+          contrastRatio(colors.title, colors.cardBackground),
+        ).toBeGreaterThanOrEqual(3);
+        expect(
+          contrastRatio(colors.body, colors.cardBackground),
+        ).toBeGreaterThanOrEqual(4.5);
+        expect(
+          contrastRatio(colors.cardBorder, colors.cardBackground),
+        ).toBeGreaterThanOrEqual(3);
+        expect(
+          contrastRatio(colors.markerColor, colors.markerBackground),
+        ).toBeGreaterThanOrEqual(4.5);
+        expect(
+          contrastRatio(colors.connector, colors.cardBackground),
+        ).toBeGreaterThanOrEqual(3);
+      });
+    }
+  }
+
+  test("reduced motion renders every step immediately without movement", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await preparePage(page, "light", true);
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+
+    const section = getSection(page);
+    const listItems = section.locator("ol > li");
+    const firstCard = section.locator(".homepage-hover-card").first();
+
+    await section.scrollIntoViewIfNeeded();
+    await expect(listItems).toHaveCount(steps.length);
+
+    for (let index = 0; index < steps.length; index += 1) {
+      await expect
+        .poll(() =>
+          listItems.nth(index).evaluate((element) => {
+            const styles = getComputedStyle(element);
+            return { opacity: styles.opacity, transform: styles.transform };
+          }),
+        )
+        .toEqual({ opacity: "1", transform: "none" });
+    }
+
+    await firstCard.hover();
+    await expect
+      .poll(() =>
+        firstCard.evaluate((element) => getComputedStyle(element).transform),
+      )
+      .toBe("none");
+  });
+
+  test("200% text zoom preserves reflow and readable content", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 768, height: 1024 });
+    await preparePage(page, "light", true);
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await page.evaluate(() => {
+      document.documentElement.style.fontSize = "200%";
+    });
+
+    const section = getSection(page);
+    const listItems = section.locator("ol > li");
+
+    await section.scrollIntoViewIfNeeded();
+    await expect(listItems).toHaveCount(steps.length);
+
+    const clippedContent = await listItems.evaluateAll((items) =>
+      items.flatMap((item) =>
+        Array.from(item.querySelectorAll<HTMLElement>("h3, p"))
+          .filter((element) => element.scrollWidth - element.clientWidth > 1)
+          .map((element) => ({
+            text: element.textContent?.trim(),
+            scrollWidth: element.scrollWidth,
+            clientWidth: element.clientWidth,
+          })),
+      ),
+    );
+
+    expect(clippedContent).toEqual([]);
+    expect(
+      await page.evaluate(
+        () => document.documentElement.scrollWidth - window.innerWidth > 1,
+      ),
+    ).toBe(false);
+  });
+});

--- a/e2e/homepage-care-pathway.spec.ts
+++ b/e2e/homepage-care-pathway.spec.ts
@@ -47,8 +47,11 @@ const steps = [
 
 const viewports = [
   { name: "mobile", width: 390, height: 844, columns: 1 },
+  { name: "mobile-boundary", width: 767, height: 1024, columns: 1 },
   { name: "tablet", width: 768, height: 1024, columns: 2 },
   { name: "ipad-pro", width: 1024, height: 1366, columns: 2 },
+  { name: "tablet-boundary", width: 1279, height: 900, columns: 2 },
+  { name: "desktop-boundary", width: 1280, height: 900, columns: 6 },
   { name: "desktop", width: 1440, height: 900, columns: 6 },
 ] as const;
 
@@ -157,29 +160,26 @@ async function getSectionColors(section: Locator) {
       return normalizedColor;
     };
 
-    const card = element.querySelector<HTMLElement>(".homepage-hover-card");
-    const title = card?.querySelector<HTMLElement>("h3");
-    const body = card?.querySelector<HTMLElement>("p");
-    const marker = card?.querySelector<HTMLElement>(
-      'span[aria-hidden="true"]',
+    const ledger = element.querySelector<HTMLElement>(
+      "[data-care-pathway-ledger]",
     );
-    const connector = element.querySelector<HTMLElement>(
-      '[data-testid^="care-pathway-"][data-testid$="-connector"]',
+    const title = ledger?.querySelector<HTMLElement>("h3");
+    const body = ledger?.querySelector<HTMLElement>("p");
+    const marker = ledger?.querySelector<HTMLElement>(
+      "[data-care-pathway-marker]",
     );
 
-    if (!card || !title || !body || !marker || !connector) {
+    if (!ledger || !title || !body || !marker) {
       throw new Error("Care pathway contrast targets were not rendered");
     }
 
-    const cardStyles = getComputedStyle(card);
-    const markerStyles = getComputedStyle(marker);
+    const sectionStyles = getComputedStyle(element);
+    const ledgerStyles = getComputedStyle(ledger);
 
     return {
-      cardBackground: normalizeToSrgb(cardStyles.backgroundColor),
-      cardBorder: normalizeToSrgb(cardStyles.borderTopColor),
-      connector: normalizeToSrgb(getComputedStyle(connector).backgroundColor),
-      markerBackground: normalizeToSrgb(markerStyles.backgroundColor),
-      markerColor: normalizeToSrgb(markerStyles.color),
+      sectionBackground: normalizeToSrgb(sectionStyles.backgroundColor),
+      ledgerRule: normalizeToSrgb(ledgerStyles.borderTopColor),
+      marker: normalizeToSrgb(getComputedStyle(marker).color),
       title: normalizeToSrgb(getComputedStyle(title).color),
       body: normalizeToSrgb(getComputedStyle(body).color),
     };
@@ -202,12 +202,6 @@ test.describe("homepage care outcomes pathway", () => {
         const section = getSection(page);
         const list = section.locator("ol");
         const listItems = list.locator(":scope > li");
-        const mobileConnectors = section.getByTestId(
-          "care-pathway-mobile-connector",
-        );
-        const desktopConnectors = section.getByTestId(
-          "care-pathway-desktop-connector",
-        );
 
         await expect(page.locator("html")).toHaveClass(new RegExp(theme));
         await expect(section).toBeVisible();
@@ -221,7 +215,12 @@ test.describe("homepage care outcomes pathway", () => {
         await expect(section.getByText("What We Measure", { exact: true })).toBeVisible();
         await expect(section.getByText(introduction, { exact: true })).toBeVisible();
         await expect(list).toHaveCount(1);
+        await expect(list).toHaveAttribute("data-care-pathway-ledger");
         await expect(listItems).toHaveCount(steps.length);
+        await expect(section.locator(".homepage-hover-card")).toHaveCount(0);
+        await expect(
+          section.locator('[data-testid$="-connector"]'),
+        ).toHaveCount(0);
         await expect(section).not.toContainText("3,000+");
         await expect(section).not.toContainText("95%");
 
@@ -268,7 +267,7 @@ test.describe("homepage care outcomes pathway", () => {
             expect(Math.abs(geometry[index].left - geometry[0].left)).toBeLessThan(
               2,
             );
-            expect(geometry[index].top).toBeGreaterThan(
+            expect(geometry[index].top).toBeGreaterThanOrEqual(
               geometry[index - 1].bottom,
             );
           }
@@ -278,10 +277,12 @@ test.describe("homepage care outcomes pathway", () => {
             const second = geometry[row * 2 + 1];
 
             expect(Math.abs(first.top - second.top)).toBeLessThan(2);
-            expect(second.left).toBeGreaterThan(first.right);
+            expect(second.left).toBeGreaterThanOrEqual(first.right);
 
             if (row > 0) {
-              expect(first.top).toBeGreaterThan(geometry[(row - 1) * 2].bottom);
+              expect(first.top).toBeGreaterThanOrEqual(
+                geometry[(row - 1) * 2].bottom,
+              );
             }
           }
         } else {
@@ -289,28 +290,10 @@ test.describe("homepage care outcomes pathway", () => {
             Math.min(...geometry.map((item) => item.top)) + 2,
           );
           for (let index = 1; index < geometry.length; index += 1) {
-            expect(geometry[index].left).toBeGreaterThan(
+            expect(geometry[index].left).toBeGreaterThanOrEqual(
               geometry[index - 1].right,
             );
           }
-        }
-
-        await expect(mobileConnectors).toHaveCount(steps.length - 1);
-        await expect(desktopConnectors).toHaveCount(steps.length - 1);
-        for (let index = 0; index < steps.length - 1; index += 1) {
-          const mobileDisplay = await mobileConnectors
-            .nth(index)
-            .evaluate((element) => getComputedStyle(element).display);
-          const desktopDisplay = await desktopConnectors
-            .nth(index)
-            .evaluate((element) => getComputedStyle(element).display);
-
-          expect(mobileDisplay).toBe(
-            viewport.columns === 1 ? "block" : "none",
-          );
-          expect(desktopDisplay).toBe(
-            viewport.columns === 6 ? "block" : "none",
-          );
         }
 
         expect(
@@ -321,19 +304,16 @@ test.describe("homepage care outcomes pathway", () => {
 
         const colors = await getSectionColors(section);
         expect(
-          contrastRatio(colors.title, colors.cardBackground),
-        ).toBeGreaterThanOrEqual(3);
-        expect(
-          contrastRatio(colors.body, colors.cardBackground),
+          contrastRatio(colors.title, colors.sectionBackground),
         ).toBeGreaterThanOrEqual(4.5);
         expect(
-          contrastRatio(colors.cardBorder, colors.cardBackground),
-        ).toBeGreaterThanOrEqual(3);
-        expect(
-          contrastRatio(colors.markerColor, colors.markerBackground),
+          contrastRatio(colors.body, colors.sectionBackground),
         ).toBeGreaterThanOrEqual(4.5);
         expect(
-          contrastRatio(colors.connector, colors.cardBackground),
+          contrastRatio(colors.ledgerRule, colors.sectionBackground),
+        ).toBeGreaterThanOrEqual(3);
+        expect(
+          contrastRatio(colors.marker, colors.sectionBackground),
         ).toBeGreaterThanOrEqual(3);
       });
     }
@@ -348,7 +328,6 @@ test.describe("homepage care outcomes pathway", () => {
 
     const section = getSection(page);
     const listItems = section.locator("ol > li");
-    const firstCard = section.locator(".homepage-hover-card").first();
 
     await section.scrollIntoViewIfNeeded();
     await expect(listItems).toHaveCount(steps.length);
@@ -363,13 +342,6 @@ test.describe("homepage care outcomes pathway", () => {
         )
         .toEqual({ opacity: "1", transform: "none" });
     }
-
-    await firstCard.hover();
-    await expect
-      .poll(() =>
-        firstCard.evaluate((element) => getComputedStyle(element).transform),
-      )
-      .toBe("none");
   });
 
   test("200% text zoom preserves reflow and readable content", async ({

--- a/e2e/homepage-care-pathway.spec.ts
+++ b/e2e/homepage-care-pathway.spec.ts
@@ -160,29 +160,37 @@ async function getSectionColors(section: Locator) {
       return normalizedColor;
     };
 
-    const ledger = element.querySelector<HTMLElement>(
-      "[data-care-pathway-ledger]",
-    );
-    const title = ledger?.querySelector<HTMLElement>("h3");
-    const body = ledger?.querySelector<HTMLElement>("p");
-    const marker = ledger?.querySelector<HTMLElement>(
-      "[data-care-pathway-marker]",
+    const stages = Array.from(
+      element.querySelectorAll<HTMLElement>(
+        "[data-care-pathway-bands] > li",
+      ),
     );
 
-    if (!ledger || !title || !body || !marker) {
+    if (stages.length === 0) {
       throw new Error("Care pathway contrast targets were not rendered");
     }
 
-    const sectionStyles = getComputedStyle(element);
-    const ledgerStyles = getComputedStyle(ledger);
+    return stages.map((stage) => {
+      const title = stage.querySelector<HTMLElement>("h3");
+      const body = stage.querySelector<HTMLElement>("p");
+      const marker = stage.querySelector<HTMLElement>(
+        "[data-care-pathway-marker]",
+      );
 
-    return {
-      sectionBackground: normalizeToSrgb(sectionStyles.backgroundColor),
-      ledgerRule: normalizeToSrgb(ledgerStyles.borderTopColor),
-      marker: normalizeToSrgb(getComputedStyle(marker).color),
-      title: normalizeToSrgb(getComputedStyle(title).color),
-      body: normalizeToSrgb(getComputedStyle(body).color),
-    };
+      if (!title || !body || !marker) {
+        throw new Error("Care pathway stage content was not rendered");
+      }
+
+      const stageStyles = getComputedStyle(stage);
+
+      return {
+        background: normalizeToSrgb(stageStyles.backgroundColor),
+        border: normalizeToSrgb(stageStyles.borderBottomColor),
+        marker: normalizeToSrgb(getComputedStyle(marker).color),
+        title: normalizeToSrgb(getComputedStyle(title).color),
+        body: normalizeToSrgb(getComputedStyle(body).color),
+      };
+    });
   });
 }
 
@@ -215,7 +223,7 @@ test.describe("homepage care outcomes pathway", () => {
         await expect(section.getByText("What We Measure", { exact: true })).toBeVisible();
         await expect(section.getByText(introduction, { exact: true })).toBeVisible();
         await expect(list).toHaveCount(1);
-        await expect(list).toHaveAttribute("data-care-pathway-ledger");
+        await expect(list).toHaveAttribute("data-care-pathway-bands");
         await expect(listItems).toHaveCount(steps.length);
         await expect(section.locator(".homepage-hover-card")).toHaveCount(0);
         await expect(
@@ -302,19 +310,21 @@ test.describe("homepage care outcomes pathway", () => {
           ),
         ).toBe(false);
 
-        const colors = await getSectionColors(section);
-        expect(
-          contrastRatio(colors.title, colors.sectionBackground),
-        ).toBeGreaterThanOrEqual(4.5);
-        expect(
-          contrastRatio(colors.body, colors.sectionBackground),
-        ).toBeGreaterThanOrEqual(4.5);
-        expect(
-          contrastRatio(colors.ledgerRule, colors.sectionBackground),
-        ).toBeGreaterThanOrEqual(3);
-        expect(
-          contrastRatio(colors.marker, colors.sectionBackground),
-        ).toBeGreaterThanOrEqual(3);
+        const stageColors = await getSectionColors(section);
+        for (const colors of stageColors) {
+          expect(
+            contrastRatio(colors.title, colors.background),
+          ).toBeGreaterThanOrEqual(4.5);
+          expect(
+            contrastRatio(colors.body, colors.background),
+          ).toBeGreaterThanOrEqual(4.5);
+          expect(
+            contrastRatio(colors.border, colors.background),
+          ).toBeGreaterThanOrEqual(3);
+          expect(
+            contrastRatio(colors.marker, colors.background),
+          ).toBeGreaterThanOrEqual(3);
+        }
       });
     }
   }

--- a/e2e/homepage-editorial-sections.spec.ts
+++ b/e2e/homepage-editorial-sections.spec.ts
@@ -1,0 +1,180 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+import { announcementCampaign } from "../src/data/announcements";
+
+const viewports = [
+  { name: "mobile", width: 390, height: 844, impactColumns: 1 },
+  { name: "tablet", width: 768, height: 1024, impactColumns: 2 },
+  { name: "ipad-pro", width: 1024, height: 1366, impactColumns: 2 },
+  { name: "desktop", width: 1440, height: 900, impactColumns: 4 },
+] as const;
+
+const themes = ["light", "dark"] as const;
+
+async function preparePage(
+  page: Page,
+  theme: (typeof themes)[number],
+) {
+  await page.emulateMedia({ colorScheme: theme });
+  await page.addInitScript(
+    ({ announcementVersion, storedTheme }) => {
+      localStorage.setItem(
+        "akomapa-announcements-dismissed",
+        announcementVersion,
+      );
+      localStorage.setItem("akomapa-theme", storedTheme);
+      document.documentElement.classList.remove("light", "dark");
+      document.documentElement.classList.add(storedTheme);
+    },
+    {
+      announcementVersion: announcementCampaign.version,
+      storedTheme: theme,
+    },
+  );
+}
+
+async function boxesFor(locator: Locator) {
+  const boxes = await locator.evaluateAll((elements) =>
+    elements.map((element) => {
+      const rect = element.getBoundingClientRect();
+      return {
+        x: rect.x,
+        y: rect.y,
+        width: rect.width,
+        height: rect.height,
+      };
+    }),
+  );
+
+  expect(boxes.length).toBeGreaterThan(0);
+  return boxes;
+}
+
+test.describe("homepage editorial impact, values, and vision sections", () => {
+  for (const theme of themes) {
+    for (const viewport of viewports) {
+      test(`${viewport.name} ${theme}: preserves section tones and responsive hierarchy`, async ({
+        page,
+      }) => {
+        await page.setViewportSize({
+          width: viewport.width,
+          height: viewport.height,
+        });
+        await preparePage(page, theme);
+        await page.goto("/", { waitUntil: "domcontentloaded" });
+
+        const impact = page.locator("[data-transformational-impact]");
+        const values = page.locator("[data-values-section]");
+        const vision = page.locator("[data-vision-section]");
+        const impactCopyLocator = impact.locator("[data-impact-copy]");
+        const valuesCopyLocator = values.locator("[data-values-copy]");
+        const visionStatementLocator = vision.locator(
+          "[data-vision-statement]",
+        );
+
+        await Promise.all([
+          expect(impactCopyLocator).toBeVisible({ timeout: 15_000 }),
+          expect(valuesCopyLocator).toBeVisible({ timeout: 15_000 }),
+          expect(visionStatementLocator).toBeVisible({ timeout: 15_000 }),
+        ]);
+
+        await expect(impact).toHaveCSS("background-color", "rgb(0, 151, 178)");
+        await expect(values).toHaveCSS(
+          "background-color",
+          theme === "light" ? "rgb(252, 250, 239)" : "rgb(18, 21, 20)",
+        );
+        await expect(vision).toHaveCSS(
+          "background-color",
+          theme === "light" ? "rgb(255, 255, 255)" : "rgb(28, 31, 30)",
+        );
+
+        const impactCopy = await impactCopyLocator.boundingBox();
+        const impactContext = await impact
+          .locator("[data-impact-context]")
+          .boundingBox();
+        const valuesCopy = await valuesCopyLocator.boundingBox();
+        const valuesImage = await values
+          .locator("[data-values-image]")
+          .boundingBox();
+        const visionStatement = await visionStatementLocator.boundingBox();
+        const visionCopy = await vision.locator("[data-vision-copy]").boundingBox();
+
+        expect(impactCopy).not.toBeNull();
+        expect(impactContext).not.toBeNull();
+        expect(valuesCopy).not.toBeNull();
+        expect(valuesImage).not.toBeNull();
+        expect(visionStatement).not.toBeNull();
+        expect(visionCopy).not.toBeNull();
+
+        if (
+          !impactCopy ||
+          !impactContext ||
+          !valuesCopy ||
+          !valuesImage ||
+          !visionStatement ||
+          !visionCopy
+        ) {
+          throw new Error("Editorial section geometry was not rendered");
+        }
+
+        if (viewport.width < 1024) {
+          expect(impactContext.y).toBeGreaterThanOrEqual(
+            impactCopy.y + impactCopy.height,
+          );
+          expect(valuesImage.y).toBeGreaterThanOrEqual(
+            valuesCopy.y + valuesCopy.height,
+          );
+          expect(visionCopy.y).toBeGreaterThanOrEqual(
+            visionStatement.y + visionStatement.height,
+          );
+        } else {
+          expect(impactContext.x).toBeGreaterThanOrEqual(
+            impactCopy.x + impactCopy.width,
+          );
+          expect(valuesImage.x).toBeGreaterThanOrEqual(
+            valuesCopy.x + valuesCopy.width,
+          );
+          expect(visionCopy.x).toBeGreaterThanOrEqual(
+            visionStatement.x + visionStatement.width,
+          );
+        }
+
+        const metricBoxes = await boxesFor(
+          impact.locator("[data-community-metrics] > *"),
+        );
+        expect(metricBoxes).toHaveLength(4);
+        if (viewport.impactColumns === 1) {
+          expect(metricBoxes[1].y).toBeGreaterThan(metricBoxes[0].y);
+        } else if (viewport.impactColumns === 2) {
+          expect(Math.abs(metricBoxes[0].y - metricBoxes[1].y)).toBeLessThan(2);
+          expect(metricBoxes[2].y).toBeGreaterThan(metricBoxes[0].y);
+        } else {
+          for (const metricBox of metricBoxes.slice(1)) {
+            expect(Math.abs(metricBoxes[0].y - metricBox.y)).toBeLessThan(2);
+          }
+        }
+
+        const valueBoxes = await boxesFor(
+          values.locator("[data-values-list] > li"),
+        );
+        const priorityBoxes = await boxesFor(
+          vision.locator("[data-vision-priorities] > li"),
+        );
+        if (viewport.width < 640) {
+          expect(valueBoxes[1].y).toBeGreaterThan(valueBoxes[0].y);
+          expect(priorityBoxes[1].y).toBeGreaterThan(priorityBoxes[0].y);
+        } else {
+          expect(Math.abs(valueBoxes[0].y - valueBoxes[1].y)).toBeLessThan(2);
+          expect(Math.abs(priorityBoxes[0].y - priorityBoxes[1].y)).toBeLessThan(
+            2,
+          );
+        }
+
+        expect(
+          await page.evaluate(
+            () => document.documentElement.scrollWidth - window.innerWidth > 1,
+          ),
+        ).toBe(false);
+      });
+    }
+  }
+});

--- a/e2e/homepage-final-composition.spec.ts
+++ b/e2e/homepage-final-composition.spec.ts
@@ -42,6 +42,12 @@ test.describe("final homepage composition", () => {
       ).toBeVisible();
       await expect(
         page.getByRole("heading", {
+          name: "From screening numbers to care outcomes.",
+          exact: true,
+        }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("heading", {
           name: 'Akomapa means "A Good Heart."',
         }),
       ).toBeVisible();
@@ -55,6 +61,40 @@ test.describe("final homepage composition", () => {
           name: /five components, one connected system/i,
         }),
       ).toBeVisible();
+      await expect(
+        page.getByText("Community members screened", { exact: true }).first(),
+      ).toBeVisible();
+      await expect(
+        page.getByText("Linkage-to-care rate", { exact: true }).first(),
+      ).toBeVisible();
+
+      const narrativeHeadingOrder = await page
+        .locator("main h2")
+        .evaluateAll((headings) => headings.map((heading) => heading.textContent?.trim()));
+      expect(narrativeHeadingOrder.indexOf("One model. Two challenges. Lasting impact."))
+        .toBeLessThan(
+          narrativeHeadingOrder.indexOf(
+            "From screening numbers to care outcomes.",
+          ),
+        );
+      expect(
+        narrativeHeadingOrder.indexOf(
+          "From screening numbers to care outcomes.",
+        ),
+      ).toBeLessThan(
+        narrativeHeadingOrder.indexOf("Research before implementation."),
+      );
+
+      await expect(page.locator("[data-home-band-marker]")).toHaveText([
+        "01",
+        "02",
+        "03",
+        "04",
+        "05",
+        "06",
+        "07",
+        "08",
+      ]);
       await expect(
         page.getByRole("heading", {
           name: "Nkwapa connects care, learning, and evidence.",

--- a/e2e/homepage-join-movement.spec.ts
+++ b/e2e/homepage-join-movement.spec.ts
@@ -1,0 +1,146 @@
+import { expect, test, type Page } from "@playwright/test";
+import { announcementCampaign } from "../src/data/announcements";
+
+const heading =
+  "Build healthier communities and stronger health leaders with us.";
+
+const viewports = [
+  { name: "mobile", width: 390, height: 844, columns: 1 },
+  { name: "tablet", width: 768, height: 1024, columns: 2 },
+  { name: "ipad-pro", width: 1024, height: 1366, columns: 2 },
+  { name: "desktop", width: 1440, height: 900, columns: 2 },
+] as const;
+
+const themes = ["light", "dark"] as const;
+
+async function preparePage(
+  page: Page,
+  theme: (typeof themes)[number],
+) {
+  await page.emulateMedia({ colorScheme: theme });
+  await page.addInitScript(
+    ({ announcementVersion, storedTheme }) => {
+      localStorage.setItem(
+        "akomapa-announcements-dismissed",
+        announcementVersion,
+      );
+      localStorage.setItem("akomapa-theme", storedTheme);
+      document.documentElement.classList.remove("light", "dark");
+      document.documentElement.classList.add(storedTheme);
+    },
+    {
+      announcementVersion: announcementCampaign.version,
+      storedTheme: theme,
+    },
+  );
+}
+
+test.describe("homepage Join the Movement call to action", () => {
+  for (const theme of themes) {
+    for (const viewport of viewports) {
+      test(`${viewport.name} ${theme}: preserves hierarchy and responsive layout`, async ({
+        page,
+      }) => {
+        await page.setViewportSize({
+          width: viewport.width,
+          height: viewport.height,
+        });
+        await preparePage(page, theme);
+        await page.goto("/", { waitUntil: "domcontentloaded" });
+
+        const section = page.getByRole("region", {
+          name: heading,
+          exact: true,
+        });
+        const copy = section.locator("[data-join-copy]");
+        const actions = section.locator("[data-join-actions]");
+        const supportLink = section.getByRole("link", {
+          name: "Support Our Work",
+        });
+        const partnershipLink = section.getByRole("link", {
+          name: "Partner With Us",
+        });
+        const participationLink = section.getByRole("link", {
+          name: "Join Akomapa",
+        });
+
+        await section.scrollIntoViewIfNeeded();
+        await expect(section).toBeVisible();
+        await expect(page.locator("html")).toHaveClass(new RegExp(theme));
+        await expect(section).toHaveCSS(
+          "background-color",
+          "rgb(15, 76, 92)",
+        );
+        await expect(supportLink).toHaveAttribute("href", "/donate");
+        await expect(partnershipLink).toHaveAttribute(
+          "href",
+          "/partnerships",
+        );
+        await expect(participationLink).toHaveAttribute(
+          "href",
+          "/get-involved",
+        );
+
+        const [copyBox, actionsBox, supportBox, partnershipBox, participationBox] =
+          await Promise.all([
+            copy.boundingBox(),
+            actions.boundingBox(),
+            supportLink.boundingBox(),
+            partnershipLink.boundingBox(),
+            participationLink.boundingBox(),
+          ]);
+
+        expect(copyBox).not.toBeNull();
+        expect(actionsBox).not.toBeNull();
+        expect(supportBox).not.toBeNull();
+        expect(partnershipBox).not.toBeNull();
+        expect(participationBox).not.toBeNull();
+
+        if (
+          !copyBox ||
+          !actionsBox ||
+          !supportBox ||
+          !partnershipBox ||
+          !participationBox
+        ) {
+          throw new Error("Join the Movement geometry was not rendered");
+        }
+
+        if (viewport.width < 1024) {
+          expect(actionsBox.y).toBeGreaterThanOrEqual(
+            copyBox.y + copyBox.height,
+          );
+        } else {
+          expect(actionsBox.x).toBeGreaterThanOrEqual(
+            copyBox.x + copyBox.width,
+          );
+        }
+
+        if (viewport.columns === 1) {
+          expect(partnershipBox.y).toBeGreaterThanOrEqual(
+            supportBox.y + supportBox.height,
+          );
+          expect(participationBox.y).toBeGreaterThanOrEqual(
+            partnershipBox.y + partnershipBox.height,
+          );
+        } else {
+          expect(partnershipBox.y).toBeGreaterThan(
+            supportBox.y + supportBox.height,
+          );
+          expect(Math.abs(partnershipBox.y - participationBox.y)).toBeLessThan(
+            2,
+          );
+          expect(participationBox.x).toBeGreaterThanOrEqual(
+            partnershipBox.x + partnershipBox.width,
+          );
+        }
+
+        expect(
+          await page.evaluate(
+            () => document.documentElement.scrollWidth - window.innerWidth > 1,
+          ),
+        ).toBe(false);
+      });
+    }
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -2094,9 +2094,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.19",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.19.tgz",
-      "integrity": "sha512-sWWluFvcv5v3Fxznmf2ZfjyoVQt/64oCnYqS90inQWGzMPK1VjvekPiz3OPHKmFT30EnHrjlbyaHLt3M0vWabw==",
+      "version": "15.5.21",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.21.tgz",
+      "integrity": "sha512-hjJI/GfrjWHgNguRIBzItjRRu0m3Nrz17GhxsjuHfjIvg9hyg3239REd2dpI+bpMTFuVrVprHzEQ19m++cDtbw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2110,9 +2110,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.19.tgz",
-      "integrity": "sha512-jx9wWlTKueHKPvVOndyr7WuaevWCkuYqsQ8gC0TMPKAVWG3MhcdMrjfo9tvIZNXd0QOUYXXvAcZ325y8Uq7uzg==",
+      "version": "15.5.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.21.tgz",
+      "integrity": "sha512-ZfjqPEdi6TRC/fWx7UDbwb1fbVgyh2uD5tVTRKIDZDlYM+UNuE/LafDG2fwuAoZilADpABh46OY/F5qf9JjqLQ==",
       "cpu": [
         "arm64"
       ],
@@ -2126,9 +2126,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.19.tgz",
-      "integrity": "sha512-291KFcsIQ3OenRdiUDFOR6W3wezzH4auENXm1gbm1Bjd4ANMMRgxPrWTUztQN43BnVoVuMnHCrLeECIMwgFKbA==",
+      "version": "15.5.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.21.tgz",
+      "integrity": "sha512-TlCf1NpxgQLzTrexuev75xwmNCJMd1/qkJpTVP1GRRcih93hlIBn1P72hkh8T0gnRFr6BmWksQtbyG3jT6jnww==",
       "cpu": [
         "x64"
       ],
@@ -2142,9 +2142,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.19.tgz",
-      "integrity": "sha512-WeH+nelQyyMeE2f8FxBRZNrGipya5zHZV2vjzfCOAYyiI6am+NbnWAAldOBFQBB2w0DjJcsvrKqoFT2b7+5YoA==",
+      "version": "15.5.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.21.tgz",
+      "integrity": "sha512-LXRsq1p+HvHSi7ygwNcSEEcK0zuo5jS75ZlqFHtOH+LF7qntXAJVJxah+1Pi/GyBm7EpkwU7m4EgbvIKrMqm9A==",
       "cpu": [
         "arm64"
       ],
@@ -2158,9 +2158,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.19.tgz",
-      "integrity": "sha512-5xTOE0lDlDCSSfp+BAif7j17VRRCjWp//ZPZy6NI0QpdrhxtQnsZguSx0xAAZ0c9XZLrLLwCe/XVe5YPrRilKw==",
+      "version": "15.5.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.21.tgz",
+      "integrity": "sha512-hyGixhFxpDKjqoev6l4KlcRBlt9AXWrGhDZwmwg49sMJM5tnKQPSi+SEj9+e5n+l/bthRGZUdh59GKIs6lQPRw==",
       "cpu": [
         "arm64"
       ],
@@ -2174,9 +2174,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.19.tgz",
-      "integrity": "sha512-LTxRmMgqqMv05Had879W00Fm53quiJd3Zuz8h1JSNJ3nGSlbZ/7Tjs1tKyScgN3Au3t3MyPsjPlq60fMmSHLsg==",
+      "version": "15.5.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.21.tgz",
+      "integrity": "sha512-qfE+YfOba6S2+13e8qn1/UozDVNZ2clBlrs8UtDoax4s8ediu6sq93z66OEHUYlb69Tffh5JTNkgtsAKiSuugg==",
       "cpu": [
         "x64"
       ],
@@ -2190,9 +2190,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.19.tgz",
-      "integrity": "sha512-eoNQSpA5PQfB9wBO4RA47MTDXWz1fizy9Y3Z6e4DetYIF3dvjuu8sj7aIGn/bFCU6lnFzTK34NtCaffP4NsQ7Q==",
+      "version": "15.5.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.21.tgz",
+      "integrity": "sha512-BXLGG+EvIwp/Rrgl6HY8sqvD6BOUOIRz8/naDbeLNX7mlA5H2XRcL6MW/0IGnJISfj5BA9gNhFyJj5yOoiIDJQ==",
       "cpu": [
         "x64"
       ],
@@ -2206,9 +2206,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.19.tgz",
-      "integrity": "sha512-6UNt2dFuCHOe446sm/Kp69nUe8/wIhnh9bm6Xcqw4qEWCOppLMOvhTBVgvM7invVUNr4SPpP6NOQsACtn2IN9Q==",
+      "version": "15.5.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.21.tgz",
+      "integrity": "sha512-tNGNOlT0Wn7E4IMsSnufjXN/l2L2/AGdLLpa2vzS89SYCBuihgLn3ngLsIrvndAnWo9nAkus+4gZHTI/Ijx9HA==",
       "cpu": [
         "arm64"
       ],
@@ -2222,9 +2222,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.19.tgz",
-      "integrity": "sha512-PhmojAHyqMne56HBLGu9dhDnHPuFmEjrXSQMM/nW0J6j849lk3ESrVtqNJcCk8CKOV7brpTTbaYAjwKPzKM69w==",
+      "version": "15.5.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.21.tgz",
+      "integrity": "sha512-DmIdWmC9p4rdNIiQqo8ap0+Cnj6kKtTZnuSCxoYydSc8sgpDgAg9wFhxplunak9imLV0pTvc5WVCOHwm5eHLtQ==",
       "cpu": [
         "x64"
       ],
@@ -5934,16 +5934,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -7409,9 +7409,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9306,9 +9306,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -9763,15 +9763,15 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/glob/node_modules/minimatch": {
@@ -10858,9 +10858,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -12027,12 +12027,12 @@
       }
     },
     "node_modules/next": {
-      "version": "15.5.19",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.19.tgz",
-      "integrity": "sha512-xNOW6tYshGX1/Oi3F8uuk4gpDeWsSUE/1Z0G5uUMekIxaQ0xc03UXd9II0VQHYMWviMeA0OHpJFAKsHf8bTYVg==",
+      "version": "15.5.21",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.21.tgz",
+      "integrity": "sha512-/TsdBtkWLhkl+NVL3Uqws2UphNd6IPzOtzSk1fHaf+0P7GQKLZDUytyhns/Ykbzdy9+YRjwG7ONvrHaaTDdFqQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.19",
+        "@next/env": "15.5.21",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -12045,14 +12045,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.19",
-        "@next/swc-darwin-x64": "15.5.19",
-        "@next/swc-linux-arm64-gnu": "15.5.19",
-        "@next/swc-linux-arm64-musl": "15.5.19",
-        "@next/swc-linux-x64-gnu": "15.5.19",
-        "@next/swc-linux-x64-musl": "15.5.19",
-        "@next/swc-win32-arm64-msvc": "15.5.19",
-        "@next/swc-win32-x64-msvc": "15.5.19",
+        "@next/swc-darwin-arm64": "15.5.21",
+        "@next/swc-darwin-x64": "15.5.21",
+        "@next/swc-linux-arm64-gnu": "15.5.21",
+        "@next/swc-linux-arm64-musl": "15.5.21",
+        "@next/swc-linux-x64-gnu": "15.5.21",
+        "@next/swc-linux-x64-musl": "15.5.21",
+        "@next/swc-win32-arm64-msvc": "15.5.21",
+        "@next/swc-win32-x64-msvc": "15.5.21",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -11,6 +11,9 @@ const ChallengeSection = dynamic(
 const WhyAkomapaSection = dynamic(
   () => import("@/components/home/WhyAkomapaSection"),
 );
+const CarePathwaySection = dynamic(
+  () => import("@/components/home/CarePathwaySection"),
+);
 const BuiltOnEvidenceSection = dynamic(
   () => import("@/components/home/BuiltOnEvidenceSection"),
 );
@@ -42,6 +45,7 @@ export default function Home() {
       <HeroSection />
       <ChallengeSection />
       <WhyAkomapaSection />
+      <CarePathwaySection />
       <BuiltOnEvidenceSection />
       <OurModelSection />
       <TransformationalImpactSection />

--- a/src/components/home/AkomapaMeaningSection.tsx
+++ b/src/components/home/AkomapaMeaningSection.tsx
@@ -8,16 +8,79 @@ import {
   HomeLead,
 } from "@/components/home/_home-ui";
 
-const values = ["Empathy", "Equity", "Excellence"];
+const values = [
+  { name: "Empathy", number: "01" },
+  { name: "Equity", number: "02" },
+  { name: "Excellence", number: "03" },
+] as const;
 
 export default function AkomapaMeaningSection() {
   const headingId = "akomapa-meaning-heading";
 
   return (
-    <HomeBand tone="cream" marker="06" aria-labelledby={headingId}>
-      <div className="grid items-center gap-10 lg:grid-cols-12 lg:gap-16">
-        <FadeIn direction="right" className="lg:col-span-5">
-          <div className="relative mx-auto aspect-[4/5] w-full max-w-md overflow-hidden rounded-2xl border border-[#E6E7E7] dark:border-[#2F3332]">
+    <HomeBand
+      tone="cream"
+      marker="06"
+      aria-labelledby={headingId}
+      data-values-section
+    >
+      <div className="grid items-center gap-12 lg:grid-cols-12 lg:gap-16">
+        <FadeIn className="lg:col-span-7">
+          <div data-values-copy>
+            <HomeEyebrow tone="gold">Our Values</HomeEyebrow>
+            <HomeHeading
+              id={headingId}
+              className="mt-4 max-w-3xl lg:text-[3.2rem]"
+            >
+              Akomapa means &quot;A Good Heart.&quot;
+            </HomeHeading>
+            <div className="mt-6 max-w-2xl space-y-5">
+              <HomeLead>
+                In Akan, Akomapa represents more than compassion. It reflects our
+                belief that meaningful healthcare begins with both clinical
+                excellence and moral leadership.
+              </HomeLead>
+              <HomeLead>
+                We believe every person deserves compassionate care, every
+                community deserves equitable access to high-quality healthcare,
+                and every health professional has a responsibility to lead with
+                humility, integrity, and service.
+              </HomeLead>
+            </div>
+
+            <ul
+              aria-label="Akomapa values"
+              data-values-list
+              className="mt-9 grid border-y border-[#0097b2]/25 sm:grid-cols-3 dark:border-[#66C4DC]/25"
+            >
+              {values.map((value, index) => (
+                <li
+                  key={value.name}
+                  className={`flex min-h-32 flex-col justify-between border-[#0097b2]/25 py-5 sm:px-5 dark:border-[#66C4DC]/25 ${
+                    index > 0 ? "border-t sm:border-l sm:border-t-0" : ""
+                  }`}
+                >
+                  <span className="font-subheading text-xs font-bold tracking-[0.2em] text-[#C9920F] dark:text-[#F5C94D]">
+                    {value.number}
+                  </span>
+                  <span className="font-heading text-2xl font-semibold text-[#0097b2] dark:text-[#66C4DC]">
+                    {value.name}
+                  </span>
+                </li>
+              ))}
+            </ul>
+
+            <HomeArrowLink href="/about" className="mt-8">
+              Our story
+            </HomeArrowLink>
+          </div>
+        </FadeIn>
+
+        <FadeIn direction="left" className="lg:col-span-5">
+          <div
+            data-values-image
+            className="relative mx-auto aspect-[4/5] w-full max-w-md overflow-hidden border-l-[6px] border-[#eeba2b] bg-[#E6E7E7] dark:bg-[#2F3332]"
+          >
             <Image
               src="/highlights/Akomapa-48.jpg"
               alt="Akomapa health professionals offering compassionate community care"
@@ -25,50 +88,15 @@ export default function AkomapaMeaningSection() {
               sizes="(min-width: 1024px) 40vw, 100vw"
               className="object-cover"
             />
-            <div className="absolute bottom-4 left-4 rounded-lg bg-[#FCFAEF] px-4 py-3 text-[#1C1F1E] shadow-sm dark:bg-[#1C1F1E] dark:text-[#FCFAEF]">
+            <div className="absolute inset-x-0 bottom-0 border-t border-white/30 bg-[#0F4C5C]/95 px-5 py-4 text-[#FCFAEF] backdrop-blur-sm">
               <p className="font-heading text-base font-semibold text-[#0097b2] dark:text-[#66C4DC]">
                 Nya Akomapa
               </p>
-              <p className="text-xs text-[#2F3332]/75 dark:text-[#E6E7E7]/75">
+              <p className="text-xs text-[#FCFAEF]/75">
                 &ldquo;Have a good heart&rdquo;
               </p>
             </div>
           </div>
-        </FadeIn>
-
-        <FadeIn className="lg:col-span-7">
-          <HomeEyebrow tone="gold">Our Values</HomeEyebrow>
-          <HomeHeading id={headingId} className="mt-4">
-            Akomapa means &quot;A Good Heart.&quot;
-          </HomeHeading>
-          <div className="mt-6 max-w-2xl space-y-5">
-            <HomeLead>
-              In Akan, Akomapa represents more than compassion. It reflects our
-              belief that meaningful healthcare begins with both clinical
-              excellence and moral leadership.
-            </HomeLead>
-            <HomeLead>
-              We believe every person deserves compassionate care, every
-              community deserves equitable access to high-quality healthcare,
-              and every health professional has a responsibility to lead with
-              humility, integrity, and service.
-            </HomeLead>
-          </div>
-
-          <ul className="mt-8 flex flex-wrap gap-3">
-            {values.map((value) => (
-              <li
-                key={value}
-                className="rounded-full border border-[#0097b2]/25 px-5 py-2 font-heading text-base font-semibold text-[#0097b2] dark:border-[#66C4DC]/30 dark:text-[#66C4DC]"
-              >
-                {value}
-              </li>
-            ))}
-          </ul>
-
-          <HomeArrowLink href="/about" className="mt-8">
-            Our story
-          </HomeArrowLink>
         </FadeIn>
       </div>
     </HomeBand>

--- a/src/components/home/AkomapaMeaningSection.tsx
+++ b/src/components/home/AkomapaMeaningSection.tsx
@@ -14,7 +14,7 @@ export default function AkomapaMeaningSection() {
   const headingId = "akomapa-meaning-heading";
 
   return (
-    <HomeBand tone="cream" marker="05" aria-labelledby={headingId}>
+    <HomeBand tone="cream" marker="06" aria-labelledby={headingId}>
       <div className="grid items-center gap-10 lg:grid-cols-12 lg:gap-16">
         <FadeIn direction="right" className="lg:col-span-5">
           <div className="relative mx-auto aspect-[4/5] w-full max-w-md overflow-hidden rounded-2xl border border-[#E6E7E7] dark:border-[#2F3332]">

--- a/src/components/home/BuiltOnEvidenceSection.tsx
+++ b/src/components/home/BuiltOnEvidenceSection.tsx
@@ -12,7 +12,7 @@ export default function BuiltOnEvidenceSection() {
   const headingId = "built-on-evidence-heading";
 
   return (
-    <HomeBand tone="cream" marker="03" aria-labelledby={headingId}>
+    <HomeBand tone="white" marker="04" aria-labelledby={headingId}>
       <div className="grid items-center gap-10 lg:grid-cols-12 lg:gap-16">
         <FadeIn direction="right" className="lg:col-span-5">
           <div className="relative aspect-[4/3] overflow-hidden rounded-2xl border border-[#E6E7E7] dark:border-[#2F3332]">

--- a/src/components/home/CarePathwaySection.tsx
+++ b/src/components/home/CarePathwaySection.tsx
@@ -1,0 +1,122 @@
+import { FadeIn } from "@/components/animations";
+import {
+  HomeBand,
+  HomeEyebrow,
+  HomeHeading,
+  HomeLead,
+} from "@/components/home/_home-ui";
+
+type CarePathwayStep = Readonly<{
+  id: string;
+  marker: string;
+  title: string;
+  description: string;
+}>;
+
+const carePathwaySteps = [
+  {
+    id: "screened",
+    marker: "01",
+    title: "Screened",
+    description:
+      "Community members screened for blood pressure, glucose, BMI, and related risk factors.",
+  },
+  {
+    id: "identified",
+    marker: "02",
+    title: "Identified",
+    description:
+      "New suspected hypertension, diabetes, or high-risk cases detected.",
+  },
+  {
+    id: "referred",
+    marker: "03",
+    title: "Referred",
+    description:
+      "Patients referred to clinics, providers, or partner facilities.",
+  },
+  {
+    id: "linked-to-care",
+    marker: "04",
+    title: "Linked to care",
+    description:
+      "Referred patients who complete a care visit or verified follow-up.",
+  },
+  {
+    id: "followed-up",
+    marker: "05",
+    title: "Followed up",
+    description:
+      "Patients contacted after outreach to encourage continuity of care.",
+  },
+  {
+    id: "leaders-trained",
+    marker: "06",
+    title: "Leaders trained",
+    description:
+      "Student leaders and health professionals trained in NCD prevention, ethical leadership, referral support, and community-based care.",
+  },
+] as const satisfies readonly CarePathwayStep[];
+
+export default function CarePathwaySection() {
+  const headingId = "care-pathway-heading";
+
+  return (
+    <HomeBand tone="cream" marker="03" aria-labelledby={headingId}>
+      <FadeIn>
+        <div className="max-w-3xl">
+          <HomeEyebrow>What We Measure</HomeEyebrow>
+          <HomeHeading id={headingId} className="mt-4">
+            From screening numbers to care outcomes.
+          </HomeHeading>
+          <HomeLead className="mt-6">
+            Akomapa measures success beyond the number of people reached. Our
+            goal is to understand whether people at risk are identified,
+            referred, connected to care, and supported over time.
+          </HomeLead>
+        </div>
+      </FadeIn>
+
+      <ol className="mt-12 grid list-none gap-x-6 gap-y-8 md:grid-cols-2 md:gap-y-10 xl:grid-cols-6 xl:gap-x-5">
+        {carePathwaySteps.map((step, index) => (
+          <FadeIn
+            as="li"
+            key={step.id}
+            delay={index * 0.08}
+            className="relative min-w-0 pl-16 md:pl-0"
+          >
+            <div className="homepage-hover-card relative z-10 h-full rounded-xl border border-[#8C908E] bg-white p-5 dark:border-[#69706E] dark:bg-[#1C1F1E] md:p-6 xl:p-5">
+              <span
+                aria-hidden="true"
+                className="absolute -left-16 top-0 z-30 flex h-14 w-14 items-center justify-center rounded-full border border-[#0F4C5C] bg-[#0F4C5C] font-subheading text-sm font-bold tracking-[0.12em] text-[#FCFAEF] dark:border-[#66C4DC] dark:bg-[#66C4DC] dark:text-[#121514] md:static"
+              >
+                {step.marker}
+              </span>
+              <h3 className="font-heading text-xl font-semibold leading-snug text-[#0097b2] dark:text-[#66C4DC] md:mt-6 xl:text-lg">
+                {step.title}
+              </h3>
+              <p className="mt-3 text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80 md:text-base xl:text-sm">
+                {step.description}
+              </p>
+            </div>
+
+            {index < carePathwaySteps.length - 1 ? (
+              <>
+                <span
+                  aria-hidden="true"
+                  data-testid="care-pathway-mobile-connector"
+                  className="absolute -bottom-8 left-7 top-14 w-px bg-[#527B80] dark:bg-[#7AAAB4] md:hidden"
+                />
+                <span
+                  aria-hidden="true"
+                  data-testid="care-pathway-desktop-connector"
+                  className="absolute left-[4.75rem] right-[-1.25rem] top-12 z-20 hidden h-px bg-[#527B80] dark:bg-[#7AAAB4] xl:block"
+                />
+              </>
+            ) : null}
+          </FadeIn>
+        ))}
+      </ol>
+    </HomeBand>
+  );
+}

--- a/src/components/home/CarePathwaySection.tsx
+++ b/src/components/home/CarePathwaySection.tsx
@@ -78,36 +78,43 @@ export default function CarePathwaySection() {
       </FadeIn>
 
       <ol
-        data-care-pathway-ledger
-        className="mt-12 grid list-none border-y border-[#527B80] md:grid-cols-2 xl:grid-cols-6 dark:border-[#7AAAB4]"
+        data-care-pathway-bands
+        className="mt-12 grid list-none overflow-hidden md:grid-cols-2 xl:grid-cols-6"
       >
         {carePathwaySteps.map((step, index) => (
           <FadeIn
             as="li"
             key={step.id}
             delay={index * 0.08}
-            className="relative min-w-0 border-b border-[#527B80] py-7 last:border-b-0 md:border-b md:px-7 md:py-9 md:[&:nth-child(2n+1)]:border-r md:[&:nth-child(n+5)]:border-b-0 xl:border-b-0 xl:border-r xl:px-5 xl:py-10 xl:first:pl-0 xl:last:border-r-0 xl:last:pr-0 dark:border-[#7AAAB4]"
+            className="relative min-w-0 overflow-hidden border-b border-[#FCFAEF]/60 bg-[#0F4C5C] px-5 py-7 text-[#FCFAEF] last:border-b-0 even:bg-[#16697A] md:min-h-64 md:border-b md:border-r md:px-7 md:py-9 md:[&:nth-child(2n)]:border-r-0 md:[&:nth-child(n+5)]:border-b-0 xl:min-h-80 xl:border-b-0 xl:border-r xl:px-5 xl:py-10 xl:last:border-r-0"
           >
-            <div className="grid grid-cols-[4.5rem_minmax(0,1fr)] gap-x-5 md:block">
-              <div className="flex items-center gap-3 md:block">
+            <span
+              aria-hidden="true"
+              className="pointer-events-none absolute -bottom-3 right-3 font-heading text-[5.5rem] font-semibold leading-none tracking-[-0.08em] text-[#FCFAEF]/10 md:-bottom-4 md:text-[7rem] xl:-bottom-2 xl:right-2 xl:text-[5.5rem]"
+            >
+              {step.marker}
+            </span>
+
+            <div className="relative z-10 grid grid-cols-[4.5rem_minmax(0,1fr)] gap-x-5 md:block">
+              <div className="flex items-center gap-3">
                 <span
                   aria-hidden="true"
                   data-care-pathway-marker
-                  className="font-heading text-[2.75rem] font-semibold leading-none tracking-[-0.06em] text-[#0F4C5C]/65 dark:text-[#66C4DC]/65 md:text-[3.25rem] xl:text-[3rem]"
+                  className="font-subheading text-xs font-bold uppercase tracking-[0.18em] text-[#F5C94D]"
                 >
-                  {step.marker}
+                  Stage {step.marker}
                 </span>
                 <span
                   aria-hidden="true"
-                  className="h-px w-5 bg-[#C9920F] md:mt-5 md:block md:w-8 dark:bg-[#F5C94D]"
+                  className="h-px w-5 bg-[#F5C94D]/80"
                 />
               </div>
 
-              <div className="min-w-0 self-center md:mt-7">
-                <h3 className="break-words font-heading text-xl font-semibold leading-snug text-[#0F4C5C] dark:text-[#66C4DC] xl:text-lg">
+              <div className="min-w-0 self-center md:mt-8">
+                <h3 className="break-words font-heading text-xl font-semibold leading-snug text-[#FCFAEF] xl:text-lg">
                   {step.title}
                 </h3>
-                <p className="mt-2 break-words text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80 md:mt-3 md:text-base xl:text-sm">
+                <p className="mt-2 break-words text-sm leading-relaxed text-[#FCFAEF]/90 md:mt-3 md:text-base xl:text-sm">
                   {step.description}
                 </p>
               </div>

--- a/src/components/home/CarePathwaySection.tsx
+++ b/src/components/home/CarePathwaySection.tsx
@@ -78,43 +78,36 @@ export default function CarePathwaySection() {
       </FadeIn>
 
       <ol
-        data-care-pathway-bands
-        className="mt-12 grid list-none overflow-hidden md:grid-cols-2 xl:grid-cols-6"
+        data-care-pathway-ledger
+        className="mt-12 grid list-none border-y border-[#527B80] md:grid-cols-2 xl:grid-cols-6 dark:border-[#7AAAB4]"
       >
         {carePathwaySteps.map((step, index) => (
           <FadeIn
             as="li"
             key={step.id}
             delay={index * 0.08}
-            className="relative min-w-0 overflow-hidden border-b border-[#FCFAEF]/60 bg-[#0F4C5C] px-5 py-7 text-[#FCFAEF] last:border-b-0 even:bg-[#16697A] md:min-h-64 md:border-b md:border-r md:px-7 md:py-9 md:[&:nth-child(2n)]:border-r-0 md:[&:nth-child(n+5)]:border-b-0 xl:min-h-80 xl:border-b-0 xl:border-r xl:px-5 xl:py-10 xl:last:border-r-0"
+            className="relative min-w-0 border-b border-[#527B80] py-7 last:border-b-0 md:border-b md:px-7 md:py-9 md:[&:nth-child(2n+1)]:border-r md:[&:nth-child(n+5)]:border-b-0 xl:border-b-0 xl:border-r xl:px-5 xl:py-10 xl:first:pl-0 xl:last:border-r-0 xl:last:pr-0 dark:border-[#7AAAB4]"
           >
-            <span
-              aria-hidden="true"
-              className="pointer-events-none absolute -bottom-3 right-3 font-heading text-[5.5rem] font-semibold leading-none tracking-[-0.08em] text-[#FCFAEF]/10 md:-bottom-4 md:text-[7rem] xl:-bottom-2 xl:right-2 xl:text-[5.5rem]"
-            >
-              {step.marker}
-            </span>
-
-            <div className="relative z-10 grid grid-cols-[4.5rem_minmax(0,1fr)] gap-x-5 md:block">
-              <div className="flex items-center gap-3">
+            <div className="grid grid-cols-[4.5rem_minmax(0,1fr)] gap-x-5 md:block">
+              <div className="flex items-center gap-3 md:block">
                 <span
                   aria-hidden="true"
                   data-care-pathway-marker
-                  className="font-subheading text-xs font-bold uppercase tracking-[0.18em] text-[#F5C94D]"
+                  className="font-heading text-[2.75rem] font-semibold leading-none tracking-[-0.06em] text-[#0F4C5C]/65 dark:text-[#66C4DC]/65 md:text-[3.25rem] xl:text-[3rem]"
                 >
-                  Stage {step.marker}
+                  {step.marker}
                 </span>
                 <span
                   aria-hidden="true"
-                  className="h-px w-5 bg-[#F5C94D]/80"
+                  className="h-px w-5 bg-[#C9920F] md:mt-5 md:block md:w-8 dark:bg-[#F5C94D]"
                 />
               </div>
 
-              <div className="min-w-0 self-center md:mt-8">
-                <h3 className="break-words font-heading text-xl font-semibold leading-snug text-[#FCFAEF] xl:text-lg">
+              <div className="min-w-0 self-center md:mt-7">
+                <h3 className="break-words font-heading text-xl font-semibold leading-snug text-[#0F4C5C] dark:text-[#66C4DC] xl:text-lg">
                   {step.title}
                 </h3>
-                <p className="mt-2 break-words text-sm leading-relaxed text-[#FCFAEF]/90 md:mt-3 md:text-base xl:text-sm">
+                <p className="mt-2 break-words text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80 md:mt-3 md:text-base xl:text-sm">
                   {step.description}
                 </p>
               </div>

--- a/src/components/home/CarePathwaySection.tsx
+++ b/src/components/home/CarePathwaySection.tsx
@@ -92,10 +92,10 @@ export default function CarePathwaySection() {
               >
                 {step.marker}
               </span>
-              <h3 className="font-heading text-xl font-semibold leading-snug text-[#0097b2] dark:text-[#66C4DC] md:mt-6 xl:text-lg">
+              <h3 className="break-words font-heading text-xl font-semibold leading-snug text-[#0097b2] dark:text-[#66C4DC] md:mt-6 xl:text-lg">
                 {step.title}
               </h3>
-              <p className="mt-3 text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80 md:text-base xl:text-sm">
+              <p className="mt-3 break-words text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80 md:text-base xl:text-sm">
                 {step.description}
               </p>
             </div>

--- a/src/components/home/CarePathwaySection.tsx
+++ b/src/components/home/CarePathwaySection.tsx
@@ -77,43 +77,41 @@ export default function CarePathwaySection() {
         </div>
       </FadeIn>
 
-      <ol className="mt-12 grid list-none gap-x-6 gap-y-8 md:grid-cols-2 md:gap-y-10 xl:grid-cols-6 xl:gap-x-5">
+      <ol
+        data-care-pathway-ledger
+        className="mt-12 grid list-none border-y border-[#527B80] md:grid-cols-2 xl:grid-cols-6 dark:border-[#7AAAB4]"
+      >
         {carePathwaySteps.map((step, index) => (
           <FadeIn
             as="li"
             key={step.id}
             delay={index * 0.08}
-            className="relative min-w-0 pl-16 md:pl-0"
+            className="relative min-w-0 border-b border-[#527B80] py-7 last:border-b-0 md:border-b md:px-7 md:py-9 md:[&:nth-child(2n+1)]:border-r md:[&:nth-child(n+5)]:border-b-0 xl:border-b-0 xl:border-r xl:px-5 xl:py-10 xl:first:pl-0 xl:last:border-r-0 xl:last:pr-0 dark:border-[#7AAAB4]"
           >
-            <div className="homepage-hover-card relative z-10 h-full rounded-xl border border-[#8C908E] bg-white p-5 dark:border-[#69706E] dark:bg-[#1C1F1E] md:p-6 xl:p-5">
-              <span
-                aria-hidden="true"
-                className="absolute -left-16 top-0 z-30 flex h-14 w-14 items-center justify-center rounded-full border border-[#0F4C5C] bg-[#0F4C5C] font-subheading text-sm font-bold tracking-[0.12em] text-[#FCFAEF] dark:border-[#66C4DC] dark:bg-[#66C4DC] dark:text-[#121514] md:static"
-              >
-                {step.marker}
-              </span>
-              <h3 className="break-words font-heading text-xl font-semibold leading-snug text-[#0097b2] dark:text-[#66C4DC] md:mt-6 xl:text-lg">
-                {step.title}
-              </h3>
-              <p className="mt-3 break-words text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80 md:text-base xl:text-sm">
-                {step.description}
-              </p>
-            </div>
+            <div className="grid grid-cols-[4.5rem_minmax(0,1fr)] gap-x-5 md:block">
+              <div className="flex items-center gap-3 md:block">
+                <span
+                  aria-hidden="true"
+                  data-care-pathway-marker
+                  className="font-heading text-[2.75rem] font-semibold leading-none tracking-[-0.06em] text-[#0F4C5C]/65 dark:text-[#66C4DC]/65 md:text-[3.25rem] xl:text-[3rem]"
+                >
+                  {step.marker}
+                </span>
+                <span
+                  aria-hidden="true"
+                  className="h-px w-5 bg-[#C9920F] md:mt-5 md:block md:w-8 dark:bg-[#F5C94D]"
+                />
+              </div>
 
-            {index < carePathwaySteps.length - 1 ? (
-              <>
-                <span
-                  aria-hidden="true"
-                  data-testid="care-pathway-mobile-connector"
-                  className="absolute -bottom-8 left-7 top-14 w-px bg-[#527B80] dark:bg-[#7AAAB4] md:hidden"
-                />
-                <span
-                  aria-hidden="true"
-                  data-testid="care-pathway-desktop-connector"
-                  className="absolute left-[4.75rem] right-[-1.25rem] top-12 z-20 hidden h-px bg-[#527B80] dark:bg-[#7AAAB4] xl:block"
-                />
-              </>
-            ) : null}
+              <div className="min-w-0 self-center md:mt-7">
+                <h3 className="break-words font-heading text-xl font-semibold leading-snug text-[#0F4C5C] dark:text-[#66C4DC] xl:text-lg">
+                  {step.title}
+                </h3>
+                <p className="mt-2 break-words text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80 md:mt-3 md:text-base xl:text-sm">
+                  {step.description}
+                </p>
+              </div>
+            </div>
           </FadeIn>
         ))}
       </ol>

--- a/src/components/home/CarePathwaySection.tsx
+++ b/src/components/home/CarePathwaySection.tsx
@@ -71,14 +71,19 @@ export default function CarePathwaySection() {
   const headingId = "care-pathway-heading";
 
   return (
-    <HomeBand tone="cream" marker="03" aria-labelledby={headingId}>
+    <HomeBand
+      tone="teal"
+      marker="03"
+      aria-labelledby={headingId}
+      className="bg-[#0F4C5C]"
+    >
       <FadeIn>
         <div className="max-w-3xl">
-          <HomeEyebrow>What We Measure</HomeEyebrow>
+          <HomeEyebrow tone="light">What We Measure</HomeEyebrow>
           <HomeHeading id={headingId} className="mt-4">
             From screening numbers to care outcomes.
           </HomeHeading>
-          <HomeLead className="mt-6">
+          <HomeLead className="mt-6 text-[#FCFAEF]/85 dark:text-[#FCFAEF]/85">
             Akomapa measures success beyond the number of people reached. Our
             goal is to understand whether people at risk are identified,
             referred, connected to care, and supported over time.
@@ -95,11 +100,11 @@ export default function CarePathwaySection() {
             as="li"
             key={step.id}
             delay={index * 0.08}
-            className={`relative min-w-0 border-b border-[#527B80] py-7 last:border-b-0 md:border-b-0 md:border-t-2 md:pb-0 md:pt-6 dark:border-[#7AAAB4] ${desktopStepOffsets[index]}`}
+            className={`relative min-w-0 border-b border-[#66C4DC] py-7 last:border-b-0 md:border-b-0 md:border-t-2 md:pb-0 md:pt-6 ${desktopStepOffsets[index]}`}
           >
             <span
               aria-hidden="true"
-              className="absolute -top-0.5 left-0 hidden h-0.5 w-10 bg-[#C9920F] md:block dark:bg-[#F5C94D]"
+              className="absolute -top-0.5 left-0 hidden h-0.5 w-10 bg-[#eeba2b] md:block"
             />
 
             <div className="grid grid-cols-[4.75rem_minmax(0,1fr)] gap-x-5 md:block">
@@ -107,23 +112,23 @@ export default function CarePathwaySection() {
                 <span
                   aria-hidden="true"
                   data-care-pathway-marker
-                  className="font-heading text-[3rem] font-semibold leading-none tracking-[-0.06em] text-[#0F4C5C]/65 dark:text-[#66C4DC]/65 md:text-[3.5rem] xl:text-[3.25rem]"
+                  className="font-heading text-[3rem] font-semibold leading-none tracking-[-0.06em] text-[#FCFAEF]/80 md:text-[3.5rem] xl:text-[3.25rem]"
                 >
                   {step.marker}
                 </span>
                 <span
                   aria-hidden="true"
-                  className="mt-0.5 font-subheading text-lg font-bold leading-none text-[#C9920F] dark:text-[#F5C94D]"
+                  className="mt-0.5 font-subheading text-lg font-bold leading-none text-[#eeba2b]"
                 >
                   /
                 </span>
               </div>
 
               <div className="min-w-0 self-center md:mt-6">
-                <h3 className="break-words font-heading text-xl font-semibold leading-snug text-[#0F4C5C] dark:text-[#66C4DC] xl:text-lg">
+                <h3 className="break-words font-heading text-xl font-semibold leading-snug text-[#F5C94D] xl:text-lg">
                   {step.title}
                 </h3>
-                <p className="mt-2 break-words text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80 md:mt-3 md:text-base xl:text-sm">
+                <p className="mt-2 break-words text-sm leading-relaxed text-[#FCFAEF]/85 md:mt-3 md:text-base xl:text-sm">
                   {step.description}
                 </p>
               </div>

--- a/src/components/home/CarePathwaySection.tsx
+++ b/src/components/home/CarePathwaySection.tsx
@@ -58,6 +58,15 @@ const carePathwaySteps = [
   },
 ] as const satisfies readonly CarePathwayStep[];
 
+const desktopStepOffsets = [
+  "xl:mt-0",
+  "xl:mt-[1.5rem]",
+  "xl:mt-[3rem]",
+  "xl:mt-[4.5rem]",
+  "xl:mt-[6rem]",
+  "xl:mt-[7.5rem]",
+] as const;
+
 export default function CarePathwaySection() {
   const headingId = "care-pathway-heading";
 
@@ -78,32 +87,39 @@ export default function CarePathwaySection() {
       </FadeIn>
 
       <ol
-        data-care-pathway-ledger
-        className="mt-12 grid list-none border-y border-[#527B80] md:grid-cols-2 xl:grid-cols-6 dark:border-[#7AAAB4]"
+        data-care-pathway-staircase
+        className="mt-12 grid list-none gap-y-2 md:grid-cols-2 md:gap-x-10 md:gap-y-10 xl:grid-cols-6 xl:items-start xl:gap-x-5 xl:gap-y-0"
       >
         {carePathwaySteps.map((step, index) => (
           <FadeIn
             as="li"
             key={step.id}
             delay={index * 0.08}
-            className="relative min-w-0 border-b border-[#527B80] py-7 last:border-b-0 md:border-b md:px-7 md:py-9 md:[&:nth-child(2n+1)]:border-r md:[&:nth-child(n+5)]:border-b-0 xl:border-b-0 xl:border-r xl:px-5 xl:py-10 xl:first:pl-0 xl:last:border-r-0 xl:last:pr-0 dark:border-[#7AAAB4]"
+            className={`relative min-w-0 border-b border-[#527B80] py-7 last:border-b-0 md:border-b-0 md:border-t-2 md:pb-0 md:pt-6 dark:border-[#7AAAB4] ${desktopStepOffsets[index]}`}
           >
-            <div className="grid grid-cols-[4.5rem_minmax(0,1fr)] gap-x-5 md:block">
-              <div className="flex items-center gap-3 md:block">
+            <span
+              aria-hidden="true"
+              className="absolute -top-0.5 left-0 hidden h-0.5 w-10 bg-[#C9920F] md:block dark:bg-[#F5C94D]"
+            />
+
+            <div className="grid grid-cols-[4.75rem_minmax(0,1fr)] gap-x-5 md:block">
+              <div className="flex items-start gap-2">
                 <span
                   aria-hidden="true"
                   data-care-pathway-marker
-                  className="font-heading text-[2.75rem] font-semibold leading-none tracking-[-0.06em] text-[#0F4C5C]/65 dark:text-[#66C4DC]/65 md:text-[3.25rem] xl:text-[3rem]"
+                  className="font-heading text-[3rem] font-semibold leading-none tracking-[-0.06em] text-[#0F4C5C]/65 dark:text-[#66C4DC]/65 md:text-[3.5rem] xl:text-[3.25rem]"
                 >
                   {step.marker}
                 </span>
                 <span
                   aria-hidden="true"
-                  className="h-px w-5 bg-[#C9920F] md:mt-5 md:block md:w-8 dark:bg-[#F5C94D]"
-                />
+                  className="mt-0.5 font-subheading text-lg font-bold leading-none text-[#C9920F] dark:text-[#F5C94D]"
+                >
+                  /
+                </span>
               </div>
 
-              <div className="min-w-0 self-center md:mt-7">
+              <div className="min-w-0 self-center md:mt-6">
                 <h3 className="break-words font-heading text-xl font-semibold leading-snug text-[#0F4C5C] dark:text-[#66C4DC] xl:text-lg">
                   {step.title}
                 </h3>

--- a/src/components/home/JoinTheMovementSection.tsx
+++ b/src/components/home/JoinTheMovementSection.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { FadeIn } from "@/components/animations";
 import { trackEvent } from "@/lib/analytics";
 import { HomeButton, HomeEyebrow, HomeHeading } from "@/components/home/_home-ui";
 
@@ -9,43 +10,79 @@ export default function JoinTheMovementSection() {
   return (
     <section
       aria-labelledby={headingId}
-      className="relative overflow-hidden bg-[#121514] text-[#FCFAEF]"
+      data-join-the-movement
+      className="relative overflow-hidden border-t border-[#66C4DC]/45 bg-[#0F4C5C] text-[#FCFAEF]"
     >
-      <div className="site-container mx-auto px-4 py-20 md:py-24">
-        <div className="mx-auto max-w-3xl text-center">
-          <HomeEyebrow tone="gold" className="inline-block">
-            Join the Movement
-          </HomeEyebrow>
-          <HomeHeading id={headingId} className="mt-4 text-[#FCFAEF]">
-            Build healthier communities and stronger health leaders with us.
-          </HomeHeading>
-          <p className="mx-auto mt-6 max-w-2xl text-base leading-relaxed text-[#FCFAEF]/80 md:text-lg">
-            Improving chronic disease care takes communities, universities,
-            healthcare institutions, policymakers, and supporters working
-            together. Join us as we care for today&rsquo;s patients and prepare
-            tomorrow&rsquo;s health leaders.
-          </p>
+      <span
+        aria-hidden="true"
+        className="absolute left-0 top-0 h-1 w-24 bg-[#eeba2b] md:w-40"
+      />
 
-          <div className="mt-9 flex flex-col items-center justify-center gap-4 sm:flex-row">
-            <HomeButton href="/partnerships" variant="light">
-              Partner With Us
-            </HomeButton>
-            <HomeButton
-              href="/donate"
-              variant="amber"
-              onClick={() =>
-                trackEvent({
-                  name: "donation_cta_click",
-                  location: "home_join_the_movement",
-                })
-              }
+      <div className="site-container relative mx-auto px-4 py-16 md:py-20 lg:py-24">
+        <div className="grid gap-12 lg:grid-cols-[minmax(0,1.15fr)_minmax(20rem,0.85fr)] lg:items-end lg:gap-16">
+          <FadeIn>
+            <div data-join-copy className="max-w-3xl">
+              <HomeEyebrow
+                tone="gold"
+                className="text-[#F5C94D] dark:text-[#F5C94D]"
+              >
+                Join the Movement
+              </HomeEyebrow>
+              <HomeHeading id={headingId} className="mt-4 text-[#FCFAEF]">
+                Build healthier communities and stronger health leaders with
+                us.
+              </HomeHeading>
+              <p className="mt-6 max-w-2xl text-base leading-relaxed text-[#FCFAEF]/85 md:text-lg">
+                Improving chronic disease care takes communities, universities,
+                healthcare institutions, policymakers, and supporters working
+                together. Join us as we care for today&rsquo;s patients and
+                prepare tomorrow&rsquo;s health leaders.
+              </p>
+            </div>
+          </FadeIn>
+
+          <FadeIn delay={0.12}>
+            <div
+              data-join-actions
+              className="border-t border-[#66C4DC]/65 pt-7 lg:border-l lg:border-t-0 lg:pl-10 lg:pt-0"
             >
-              Support Our Work
-            </HomeButton>
-            <HomeButton href="/get-involved" variant="outline-light">
-              Join Akomapa
-            </HomeButton>
-          </div>
+              <p className="font-subheading text-xs font-bold uppercase tracking-[0.2em] text-[#FCFAEF]/75">
+                Choose how to take part
+              </p>
+
+              <div className="mt-5 grid gap-3 sm:grid-cols-2">
+                <HomeButton
+                  href="/donate"
+                  variant="amber"
+                  className="min-h-14 w-full justify-between bg-[#eeba2b] px-5 py-4 text-[#1C1F1E] hover:bg-[#F5C94D] sm:col-span-2"
+                  onClick={() =>
+                    trackEvent({
+                      name: "donation_cta_click",
+                      location: "home_join_the_movement",
+                    })
+                  }
+                >
+                  Support Our Work
+                </HomeButton>
+
+                <HomeButton
+                  href="/partnerships"
+                  variant="light"
+                  className="min-h-14 w-full justify-between px-5 py-4 text-[#0F4C5C] hover:bg-[#F5C94D] hover:text-[#1C1F1E]"
+                >
+                  Partner With Us
+                </HomeButton>
+
+                <HomeButton
+                  href="/get-involved"
+                  variant="outline-light"
+                  className="min-h-14 w-full justify-between border-[#66C4DC] px-5 py-4 hover:border-[#FCFAEF] hover:text-[#0F4C5C]"
+                >
+                  Join Akomapa
+                </HomeButton>
+              </div>
+            </div>
+          </FadeIn>
         </div>
       </div>
     </section>

--- a/src/components/home/OurModelSection.tsx
+++ b/src/components/home/OurModelSection.tsx
@@ -45,7 +45,7 @@ export default function OurModelSection() {
   const headingId = "our-model-heading";
 
   return (
-    <HomeBand tone="white" marker="04" aria-labelledby={headingId}>
+    <HomeBand tone="cream" marker="05" aria-labelledby={headingId}>
       <FadeIn>
         <div className="max-w-3xl">
           <HomeEyebrow>Our Model</HomeEyebrow>
@@ -72,7 +72,7 @@ export default function OurModelSection() {
             >
               <Link
                 href={item.href}
-                className="group relative flex h-full flex-col rounded-xl p-3 transition-colors hover:bg-[#FCFAEF] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0097b2] dark:hover:bg-[#1C1F1E]"
+                className="group relative flex h-full flex-col rounded-xl p-3 transition-colors hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0097b2] dark:hover:bg-[#1C1F1E]"
               >
                 <span className="relative z-10 flex h-14 w-14 items-center justify-center rounded-md border border-[#1C1F1E]/25 bg-white font-subheading text-base font-bold tracking-[0.1em] text-[#0097b2] transition-colors group-hover:border-transparent group-hover:bg-[#0097b2] group-hover:text-[#FCFAEF] dark:border-[#FCFAEF]/25 dark:bg-[#1C1F1E] dark:text-[#66C4DC] dark:group-hover:bg-[#0097b2] dark:group-hover:text-[#FCFAEF]">
                   {String(index + 1).padStart(2, "0")}

--- a/src/components/home/TransformationalImpactSection.tsx
+++ b/src/components/home/TransformationalImpactSection.tsx
@@ -43,13 +43,6 @@ export default function TransformationalImpactSection() {
       className="relative isolate overflow-hidden bg-[#0097b2] text-[#FCFAEF]"
     >
       <div className="site-container relative mx-auto px-4 py-20 md:py-24 lg:py-28">
-        <span
-          aria-hidden="true"
-          className="pointer-events-none absolute right-4 top-6 hidden select-none rounded px-2 py-1 font-subheading text-xs font-bold tracking-[0.2em] text-[#FCFAEF]/70 ring-1 ring-[#FCFAEF]/30 md:inline-block"
-        >
-          06
-        </span>
-
         <div className="grid gap-10 lg:grid-cols-12 lg:gap-16">
           <div className="lg:col-span-5">
             <HomeEyebrow tone="light">Transformational Impact</HomeEyebrow>

--- a/src/components/home/TransformationalImpactSection.tsx
+++ b/src/components/home/TransformationalImpactSection.tsx
@@ -3,6 +3,11 @@
 import { useRef } from "react";
 import { useInView } from "framer-motion";
 import {
+  FadeIn,
+  FadeInStagger,
+  FadeInStaggerItem,
+} from "@/components/animations";
+import {
   HomeArrowLink,
   HomeEyebrow,
   HomeHeading,
@@ -31,6 +36,13 @@ const researchMetrics = researchMetricIds.map((id) => {
   return metric;
 });
 
+const metricDividerClasses = [
+  "sm:border-r",
+  "border-t sm:border-t-0 xl:border-r",
+  "border-t sm:border-r xl:border-t-0",
+  "border-t xl:border-t-0",
+] as const;
+
 export default function TransformationalImpactSection() {
   const headingId = "transformational-impact-heading";
   const ref = useRef<HTMLDivElement | null>(null);
@@ -40,71 +52,104 @@ export default function TransformationalImpactSection() {
   return (
     <section
       aria-labelledby={headingId}
-      className="relative isolate overflow-hidden bg-[#0097b2] text-[#FCFAEF]"
+      data-transformational-impact
+      className="relative isolate overflow-hidden border-t border-[#FCFAEF]/20 bg-[#0097b2] text-[#FCFAEF]"
     >
-      <div className="site-container relative mx-auto px-4 py-20 md:py-24 lg:py-28">
-        <div className="grid gap-10 lg:grid-cols-12 lg:gap-16">
-          <div className="lg:col-span-5">
-            <HomeEyebrow tone="light">Transformational Impact</HomeEyebrow>
-            <HomeHeading id={headingId} className="mt-4 text-[#FCFAEF]">
-              Building healthier communities. Preparing stronger health leaders.
-            </HomeHeading>
-            <p className="mt-6 max-w-md text-base leading-relaxed text-[#FCFAEF]/85 md:text-lg">
-              Every clinic improves care for today&rsquo;s patients. Every
-              student encounter prepares tomorrow&rsquo;s workforce. The numbers
-              below track both.
-            </p>
-            <HomeArrowLink href="/impact" tone="light" className="mt-8">
-              Explore our impact
-            </HomeArrowLink>
-          </div>
+      <span
+        aria-hidden="true"
+        className="absolute left-0 top-0 h-1 w-24 bg-[#eeba2b] md:w-40"
+      />
 
-          <div ref={ref} className="lg:col-span-7">
-            <dl className="grid grid-cols-1 gap-x-10 gap-y-10 sm:grid-cols-2">
+      <div className="site-container relative mx-auto px-4 py-20 md:py-24 lg:py-28">
+        <div className="grid gap-8 lg:grid-cols-12 lg:items-end lg:gap-16">
+          <FadeIn className="lg:col-span-7">
+            <div data-impact-copy>
+              <HomeEyebrow tone="light">Transformational Impact</HomeEyebrow>
+              <HomeHeading
+                id={headingId}
+                className="mt-4 max-w-3xl text-[#FCFAEF] lg:text-[3.2rem]"
+              >
+                Building healthier communities. Preparing stronger health
+                leaders.
+              </HomeHeading>
+            </div>
+          </FadeIn>
+
+          <FadeIn delay={0.1} className="lg:col-span-5">
+            <div
+              data-impact-context
+              className="lg:border-l lg:border-[#FCFAEF]/30 lg:pl-10"
+            >
+              <p className="mt-6 max-w-md text-base leading-relaxed text-[#FCFAEF]/85 md:text-lg">
+                Every clinic improves care for today&rsquo;s patients. Every
+                student encounter prepares tomorrow&rsquo;s workforce. The
+                numbers below track both.
+              </p>
+              <HomeArrowLink href="/impact" tone="light" className="mt-8">
+                Explore our impact
+              </HomeArrowLink>
+            </div>
+          </FadeIn>
+        </div>
+
+        <div ref={ref} className="mt-14 md:mt-16">
+          <FadeInStagger>
+            <dl
+              data-community-metrics
+              className="grid border-y border-[#FCFAEF]/30 sm:grid-cols-2 xl:grid-cols-4"
+            >
               {communityMetrics.map((metric, index) => (
-                <div
-                  key={metric.label}
-                  className="border-t border-[#FCFAEF]/25 pt-4"
-                >
-                  <span
-                    aria-hidden="true"
-                    className="block h-0.5 w-8 -translate-y-[1.05rem] bg-[#eeba2b]"
-                  />
-                  <dt className="sr-only">{metric.label}</dt>
-                  <dd>
-                    <span className="font-heading text-5xl font-semibold tracking-tight text-[#FCFAEF] md:text-6xl">
-                      {counts[index].toLocaleString()}
-                      {metric.suffix}
+                <FadeInStaggerItem key={metric.label}>
+                  <div
+                    className={`flex min-h-44 flex-col justify-between border-[#FCFAEF]/30 px-0 py-7 sm:px-7 xl:min-h-52 xl:px-8 ${metricDividerClasses[index]}`}
+                  >
+                    <span
+                      aria-hidden="true"
+                      className="block font-subheading text-xs font-bold tracking-[0.2em] text-[#F5C94D]"
+                    >
+                      0{index + 1}
                     </span>
-                    <span className="mt-3 block text-sm font-medium leading-snug text-[#FCFAEF]/80">
-                      {metric.label}
-                    </span>
-                  </dd>
-                </div>
+                    <div>
+                      <dt className="sr-only">{metric.label}</dt>
+                      <dd>
+                        <span className="font-heading text-5xl font-semibold tracking-tight text-[#FCFAEF] md:text-6xl">
+                          {counts[index].toLocaleString()}
+                          {metric.suffix}
+                        </span>
+                        <span className="mt-3 block max-w-44 text-sm font-medium leading-snug text-[#FCFAEF]/80">
+                          {metric.label}
+                        </span>
+                      </dd>
+                    </div>
+                  </div>
+                </FadeInStaggerItem>
               ))}
             </dl>
+          </FadeInStagger>
 
-            <div className="mt-12 border-t border-[#FCFAEF]/25 pt-8">
+          <FadeIn delay={0.15}>
+            <div
+              data-research-metrics
+              className="grid gap-6 border-b border-[#FCFAEF]/30 py-7 md:grid-cols-4 md:items-start md:gap-8"
+            >
               <p className="font-subheading text-xs font-bold uppercase tracking-[0.2em] text-[#FCFAEF]/70">
                 Research &amp; Innovation
               </p>
-              <dl className="mt-5 grid grid-cols-3 gap-6">
-                {researchMetrics.map((metric) => (
-                  <div key={metric.id}>
-                    <dt className="sr-only">{metric.label}</dt>
-                    <dd>
-                      <span className="font-heading text-2xl font-semibold tracking-tight text-[#FCFAEF] md:text-3xl">
-                        {metric.currentValue}
-                      </span>
-                      <span className="mt-1 block text-xs leading-snug text-[#FCFAEF]/75">
-                        {metric.label}
-                      </span>
-                    </dd>
-                  </div>
-                ))}
-              </dl>
+              {researchMetrics.map((metric) => (
+                <dl key={metric.id}>
+                  <dt className="sr-only">{metric.label}</dt>
+                  <dd>
+                    <span className="font-heading text-2xl font-semibold tracking-tight text-[#FCFAEF] md:text-3xl">
+                      {metric.currentValue}
+                    </span>
+                    <span className="mt-1 block text-xs leading-snug text-[#FCFAEF]/75">
+                      {metric.label}
+                    </span>
+                  </dd>
+                </dl>
+              ))}
             </div>
-          </div>
+          </FadeIn>
         </div>
       </div>
     </section>

--- a/src/components/home/VisionSection.tsx
+++ b/src/components/home/VisionSection.tsx
@@ -1,23 +1,76 @@
 import { FadeIn } from "@/components/animations";
 import { HomeBand, HomeEyebrow, HomeHeading } from "@/components/home/_home-ui";
 
+const visionPriorities = [
+  "Compassionate care",
+  "Continuous access",
+  "Ethical leadership",
+] as const;
+
 export default function VisionSection() {
   const headingId = "vision-heading";
 
   return (
-    <HomeBand tone="white" marker="07" aria-labelledby={headingId}>
-      <FadeIn className="mx-auto max-w-3xl text-center">
-        <HomeEyebrow className="inline-block">Our Vision</HomeEyebrow>
-        <HomeHeading id={headingId} className="mt-5">
-          Every community deserves high-quality chronic disease care.
-        </HomeHeading>
-        <p className="mx-auto mt-6 max-w-2xl text-base leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80 md:text-lg">
-          We envision a future where preventable complications from
-          hypertension, diabetes, and other noncommunicable diseases become
-          increasingly rare — because every community has access to
-          compassionate, continuous, community-centered primary care delivered
-          by ethical health leaders.
-        </p>
+    <HomeBand
+      tone="white"
+      marker="07"
+      aria-labelledby={headingId}
+      data-vision-section
+    >
+      <span
+        aria-hidden="true"
+        className="absolute left-4 top-0 h-1 w-24 bg-[#eeba2b] md:w-40"
+      />
+
+      <div className="grid gap-10 lg:grid-cols-12 lg:items-end lg:gap-16">
+        <FadeIn className="lg:col-span-8">
+          <div data-vision-statement>
+            <HomeEyebrow>Our Vision</HomeEyebrow>
+            <HomeHeading
+              id={headingId}
+              className="mt-5 max-w-4xl text-[2.35rem] md:text-[3.5rem] lg:text-[4.35rem]"
+            >
+              Every community deserves high-quality chronic disease care.
+            </HomeHeading>
+          </div>
+        </FadeIn>
+
+        <FadeIn delay={0.12} className="lg:col-span-4">
+          <p
+            data-vision-copy
+            className="border-l-2 border-[#0097b2] pl-6 text-base leading-relaxed text-[#2F3332]/80 dark:border-[#66C4DC] dark:text-[#E6E7E7]/80 md:text-lg"
+          >
+            We envision a future where preventable complications from
+            hypertension, diabetes, and other noncommunicable diseases become
+            increasingly rare — because every community has access to
+            compassionate, continuous, community-centered primary care delivered
+            by ethical health leaders.
+          </p>
+        </FadeIn>
+      </div>
+
+      <FadeIn delay={0.18}>
+        <ul
+          aria-label="Vision priorities"
+          data-vision-priorities
+          className="mt-14 grid border-y border-[#1C1F1E]/15 sm:grid-cols-3 dark:border-[#FCFAEF]/20"
+        >
+          {visionPriorities.map((priority, index) => (
+            <li
+              key={priority}
+              className={`flex items-center gap-4 border-[#1C1F1E]/15 py-5 sm:px-6 dark:border-[#FCFAEF]/20 ${
+                index > 0 ? "border-t sm:border-l sm:border-t-0" : ""
+              }`}
+            >
+              <span className="font-subheading text-xs font-bold tracking-[0.2em] text-[#C9920F] dark:text-[#F5C94D]">
+                0{index + 1}
+              </span>
+              <span className="font-heading text-lg font-semibold">
+                {priority}
+              </span>
+            </li>
+          ))}
+        </ul>
       </FadeIn>
     </HomeBand>
   );

--- a/src/components/home/__tests__/CarePathwaySection.test.tsx
+++ b/src/components/home/__tests__/CarePathwaySection.test.tsx
@@ -85,13 +85,13 @@ describe("CarePathwaySection", () => {
     });
   });
 
-  it("uses one continuous field of care-stage bands", () => {
+  it("uses one open ledger instead of cards or connectors", () => {
     render(<CarePathwaySection />);
 
     const section = screen.getByRole("region", { name: heading });
     const list = within(section).getByRole("list");
 
-    expect(list).toHaveAttribute("data-care-pathway-bands");
+    expect(list).toHaveAttribute("data-care-pathway-ledger");
     expect(list.querySelectorAll("[data-care-pathway-marker]")).toHaveLength(
       steps.length,
     );

--- a/src/components/home/__tests__/CarePathwaySection.test.tsx
+++ b/src/components/home/__tests__/CarePathwaySection.test.tsx
@@ -85,13 +85,13 @@ describe("CarePathwaySection", () => {
     });
   });
 
-  it("uses one open ledger instead of cards or connectors", () => {
+  it("uses an open typographic staircase instead of cards or connectors", () => {
     render(<CarePathwaySection />);
 
     const section = screen.getByRole("region", { name: heading });
     const list = within(section).getByRole("list");
 
-    expect(list).toHaveAttribute("data-care-pathway-ledger");
+    expect(list).toHaveAttribute("data-care-pathway-staircase");
     expect(list.querySelectorAll("[data-care-pathway-marker]")).toHaveLength(
       steps.length,
     );

--- a/src/components/home/__tests__/CarePathwaySection.test.tsx
+++ b/src/components/home/__tests__/CarePathwaySection.test.tsx
@@ -85,13 +85,13 @@ describe("CarePathwaySection", () => {
     });
   });
 
-  it("uses one open ledger instead of cards or connectors", () => {
+  it("uses one continuous field of care-stage bands", () => {
     render(<CarePathwaySection />);
 
     const section = screen.getByRole("region", { name: heading });
     const list = within(section).getByRole("list");
 
-    expect(list).toHaveAttribute("data-care-pathway-ledger");
+    expect(list).toHaveAttribute("data-care-pathway-bands");
     expect(list.querySelectorAll("[data-care-pathway-marker]")).toHaveLength(
       steps.length,
     );

--- a/src/components/home/__tests__/CarePathwaySection.test.tsx
+++ b/src/components/home/__tests__/CarePathwaySection.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import CarePathwaySection from "@/components/home/CarePathwaySection";
+
+const heading = "From screening numbers to care outcomes.";
+
+const introduction =
+  "Akomapa measures success beyond the number of people reached. Our goal is to understand whether people at risk are identified, referred, connected to care, and supported over time.";
+
+const steps = [
+  {
+    marker: "01",
+    title: "Screened",
+    description:
+      "Community members screened for blood pressure, glucose, BMI, and related risk factors.",
+  },
+  {
+    marker: "02",
+    title: "Identified",
+    description:
+      "New suspected hypertension, diabetes, or high-risk cases detected.",
+  },
+  {
+    marker: "03",
+    title: "Referred",
+    description:
+      "Patients referred to clinics, providers, or partner facilities.",
+  },
+  {
+    marker: "04",
+    title: "Linked to care",
+    description:
+      "Referred patients who complete a care visit or verified follow-up.",
+  },
+  {
+    marker: "05",
+    title: "Followed up",
+    description:
+      "Patients contacted after outreach to encourage continuity of care.",
+  },
+  {
+    marker: "06",
+    title: "Leaders trained",
+    description:
+      "Student leaders and health professionals trained in NCD prevention, ethical leadership, referral support, and community-based care.",
+  },
+] as const;
+
+describe("CarePathwaySection", () => {
+  it("renders the approved measurement framework as one ordered sequence", () => {
+    render(<CarePathwaySection />);
+
+    const section = screen.getByRole("region", { name: heading });
+
+    expect(within(section).getByText("What We Measure")).toBeVisible();
+    expect(
+      within(section).getByRole("heading", {
+        level: 2,
+        name: heading,
+      }),
+    ).toHaveAttribute("id", "care-pathway-heading");
+    expect(section).toHaveAttribute("aria-labelledby", "care-pathway-heading");
+    expect(within(section).getByText(introduction)).toBeVisible();
+
+    const list = within(section).getByRole("list");
+    const listItems = within(list).getAllByRole("listitem");
+
+    expect(list.tagName).toBe("OL");
+    expect(listItems).toHaveLength(steps.length);
+
+    steps.forEach((step, index) => {
+      const listItem = listItems[index];
+
+      expect(within(listItem).getByText(step.marker)).toHaveAttribute(
+        "aria-hidden",
+        "true",
+      );
+      expect(
+        within(listItem).getByRole("heading", {
+          level: 3,
+          name: step.title,
+        }),
+      ).toBeVisible();
+      expect(within(listItem).getByText(step.description)).toBeVisible();
+    });
+  });
+
+  it("keeps connectors decorative and excludes numerical achievements", () => {
+    render(<CarePathwaySection />);
+
+    const section = screen.getByRole("region", { name: heading });
+    const connectors = [
+      ...within(section).getAllByTestId("care-pathway-mobile-connector"),
+      ...within(section).getAllByTestId("care-pathway-desktop-connector"),
+    ];
+
+    expect(connectors).toHaveLength((steps.length - 1) * 2);
+    connectors.forEach((connector) => {
+      expect(connector).toHaveAttribute("aria-hidden", "true");
+    });
+
+    expect(section).not.toHaveTextContent(/\d{1,3}(?:,\d{3})+\+?/);
+    expect(section).not.toHaveTextContent(/\d+%/);
+    expect(section).not.toHaveTextContent("3,000+");
+    expect(section).not.toHaveTextContent("95%");
+  });
+});

--- a/src/components/home/__tests__/CarePathwaySection.test.tsx
+++ b/src/components/home/__tests__/CarePathwaySection.test.tsx
@@ -85,19 +85,23 @@ describe("CarePathwaySection", () => {
     });
   });
 
-  it("keeps connectors decorative and excludes numerical achievements", () => {
+  it("uses one open ledger instead of cards or connectors", () => {
     render(<CarePathwaySection />);
 
     const section = screen.getByRole("region", { name: heading });
-    const connectors = [
-      ...within(section).getAllByTestId("care-pathway-mobile-connector"),
-      ...within(section).getAllByTestId("care-pathway-desktop-connector"),
-    ];
+    const list = within(section).getByRole("list");
 
-    expect(connectors).toHaveLength((steps.length - 1) * 2);
-    connectors.forEach((connector) => {
-      expect(connector).toHaveAttribute("aria-hidden", "true");
-    });
+    expect(list).toHaveAttribute("data-care-pathway-ledger");
+    expect(list.querySelectorAll("[data-care-pathway-marker]")).toHaveLength(
+      steps.length,
+    );
+    expect(list.querySelector(".homepage-hover-card")).not.toBeInTheDocument();
+    expect(
+      within(section).queryByTestId("care-pathway-mobile-connector"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(section).queryByTestId("care-pathway-desktop-connector"),
+    ).not.toBeInTheDocument();
 
     expect(section).not.toHaveTextContent(/\d{1,3}(?:,\d{3})+\+?/);
     expect(section).not.toHaveTextContent(/\d+%/);

--- a/src/components/home/__tests__/JoinTheMovementSection.test.tsx
+++ b/src/components/home/__tests__/JoinTheMovementSection.test.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import JoinTheMovementSection from "@/components/home/JoinTheMovementSection";
+
+const { trackEventMock } = vi.hoisted(() => ({
+  trackEventMock: vi.fn(),
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  trackEvent: trackEventMock,
+}));
+
+const heading =
+  "Build healthier communities and stronger health leaders with us.";
+
+describe("JoinTheMovementSection", () => {
+  beforeEach(() => {
+    trackEventMock.mockClear();
+  });
+
+  it("renders the closing invitation and a clear three-action hierarchy", () => {
+    render(<JoinTheMovementSection />);
+
+    const section = screen.getByRole("region", { name: heading });
+
+    expect(section).toHaveAttribute("data-join-the-movement");
+    expect(section).toHaveClass("bg-[#0F4C5C]");
+    expect(section).not.toHaveClass("bg-[#121514]");
+    expect(
+      within(section).getByRole("heading", {
+        level: 2,
+        name: heading,
+      }),
+    ).toHaveAttribute("id", "join-heading");
+    expect(within(section).getByText("Choose how to take part")).toBeVisible();
+
+    const supportLink = within(section).getByRole("link", {
+      name: "Support Our Work",
+    });
+    const partnershipLink = within(section).getByRole("link", {
+      name: "Partner With Us",
+    });
+    const participationLink = within(section).getByRole("link", {
+      name: "Join Akomapa",
+    });
+
+    expect(supportLink).toHaveAttribute("href", "/donate");
+    expect(supportLink).toHaveClass("bg-[#eeba2b]");
+    expect(partnershipLink).toHaveAttribute("href", "/partnerships");
+    expect(participationLink).toHaveAttribute("href", "/get-involved");
+  });
+
+  it("tracks donation intent from the primary action", () => {
+    render(<JoinTheMovementSection />);
+
+    const supportLink = screen.getByRole("link", {
+      name: "Support Our Work",
+    });
+    supportLink.addEventListener("click", (event) => event.preventDefault());
+    fireEvent.click(supportLink);
+
+    expect(trackEventMock).toHaveBeenCalledOnce();
+    expect(trackEventMock).toHaveBeenCalledWith({
+      name: "donation_cta_click",
+      location: "home_join_the_movement",
+    });
+  });
+});

--- a/src/components/home/__tests__/TransformationalImpactSection.test.tsx
+++ b/src/components/home/__tests__/TransformationalImpactSection.test.tsx
@@ -11,6 +11,8 @@ describe("TransformationalImpactSection", () => {
       name: /building healthier communities\. preparing stronger health leaders\./i,
     });
 
+    expect(section).toHaveAttribute("data-transformational-impact");
+    expect(section).toHaveClass("bg-[#0097b2]");
     expect(
       within(section).getByRole("heading", {
         level: 2,
@@ -36,6 +38,14 @@ describe("TransformationalImpactSection", () => {
     for (const label of labels) {
       expect(screen.getAllByText(label).length).toBeGreaterThan(0);
     }
+
+    expect(
+      within(
+        screen.getByRole("region", {
+          name: /building healthier communities\. preparing stronger health leaders\./i,
+        }),
+      ).getByText("04"),
+    ).toBeVisible();
   });
 
   it("reuses canonical research impact metrics", () => {

--- a/src/components/home/__tests__/ValuesVisionSections.test.tsx
+++ b/src/components/home/__tests__/ValuesVisionSections.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import AkomapaMeaningSection from "@/components/home/AkomapaMeaningSection";
+import VisionSection from "@/components/home/VisionSection";
+
+describe("AkomapaMeaningSection", () => {
+  it("presents the values manifesto without changing the cream section tone", () => {
+    render(<AkomapaMeaningSection />);
+
+    const section = screen.getByRole("region", {
+      name: 'Akomapa means "A Good Heart."',
+    });
+
+    expect(section).toHaveAttribute("data-values-section");
+    expect(section).toHaveClass("bg-[#FCFAEF]");
+    expect(
+      within(section).getByRole("img", {
+        name: /health professionals offering compassionate community care/i,
+      }),
+    ).toBeVisible();
+    expect(
+      within(section).getByRole("link", { name: "Our story" }),
+    ).toHaveAttribute("href", "/about");
+
+    const values = within(section).getByRole("list", {
+      name: "Akomapa values",
+    });
+    for (const value of ["Empathy", "Equity", "Excellence"]) {
+      expect(within(values).getByText(value)).toBeVisible();
+    }
+  });
+});
+
+describe("VisionSection", () => {
+  it("presents the vision as an editorial statement on the white section tone", () => {
+    render(<VisionSection />);
+
+    const section = screen.getByRole("region", {
+      name: "Every community deserves high-quality chronic disease care.",
+    });
+
+    expect(section).toHaveAttribute("data-vision-section");
+    expect(section).toHaveClass("bg-white");
+    expect(
+      within(section).getByRole("heading", {
+        level: 2,
+        name: "Every community deserves high-quality chronic disease care.",
+      }),
+    ).toHaveAttribute("id", "vision-heading");
+
+    const priorities = within(section).getByRole("list", {
+      name: "Vision priorities",
+    });
+    for (const priority of [
+      "Compassionate care",
+      "Continuous access",
+      "Ethical leadership",
+    ]) {
+      expect(within(priorities).getByText(priority)).toBeVisible();
+    }
+  });
+});

--- a/src/components/home/_home-ui.tsx
+++ b/src/components/home/_home-ui.tsx
@@ -119,6 +119,7 @@ export function HomeBand({
         {marker ? (
           <span
             aria-hidden="true"
+            data-home-band-marker
             className={cn(
               "pointer-events-none absolute right-4 top-6 hidden select-none rounded px-2 py-1 font-subheading text-xs font-bold tracking-[0.2em] ring-1 md:inline-block",
               markerToneClasses[tone],

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -6,58 +6,136 @@ import BrandLogo from "@/components/shared/BrandLogo";
 import { CONTACT } from "@/config/contact";
 
 const footerLinkClass =
-  "text-[#2F3332]/80 transition-colors hover:text-[#0097b2] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0097b2] focus-visible:ring-offset-2 focus-visible:ring-offset-[#FCFAEF] dark:text-[#FCFAEF] dark:hover:text-[#F5C94D] dark:focus-visible:ring-[#F5C94D] dark:focus-visible:ring-offset-[#121514]";
+  "inline-flex min-h-7 items-center text-[#2F3332]/75 transition-colors hover:text-[#0097b2] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0097b2] focus-visible:ring-offset-2 focus-visible:ring-offset-[#FCFAEF] dark:text-[#FCFAEF]/85 dark:hover:text-[#F5C94D] dark:focus-visible:ring-[#F5C94D] dark:focus-visible:ring-offset-[#121514]";
 
 const footerSocialLinkClass =
-  "text-[#2F3332] transition-colors hover:text-[#0097b2] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0097b2] focus-visible:ring-offset-2 focus-visible:ring-offset-[#FCFAEF] dark:text-[#FCFAEF] dark:hover:text-[#F5C94D] dark:focus-visible:ring-[#F5C94D] dark:focus-visible:ring-offset-[#121514]";
+  "inline-flex h-10 w-10 items-center justify-center border border-[#2F3332]/15 text-[#2F3332] transition-colors hover:border-[#0097b2] hover:bg-[#0097b2] hover:text-[#FCFAEF] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0097b2] focus-visible:ring-offset-2 focus-visible:ring-offset-[#FCFAEF] dark:border-[#FCFAEF]/20 dark:text-[#FCFAEF] dark:hover:border-[#F5C94D] dark:hover:bg-[#F5C94D] dark:hover:text-[#121514] dark:focus-visible:ring-[#F5C94D] dark:focus-visible:ring-offset-[#121514]";
 
 export default function Footer() {
   const currentYear = new Date().getFullYear();
-  
+
   return (
-    <footer className="bg-[#FCFAEF] text-[#1C1F1E] dark:bg-[#121514] dark:text-[#FCFAEF]">
-      <div className="site-container mx-auto px-4 py-12">
+    <footer
+      data-site-footer
+      className="relative overflow-hidden border-t border-[#0097b2]/20 bg-[#FCFAEF] text-[#1C1F1E] dark:border-[#66C4DC]/20 dark:bg-[#121514] dark:text-[#FCFAEF]"
+    >
+      <span
+        aria-hidden="true"
+        className="absolute left-0 top-0 h-1 w-24 bg-[#eeba2b] md:w-40"
+      />
+
+      <div className="site-container mx-auto px-4 py-14 md:py-16 lg:py-20">
         <div
           data-footer-grid
-          className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-4 lg:gap-10"
+          className="grid grid-cols-1 gap-x-8 gap-y-10 md:grid-cols-2 lg:grid-cols-[minmax(0,1.35fr)_minmax(0,0.7fr)_minmax(0,0.9fr)_minmax(15rem,1.1fr)] lg:gap-x-10"
         >
           {/* Logo and mission */}
-          <div className="space-y-4">
+          <div
+            data-footer-brand
+            className="border-b border-[#2F3332]/15 pb-9 md:border-b-0 md:pb-0 dark:border-[#FCFAEF]/20"
+          >
             <BrandLogo width={220} height={60} />
-            <p className="mt-4 font-body text-[#2F3332]/80 dark:text-[#FCFAEF]">
+            <p className="mt-6 max-w-sm font-body text-lg leading-relaxed text-[#2F3332]/85 dark:text-[#FCFAEF]">
               {BRAND.footerMission}
             </p>
-            <p className="font-body text-sm text-[#2F3332]/70 dark:text-[#E6E7E7]">
+            <p className="mt-5 max-w-sm font-body text-sm leading-relaxed text-[#2F3332]/65 dark:text-[#E6E7E7]/80">
               {BRAND.legalNotice}
             </p>
-            <div className="flex space-x-4 pt-2">
-              <a href="https://www.facebook.com/people/Akomapa-health/100070235658941/" target="_blank" rel="noreferrer" className={footerSocialLinkClass} aria-label="Facebook">
-                <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                  <path fillRule="evenodd" d="M22 12c0-5.523-4.477-10-10-10S2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.878v-6.987h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.988C18.343 21.128 22 16.991 22 12z" clipRule="evenodd" />
+            <div
+              aria-label="Follow Akomapa Health"
+              className="mt-7 flex flex-wrap gap-2"
+            >
+              <a
+                href="https://www.facebook.com/people/Akomapa-health/100070235658941/"
+                target="_blank"
+                rel="noreferrer"
+                className={footerSocialLinkClass}
+                aria-label="Facebook"
+              >
+                <svg
+                  className="h-5 w-5"
+                  fill="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M22 12c0-5.523-4.477-10-10-10S2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.878v-6.987h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.988C18.343 21.128 22 16.991 22 12z"
+                    clipRule="evenodd"
+                  />
                 </svg>
               </a>
-              <a href="https://www.tiktok.com/@akomapahealth" target="_blank" rel="noreferrer" className={footerSocialLinkClass} aria-label="TikTok">
-                <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M19.59 6.69a4.83 4.83 0 0 1-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 0 1-5.2 1.74 2.89 2.89 0 0 1 2.31-4.64 2.89 2.89 0 0 1 .88.13V9.4a6.84 6.84 0 0 0-1-.05A6.33 6.33 0 0 0 5 20.1a6.34 6.34 0 0 0 10.86-4.43v-7a8.16 8.16 0 0 0 4.77 1.52v-3.4a4.85 4.85 0 0 1-1-.1z"/>
+              <a
+                href="https://www.tiktok.com/@akomapahealth"
+                target="_blank"
+                rel="noreferrer"
+                className={footerSocialLinkClass}
+                aria-label="TikTok"
+              >
+                <svg
+                  className="h-5 w-5"
+                  fill="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path d="M19.59 6.69a4.83 4.83 0 0 1-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 0 1-5.2 1.74 2.89 2.89 0 0 1 2.31-4.64 2.89 2.89 0 0 1 .88.13V9.4a6.84 6.84 0 0 0-1-.05A6.33 6.33 0 0 0 5 20.1a6.34 6.34 0 0 0 10.86-4.43v-7a8.16 8.16 0 0 0 4.77 1.52v-3.4a4.85 4.85 0 0 1-1-.1z" />
                 </svg>
               </a>
-              <a href="https://www.instagram.com/akomapahealth/" target="_blank" rel="noreferrer" className={footerSocialLinkClass} aria-label="Instagram">
-                <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                  <path fillRule="evenodd" d="M12.315 2c2.43 0 2.784.013 3.808.06 1.064.049 1.791.218 2.427.465a4.902 4.902 0 011.772 1.153 4.902 4.902 0 011.153 1.772c.247.636.416 1.363.465 2.427.048 1.067.06 1.407.06 4.123v.08c0 2.643-.012 2.987-.06 4.043-.049 1.064-.218 1.791-.465 2.427a4.902 4.902 0 01-1.153 1.772 4.902 4.902 0 01-1.772 1.153c-.636.247-1.363.416-2.427.465-1.067.048-1.407.06-4.123.06h-.08c-2.643 0-2.987-.012-4.043-.06-1.064-.049-1.791-.218-2.427-.465a4.902 4.902 0 01-1.772-1.153 4.902 4.902 0 01-1.153-1.772c-.247-.636-.416-1.363-.465-2.427-.047-1.024-.06-1.379-.06-3.808v-.63c0-2.43.013-2.784.06-3.808.049-1.064.218-1.791.465-2.427a4.902 4.902 0 011.153-1.772A4.902 4.902 0 015.45 2.525c.636-.247 1.363-.416 2.427-.465C8.901 2.013 9.256 2 11.685 2h.63zm-.081 1.802h-.468c-2.456 0-2.784.011-3.807.058-.975.045-1.504.207-1.857.344-.467.182-.8.398-1.15.748-.35.35-.566.683-.748 1.15-.137.353-.3.882-.344 1.857-.047 1.023-.058 1.351-.058 3.807v.468c0 2.456.011 2.784.058 3.807.045.975.207 1.504.344 1.857.182.466.399.8.748 1.15.35.35.683.566 1.15.748.353.137.882.3 1.857.344 1.054.048 1.37.058 4.041.058h.08c2.597 0 2.917-.01 3.96-.058.976-.045 1.505-.207 1.858-.344.466-.182.8-.398 1.15-.748.35-.35.566-.683.748-1.15.137-.353.3-.882.344-1.857.048-1.055.058-1.37.058-4.041v-.08c0-2.597-.01-2.917-.058-3.96-.045-.976-.207-1.505-.344-1.858a3.097 3.097 0 00-.748-1.15 3.098 3.098 0 00-1.15-.748c-.353-.137-.882-.3-1.857-.344-1.023-.047-1.351-.058-3.807-.058zM12 6.865a5.135 5.135 0 110 10.27 5.135 5.135 0 010-10.27zm0 1.802a3.333 3.333 0 100 6.666 3.333 3.333 0 000-6.666zm5.338-3.205a1.2 1.2 0 110 2.4 1.2 1.2 0 010-2.4z" clipRule="evenodd" />
+              <a
+                href="https://www.instagram.com/akomapahealth/"
+                target="_blank"
+                rel="noreferrer"
+                className={footerSocialLinkClass}
+                aria-label="Instagram"
+              >
+                <svg
+                  className="h-5 w-5"
+                  fill="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M12.315 2c2.43 0 2.784.013 3.808.06 1.064.049 1.791.218 2.427.465a4.902 4.902 0 011.772 1.153 4.902 4.902 0 011.153 1.772c.247.636.416 1.363.465 2.427.048 1.067.06 1.407.06 4.123v.08c0 2.643-.012 2.987-.06 4.043-.049 1.064-.218 1.791-.465 2.427a4.902 4.902 0 01-1.153 1.772 4.902 4.902 0 01-1.772 1.153c-.636.247-1.363.416-2.427.465-1.067.048-1.407.06-4.123.06h-.08c-2.643 0-2.987-.012-4.043-.06-1.064-.049-1.791-.218-2.427-.465a4.902 4.902 0 01-1.772-1.153 4.902 4.902 0 01-1.153-1.772c-.247-.636-.416-1.363-.465-2.427-.047-1.024-.06-1.379-.06-3.808v-.63c0-2.43.013-2.784.06-3.808.049-1.064.218-1.791.465-2.427a4.902 4.902 0 011.153-1.772A4.902 4.902 0 015.45 2.525c.636-.247 1.363-.416 2.427-.465C8.901 2.013 9.256 2 11.685 2h.63zm-.081 1.802h-.468c-2.456 0-2.784.011-3.807.058-.975.045-1.504.207-1.857.344-.467.182-.8.398-1.15.748-.35.35-.566.683-.748 1.15-.137.353-.3.882-.344 1.857-.047 1.023-.058 1.351-.058 3.807v.468c0 2.456.011 2.784.058 3.807.045.975.207 1.504.344 1.857.182.466.399.8.748 1.15.35.35.683.566 1.15.748.353.137.882.3 1.857.344 1.054.048 1.37.058 4.041.058h.08c2.597 0 2.917-.01 3.96-.058.976-.045 1.505-.207 1.858-.344.466-.182.8-.398 1.15-.748.35-.35.566-.683.748-1.15.137-.353.3-.882.344-1.857.048-1.055.058-1.37.058-4.041v-.08c0-2.597-.01-2.917-.058-3.96-.045-.976-.207-1.505-.344-1.858a3.097 3.097 0 00-.748-1.15 3.098 3.098 0 00-1.15-.748c-.353-.137-.882-.3-1.857-.344-1.023-.047-1.351-.058-3.807-.058zM12 6.865a5.135 5.135 0 110 10.27 5.135 5.135 0 010-10.27zm0 1.802a3.333 3.333 0 100 6.666 3.333 3.333 0 000-6.666zm5.338-3.205a1.2 1.2 0 110 2.4 1.2 1.2 0 010-2.4z"
+                    clipRule="evenodd"
+                  />
                 </svg>
               </a>
-              <a href="https://www.linkedin.com/company/akomapahealth/posts/?feedView=all" target="_blank" rel="noreferrer" className={footerSocialLinkClass} aria-label="LinkedIn">
-                <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                  <path fillRule="evenodd" d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z" clipRule="evenodd" />
+              <a
+                href="https://www.linkedin.com/company/akomapahealth/posts/?feedView=all"
+                target="_blank"
+                rel="noreferrer"
+                className={footerSocialLinkClass}
+                aria-label="LinkedIn"
+              >
+                <svg
+                  className="h-5 w-5"
+                  fill="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z"
+                    clipRule="evenodd"
+                  />
                 </svg>
               </a>
             </div>
           </div>
 
           {/* Quick Links */}
-          <div>
-            <h3 className="mb-4 font-heading text-lg font-bold tracking-tight">Quick Links</h3>
-            <ul className="space-y-2.5 font-body text-sm leading-relaxed md:text-base">
+          <div className="border-t border-[#2F3332]/15 pt-5 md:border-t-0 md:pt-0 dark:border-[#FCFAEF]/20">
+            <p
+              aria-hidden="true"
+              className="mb-4 font-subheading text-xs font-bold tracking-[0.2em] text-[#C9920F] dark:text-[#F5C94D]"
+            >
+              01
+            </p>
+            <h3 className="mb-5 font-heading text-lg font-bold tracking-tight">
+              Quick Links
+            </h3>
+            <ul className="space-y-2 font-body text-sm leading-relaxed md:text-base">
               <li>
                 <Link href="/philosophy" className={footerLinkClass}>
                   Our Philosophy
@@ -87,9 +165,17 @@ export default function Footer() {
           </div>
 
           {/* Initiatives */}
-          <div>
-            <h3 className="mb-4 font-heading text-lg font-bold tracking-tight">Our Initiatives</h3>
-            <ul className="space-y-2.5 font-body text-sm leading-relaxed md:text-base">
+          <div className="border-t border-[#2F3332]/15 pt-5 md:border-t-0 md:pt-0 dark:border-[#FCFAEF]/20">
+            <p
+              aria-hidden="true"
+              className="mb-4 font-subheading text-xs font-bold tracking-[0.2em] text-[#C9920F] dark:text-[#F5C94D]"
+            >
+              02
+            </p>
+            <h3 className="mb-5 font-heading text-lg font-bold tracking-tight">
+              Our Initiatives
+            </h3>
+            <ul className="space-y-2 font-body text-sm leading-relaxed md:text-base">
               <li>
                 <Link href="/community-hubs" className={footerLinkClass}>
                   Community Health Hubs
@@ -119,15 +205,27 @@ export default function Footer() {
           </div>
 
           {/* Contact Information */}
-          <div>
-            <h3 className="mb-4 font-heading text-lg font-bold tracking-tight">Contact Us</h3>
-            <div className="space-y-6 font-body text-[#2F3332]/80 dark:text-[#FCFAEF]">
+          <div className="border-t border-[#2F3332]/15 pt-5 md:border-t-0 md:pt-0 dark:border-[#FCFAEF]/20">
+            <p
+              aria-hidden="true"
+              className="mb-4 font-subheading text-xs font-bold tracking-[0.2em] text-[#C9920F] dark:text-[#F5C94D]"
+            >
+              03
+            </p>
+            <h3 className="mb-5 font-heading text-lg font-bold tracking-tight">
+              Contact Us
+            </h3>
+            <div className="space-y-6 font-body text-[#2F3332]/75 dark:text-[#FCFAEF]/85">
               {CONTACT.offices.map((office) => (
                 <div key={office.id}>
-                  <h4 className="mb-1 font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">{office.label}</h4>
+                  <h4 className="mb-1 font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+                    {office.label}
+                  </h4>
                   <address className="not-italic text-sm leading-relaxed">
                     {office.addressLines.map((line) => (
-                      <span key={line} className="block">{line}</span>
+                      <span key={line} className="block">
+                        {line}
+                      </span>
                     ))}
                     <a href={office.phone.href} className={footerLinkClass}>
                       {office.phone.display}
@@ -135,7 +233,7 @@ export default function Footer() {
                   </address>
                 </div>
               ))}
-              <div className="flex items-start">
+              <div className="flex items-start border-t border-[#2F3332]/15 pt-5 dark:border-[#FCFAEF]/20">
                 <Mail className="mr-2 h-5 w-5 flex-shrink-0 text-[#F5C94D]" />
                 <a
                   href={CONTACT.email.href}
@@ -150,15 +248,24 @@ export default function Footer() {
 
         <Newsletter />
 
-        <div className="mt-10 flex flex-col items-center justify-between border-t border-[#2F3332]/15 pt-6 dark:border-[#FCFAEF]/20 md:flex-row">
+        <div
+          data-footer-legal
+          className="mt-10 flex flex-col gap-4 border-t border-[#2F3332]/15 pt-6 dark:border-[#FCFAEF]/20 sm:flex-row sm:items-center sm:justify-between"
+        >
           <p className="font-body text-sm text-[#2F3332]/70 dark:text-[#E6E7E7]">
             &copy; {currentYear} Akomapa Health. All rights reserved.
           </p>
-          <div className="flex space-x-6 mt-4 md:mt-0">
-            <Link href="/privacy" className={`font-body text-sm ${footerLinkClass}`}>
+          <div className="flex flex-wrap gap-x-6 gap-y-2">
+            <Link
+              href="/privacy"
+              className={`font-body text-sm ${footerLinkClass}`}
+            >
               Privacy Policy
             </Link>
-            <Link href="/terms" className={`font-body text-sm ${footerLinkClass}`}>
+            <Link
+              href="/terms"
+              className={`font-body text-sm ${footerLinkClass}`}
+            >
               Terms of Service
             </Link>
           </div>

--- a/src/components/layout/__tests__/Footer.test.tsx
+++ b/src/components/layout/__tests__/Footer.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import Footer from "@/components/layout/Footer";
+import { BRAND } from "@/config/brand";
+import { CONTACT } from "@/config/contact";
+
+describe("Footer", () => {
+  it("renders the editorial footer structure without changing its foundation", () => {
+    render(<Footer />);
+
+    const footer = screen.getByRole("contentinfo");
+
+    expect(footer).toHaveAttribute("data-site-footer");
+    expect(footer).toHaveClass("bg-[#FCFAEF]");
+    expect(footer).toHaveTextContent(BRAND.footerMission);
+    expect(footer).toHaveTextContent(BRAND.legalNotice);
+    expect(
+      within(footer).getByRole("heading", { name: "Quick Links" }),
+    ).toBeVisible();
+    expect(
+      within(footer).getByRole("heading", { name: "Our Initiatives" }),
+    ).toBeVisible();
+    expect(
+      within(footer).getByRole("heading", { name: "Contact Us" }),
+    ).toBeVisible();
+    expect(
+      within(footer).getByRole("heading", {
+        name: "Join the Akomapa newsletter",
+      }),
+    ).toBeVisible();
+  });
+
+  it("preserves contact, social, and legal destinations", () => {
+    render(<Footer />);
+
+    const footer = screen.getByRole("contentinfo");
+    for (const social of ["Facebook", "TikTok", "Instagram", "LinkedIn"]) {
+      expect(within(footer).getByRole("link", { name: social })).toBeVisible();
+    }
+
+    expect(
+      within(footer).getByRole("link", { name: CONTACT.email.display }),
+    ).toHaveAttribute("href", CONTACT.email.href);
+    expect(
+      within(footer).getByRole("link", { name: "Privacy Policy" }),
+    ).toHaveAttribute("href", "/privacy");
+    expect(
+      within(footer).getByRole("link", { name: "Terms of Service" }),
+    ).toHaveAttribute("href", "/terms");
+  });
+});

--- a/src/components/layout/__tests__/site-container.test.ts
+++ b/src/components/layout/__tests__/site-container.test.ts
@@ -34,7 +34,7 @@ describe("site container layout contract", () => {
   });
 
   it("preserves the Our Teams network hero composition", () => {
-    const teamPage = readSource("src/app/(main)/about/team/ClientPage.tsx");
+    const teamPage = readSource("src/components/about/TeamPageContent.tsx");
     const heroContainer =
       'className="relative z-10 container mx-auto px-4 sm:px-6 lg:px-10 xl:px-12 2xl:px-6 flex flex-col gap-8 sm:gap-10 md:gap-12 lg:flex-row lg:items-center"';
 

--- a/src/components/shared/NewsLetter.tsx
+++ b/src/components/shared/NewsLetter.tsx
@@ -6,7 +6,14 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { CheckCircle2, ArrowRight, Loader2, AlertCircle } from "lucide-react";
 import { trackEvent } from "@/lib/analytics";
 
@@ -33,10 +40,10 @@ export default function Newsletter() {
     setError(null);
 
     try {
-      const response = await fetch('/api/newsletter', {
-        method: 'POST',
+      const response = await fetch("/api/newsletter", {
+        method: "POST",
         headers: {
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
         },
         body: JSON.stringify({ email: data.email }),
       });
@@ -44,7 +51,7 @@ export default function Newsletter() {
       const result = await response.json();
 
       if (!response.ok) {
-        throw new Error(result.error || 'Failed to subscribe');
+        throw new Error(result.error || "Failed to subscribe");
       }
 
       setIsSubmitted(true);
@@ -55,11 +62,11 @@ export default function Newsletter() {
         success: true,
       });
     } catch (error) {
-      console.error('Newsletter subscription error:', error);
+      console.error("Newsletter subscription error:", error);
       setError(
         error instanceof Error
           ? error.message
-          : 'An unexpected error occurred. Please try again.'
+          : "An unexpected error occurred. Please try again.",
       );
       trackEvent({
         name: "newsletter_signup",
@@ -75,20 +82,25 @@ export default function Newsletter() {
     <section
       data-newsletter
       aria-labelledby="footer-newsletter-heading"
-      className="mt-10 rounded-xl border border-[#2F3332]/15 bg-white/65 p-5 shadow-sm sm:p-6 lg:p-8 dark:border-[#FCFAEF]/18 dark:bg-[#FCFAEF]/[0.06]"
+      className="relative mt-14 overflow-hidden border border-[#66C4DC]/45 bg-[#0F4C5C] p-5 text-[#FCFAEF] sm:p-7 lg:p-9"
     >
-      <div className="grid gap-6 lg:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)] lg:items-center">
-        <div>
-          <p className="mb-2 font-body text-sm font-bold uppercase tracking-[0.16em] text-[#F5C94D]">
+      <span
+        aria-hidden="true"
+        className="absolute left-0 top-0 h-1 w-24 bg-[#eeba2b] sm:w-36"
+      />
+
+      <div className="grid gap-8 lg:grid-cols-[minmax(0,0.85fr)_minmax(0,1.15fr)] lg:items-center lg:gap-12">
+        <div data-newsletter-copy>
+          <p className="mb-3 font-subheading text-xs font-bold uppercase tracking-[0.2em] text-[#F5C94D]">
             Stay Connected
           </p>
           <h2
             id="footer-newsletter-heading"
-            className="font-heading text-2xl font-bold tracking-tight text-[#1C1F1E] dark:text-[#FCFAEF]"
+            className="max-w-md font-heading text-3xl font-semibold leading-tight tracking-tight text-[#FCFAEF] md:text-4xl"
           >
             Join the Akomapa newsletter
           </h2>
-          <p className="mt-2 max-w-xl font-body text-sm leading-relaxed text-[#2F3332]/75 dark:text-[#E6E7E7]">
+          <p className="mt-3 max-w-xl font-body text-sm leading-relaxed text-[#FCFAEF]/75">
             Receive updates on community care, research, leadership programs,
             and opportunities to get involved.
           </p>
@@ -97,7 +109,7 @@ export default function Newsletter() {
         {isSubmitted ? (
           <div
             aria-live="polite"
-            className="flex flex-col gap-4 rounded-xl bg-[#FCFAEF] p-4 text-[#2F3332] sm:flex-row sm:items-center sm:justify-between dark:bg-[#1C1F1E] dark:text-[#FCFAEF]"
+            className="flex flex-col gap-4 bg-[#FCFAEF] p-5 text-[#2F3332] sm:flex-row sm:items-center sm:justify-between"
           >
             <div className="flex items-start gap-3">
               <CheckCircle2 className="mt-0.5 h-5 w-5 flex-shrink-0 text-[#0097b2]" />
@@ -105,7 +117,7 @@ export default function Newsletter() {
                 <h3 className="font-heading font-semibold">
                   Thank you for subscribing!
                 </h3>
-                <p className="mt-1 font-body text-sm text-[#2F3332]/75 dark:text-[#E6E7E7]">
+                <p className="mt-1 font-body text-sm text-[#2F3332]/75">
                   You&apos;ll now receive the latest Akomapa updates.
                 </p>
               </div>
@@ -129,13 +141,16 @@ export default function Newsletter() {
                 className="flex items-center gap-3 rounded-lg border border-red-300/60 bg-red-50 p-3 dark:bg-red-950/40"
               >
                 <AlertCircle className="h-5 w-5 flex-shrink-0 text-red-700 dark:text-red-200" />
-                <p className="font-body text-sm text-red-700 dark:text-red-100">{error}</p>
+                <p className="font-body text-sm text-red-700 dark:text-red-100">
+                  {error}
+                </p>
               </div>
             )}
 
             <Form {...form}>
               <form
                 onSubmit={form.handleSubmit(onSubmit)}
+                data-newsletter-form
                 className="flex flex-col gap-3 sm:flex-row sm:items-start"
                 noValidate
               >
@@ -167,7 +182,7 @@ export default function Newsletter() {
                 <Button
                   type="submit"
                   disabled={isLoading}
-                  className="h-12 shrink-0 bg-[#0097b2] px-6 font-medium text-[#FCFAEF] hover:bg-[#007f96] focus-visible:ring-[#F5C94D] disabled:cursor-not-allowed disabled:opacity-50 sm:px-8 dark:bg-[#F5C94D] dark:text-[#121514] dark:hover:bg-[#FCFAEF]"
+                  className="h-12 shrink-0 bg-[#F5C94D] px-6 font-semibold text-[#121514] hover:bg-[#FCFAEF] focus-visible:ring-[#F5C94D] disabled:cursor-not-allowed disabled:opacity-50 sm:px-8"
                 >
                   {isLoading ? (
                     <>
@@ -183,7 +198,7 @@ export default function Newsletter() {
               </form>
             </Form>
 
-            <p className="font-body text-xs text-[#2F3332]/65 dark:text-[#FCFAEF]/65">
+            <p className="font-body text-xs text-[#FCFAEF]/65">
               By subscribing, you agree to our Privacy Policy and consent to
               receive updates from Akomapa Health.
             </p>

--- a/src/config/__tests__/contact.test.ts
+++ b/src/config/__tests__/contact.test.ts
@@ -63,7 +63,7 @@ describe("canonical contact configuration", () => {
 
   it("keeps every public contact surface tied to the canonical source", () => {
     for (const path of [
-      "src/app/(main)/contact/ClientPage.tsx",
+      "src/app/(main)/contact/Content.tsx",
       "src/components/contact/ContactForm.tsx",
       "src/components/layout/Footer.tsx",
       "src/components/contact/LocationMap.tsx",


### PR DESCRIPTION
## Summary

Implements GitHub Issue #170 by adding a homepage care-outcomes measurement pathway that communicates impact beyond outreach volume.

### Changes

- Adds the six-stage outcomes framework:
  - Screened
  - Identified
  - Referred
  - Linked to care
  - Followed up
  - Leaders trained
- Presents the framework as a responsive editorial outcome ledger.
- Uses a stacked mobile index, two-column intermediate layout, and six-column desktop layout.
- Preserves the existing homepage narrative order and executive-verified impact metrics.
- Rebalances homepage section tones and editorial numbering.
- Applies audited Next.js and transitive dependency security patches.
- Adds unit and end-to-end regression coverage for content, order, responsiveness, contrast, reduced motion, text zoom, and overflow.
- Adds a responsive typographic care-outcomes staircase using Akomapa’s established deep-teal and mustard palette.
- Uses a compact single-column mobile index, a two-column intermediate layout, and a progressive six-stage desktop staircase.
- Avoids repeating the homepage’s existing card, circular-marker, and connector patterns.
- Preserves accessible contrast, reduced-motion behavior, 200% text zoom, semantic ordered-list structure, and overflow-free responsive layouts.

## Validation

- ESLint passed
- TypeScript passed
- Production build passed
- 126 unit tests passed
- 504 Playwright tests passed across Chromium, Firefox, and WebKit
- React Server Components security verification passed
- Pre-commit checks passed

## Security note

`npm audit` continues to report two transitive `sharp` findings. npm only offers a forced downgrade to Next.js 14.2.35, which would introduce breaking compatibility and security risk. The downgrade was intentionally not applied.