### PR TITLE
Immersion program page

### DIFF
--- a/e2e/cta-links.spec.ts
+++ b/e2e/cta-links.spec.ts
@@ -12,7 +12,7 @@ test.describe("Program CTA links", () => {
     await preparePage(page);
   });
 
-  test("GHIP Request Program Brochure CTAs point to /contact", async ({
+  test("GHIP inquiry CTAs use allow-listed contact intents", async ({
     page,
   }) => {
     await page.goto("/programs/akomapa-ghip", {
@@ -29,7 +29,24 @@ test.describe("Program CTA links", () => {
     expect(count).toBeGreaterThan(0);
 
     for (let i = 0; i < count; i += 1) {
-      await expect(brochureLinks.nth(i)).toHaveAttribute("href", "/contact");
+      await expect(brochureLinks.nth(i)).toHaveAttribute(
+        "href",
+        "/contact?type=immersion-brochure",
+      );
+    }
+
+    const interestLinks = page.getByRole("link", {
+      name: "Register Interest",
+      exact: true,
+    });
+    const interestLinkCount = await interestLinks.count();
+    expect(interestLinkCount).toBeGreaterThan(0);
+
+    for (let i = 0; i < interestLinkCount; i += 1) {
+      await expect(interestLinks.nth(i)).toHaveAttribute(
+        "href",
+        "/contact?type=immersion",
+      );
     }
   });
 

--- a/e2e/cta-links.spec.ts
+++ b/e2e/cta-links.spec.ts
@@ -15,7 +15,7 @@ test.describe("Program CTA links", () => {
   test("GHIP inquiry CTAs use allow-listed contact intents", async ({
     page,
   }) => {
-    await page.goto("/programs/akomapa-ghip", {
+    await page.goto("/global-health-immersion-program", {
       waitUntil: "domcontentloaded",
     });
 

--- a/e2e/header-nav-a11y.spec.ts
+++ b/e2e/header-nav-a11y.spec.ts
@@ -101,4 +101,56 @@ test.describe("desktop header dropdown keyboard accessibility", () => {
     await uccLink.click();
     await expect(page).toHaveURL(/\/community-hubs\/ucc$/);
   });
+
+  test("Learning Experiences reaches the Immersion program by keyboard", async ({
+    page,
+  }) => {
+    const learningTrigger = page.getByRole("button", {
+      name: "Learning Experiences",
+    });
+    await learningTrigger.focus();
+    await page.keyboard.press("Enter");
+
+    const academyLink = page.getByRole("menuitem", {
+      name: "Akomapa Academy",
+    });
+    const immersionLink = page.getByRole("menuitem", {
+      name: "Global Health Immersion Program",
+    });
+
+    await expect(academyLink).toBeFocused();
+    await page.keyboard.press("ArrowDown");
+    await expect(immersionLink).toBeFocused();
+    await page.keyboard.press("Enter");
+
+    await expect(page).toHaveURL(/\/programs\/akomapa-ghip$/);
+    await expect(immersionLink).toHaveAttribute("aria-current", "page");
+  });
+});
+
+test.describe("mobile learning experiences navigation", () => {
+  test("shows both destinations and closes after navigation", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await dismissAnnouncementIfPresent(page);
+    await page.goto("/");
+
+    await page.getByRole("button", { name: "Open main menu" }).click();
+    const drawer = page.getByRole("dialog");
+
+    await expect(
+      drawer.getByText("Learning Experiences", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      drawer.getByRole("link", { name: "Akomapa Academy" }),
+    ).toBeVisible();
+
+    const immersionLink = drawer.getByRole("link", {
+      name: "Global Health Immersion Program",
+    });
+    await expect(immersionLink).toBeVisible();
+    await immersionLink.click();
+
+    await expect(page).toHaveURL(/\/programs\/akomapa-ghip$/);
+    await expect(drawer).toBeHidden();
+  });
 });

--- a/e2e/header-nav-a11y.spec.ts
+++ b/e2e/header-nav-a11y.spec.ts
@@ -123,7 +123,7 @@ test.describe("desktop header dropdown keyboard accessibility", () => {
     await expect(immersionLink).toBeFocused();
     await page.keyboard.press("Enter");
 
-    await expect(page).toHaveURL(/\/programs\/akomapa-ghip$/);
+    await expect(page).toHaveURL(/\/global-health-immersion-program$/);
     await learningTrigger.click();
     await expect(immersionLink).toBeVisible();
     await expect(immersionLink).toHaveAttribute("aria-current", "page");
@@ -152,7 +152,7 @@ test.describe("mobile learning experiences navigation", () => {
     await expect(immersionLink).toBeVisible();
     await immersionLink.click();
 
-    await expect(page).toHaveURL(/\/programs\/akomapa-ghip$/);
+    await expect(page).toHaveURL(/\/global-health-immersion-program$/);
     await expect(drawer).toBeHidden();
   });
 });

--- a/e2e/header-nav-a11y.spec.ts
+++ b/e2e/header-nav-a11y.spec.ts
@@ -124,6 +124,8 @@ test.describe("desktop header dropdown keyboard accessibility", () => {
     await page.keyboard.press("Enter");
 
     await expect(page).toHaveURL(/\/programs\/akomapa-ghip$/);
+    await learningTrigger.click();
+    await expect(immersionLink).toBeVisible();
     await expect(immersionLink).toHaveAttribute("aria-current", "page");
   });
 });

--- a/e2e/immersion-program.spec.ts
+++ b/e2e/immersion-program.spec.ts
@@ -1,0 +1,234 @@
+import { expect, test, type Page } from "@playwright/test";
+import { announcementCampaign } from "../src/data/announcements";
+import { immersionProgram } from "../src/data/immersion-program";
+
+const viewports = [
+  { name: "mobile", width: 390, height: 844 },
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "tablet-landscape", width: 1024, height: 1366 },
+  { name: "laptop", width: 1280, height: 800 },
+  { name: "desktop", width: 1440, height: 900 },
+  { name: "wide", width: 1536, height: 960 },
+] as const;
+
+const themes = ["light", "dark"] as const;
+
+async function preparePage(
+  page: Page,
+  theme: (typeof themes)[number],
+  reducedMotion = false,
+) {
+  await page.emulateMedia({
+    colorScheme: theme,
+    reducedMotion: reducedMotion ? "reduce" : "no-preference",
+  });
+  await page.addInitScript(
+    ({ storedTheme, announcementVersion }) => {
+      localStorage.setItem(
+        "akomapa-announcements-dismissed",
+        announcementVersion,
+      );
+      localStorage.setItem("akomapa-theme", storedTheme);
+      document.documentElement.classList.remove("light", "dark");
+      document.documentElement.classList.add(storedTheme);
+    },
+    {
+      storedTheme: theme,
+      announcementVersion: announcementCampaign.version,
+    },
+  );
+}
+
+async function assertNoHorizontalOverflow(page: Page) {
+  const dimensions = await page.evaluate(() => ({
+    viewportWidth: window.innerWidth,
+    documentWidth: document.documentElement.scrollWidth,
+  }));
+
+  expect(dimensions.documentWidth).toBeLessThanOrEqual(
+    dimensions.viewportWidth + 1,
+  );
+}
+
+test.describe("Immersion program responsive editorial layout", () => {
+  for (const viewport of viewports) {
+    for (const theme of themes) {
+      test(`${viewport.name} · ${theme} remains readable and overflow-free`, async ({
+        page,
+      }) => {
+        await page.setViewportSize(viewport);
+        await preparePage(page, theme);
+        await page.goto("/programs/akomapa-ghip", {
+          waitUntil: "domcontentloaded",
+        });
+        await page.evaluate(async () => document.fonts.ready);
+
+        const pageShell = page.locator("[data-immersion-page]");
+        await expect(pageShell).toBeVisible();
+        await expect(
+          page.getByRole("heading", {
+            level: 1,
+            name: immersionProgram.title,
+          }),
+        ).toBeVisible();
+        await expect(page.locator("main h1")).toHaveCount(1);
+        await expect(pageShell.locator("section")).toHaveCount(7);
+
+        await assertNoHorizontalOverflow(page);
+
+        const layoutChecks = await pageShell.evaluate((element) => {
+          const headings = Array.from(
+            element.querySelectorAll<HTMLElement>("h1, h2, h3"),
+          );
+          const inquiryLinks = Array.from(
+            element.querySelectorAll<HTMLElement>(
+              'a[href^="/contact?type=immersion"]',
+            ),
+          );
+
+          return {
+            headingOverflow: headings.some(
+              (heading) => heading.scrollWidth > heading.clientWidth + 1,
+            ),
+            inquiryLinks: inquiryLinks.map((link) => {
+              const rect = link.getBoundingClientRect();
+              return {
+                text: link.textContent?.trim(),
+                height: rect.height,
+                clipped:
+                  rect.left < -1 || rect.right > window.innerWidth + 1,
+                labelOverflow: link.scrollWidth > link.clientWidth + 1,
+              };
+            }),
+          };
+        });
+
+        expect(layoutChecks.headingOverflow).toBe(false);
+        expect(layoutChecks.inquiryLinks).toHaveLength(4);
+        for (const link of layoutChecks.inquiryLinks) {
+          expect(link.height, link.text).toBeGreaterThanOrEqual(44);
+          expect(link.clipped, link.text).toBe(false);
+          expect(link.labelOverflow, link.text).toBe(false);
+        }
+      });
+    }
+  }
+
+  test("reflows at a 200%-zoom-equivalent CSS viewport", async ({ page }) => {
+    await page.setViewportSize({ width: 720, height: 450 });
+    await preparePage(page, "light");
+    await page.goto("/programs/akomapa-ghip", {
+      waitUntil: "domcontentloaded",
+    });
+
+    await assertNoHorizontalOverflow(page);
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: immersionProgram.title,
+      }),
+    ).toBeVisible();
+  });
+
+  test("reduced motion reveals content without transform movement", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await preparePage(page, "light", true);
+    await page.goto("/programs/akomapa-ghip", {
+      waitUntil: "domcontentloaded",
+    });
+
+    expect(
+      await page.evaluate(() =>
+        window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+      ),
+    ).toBe(true);
+
+    const section = page.getByRole("region", {
+      name: "What participants experience",
+      exact: true,
+    });
+    const heading = section.getByRole("heading", {
+      level: 2,
+      name: "What participants experience",
+    });
+    const reveal = heading.locator("xpath=../..");
+
+    await expect(reveal).toHaveCount(1);
+    await reveal.scrollIntoViewIfNeeded();
+    await expect
+      .poll(() =>
+        reveal.evaluate((element) => {
+          const styles = getComputedStyle(element);
+          return { opacity: styles.opacity, transform: styles.transform };
+        }),
+      )
+      .toEqual({ opacity: "1", transform: "none" });
+  });
+
+  test("primary hero inquiry action has visible keyboard focus", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await preparePage(page, "light");
+    await page.goto("/programs/akomapa-ghip", {
+      waitUntil: "domcontentloaded",
+    });
+
+    const hero = page.getByRole("region", {
+      name: immersionProgram.title,
+      exact: true,
+    });
+    const interestLink = hero.getByRole("link", {
+      name: "Register Interest",
+      exact: true,
+    });
+
+    await interestLink.focus();
+    await expect(interestLink).toBeFocused();
+    await expect(interestLink).toHaveCSS("outline-style", "solid");
+  });
+});
+
+test.describe("Immersion contact intents", () => {
+  test("register-interest intent pre-fills the contact form", async ({ page }) => {
+    await preparePage(page, "light");
+    await page.goto("/contact?type=immersion", {
+      waitUntil: "domcontentloaded",
+    });
+
+    await expect(page.getByLabel("Subject *", { exact: true })).toHaveValue(
+      "Global Health Immersion Program Interest",
+    );
+    await expect(page.getByLabel("Message *", { exact: true })).toHaveValue(
+      /notify me when the next cohort details are available/,
+    );
+  });
+
+  test("brochure intent pre-fills a distinct request", async ({ page }) => {
+    await preparePage(page, "light");
+    await page.goto("/contact?type=immersion-brochure", {
+      waitUntil: "domcontentloaded",
+    });
+
+    await expect(page.getByLabel("Subject *", { exact: true })).toHaveValue(
+      "Global Health Immersion Program Brochure Request",
+    );
+    await expect(page.getByLabel("Message *", { exact: true })).toHaveValue(
+      /latest available information/,
+    );
+  });
+
+  test("unknown intent values leave the contact form untouched", async ({
+    page,
+  }) => {
+    await preparePage(page, "light");
+    await page.goto("/contact?type=not-allowed", {
+      waitUntil: "domcontentloaded",
+    });
+
+    await expect(page.getByLabel("Subject *", { exact: true })).toHaveValue("");
+    await expect(page.getByLabel("Message *", { exact: true })).toHaveValue("");
+  });
+});

--- a/e2e/immersion-program.spec.ts
+++ b/e2e/immersion-program.spec.ts
@@ -58,7 +58,7 @@ test.describe("Immersion program responsive editorial layout", () => {
       }) => {
         await page.setViewportSize(viewport);
         await preparePage(page, theme);
-        await page.goto("/programs/akomapa-ghip", {
+        await page.goto("/global-health-immersion-program", {
           waitUntil: "domcontentloaded",
         });
         await page.evaluate(async () => document.fonts.ready);
@@ -117,7 +117,7 @@ test.describe("Immersion program responsive editorial layout", () => {
   test("reflows at a 200%-zoom-equivalent CSS viewport", async ({ page }) => {
     await page.setViewportSize({ width: 720, height: 450 });
     await preparePage(page, "light");
-    await page.goto("/programs/akomapa-ghip", {
+    await page.goto("/global-health-immersion-program", {
       waitUntil: "domcontentloaded",
     });
 
@@ -135,7 +135,7 @@ test.describe("Immersion program responsive editorial layout", () => {
   }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await preparePage(page, "light", true);
-    await page.goto("/programs/akomapa-ghip", {
+    await page.goto("/global-health-immersion-program", {
       waitUntil: "domcontentloaded",
     });
 
@@ -172,7 +172,7 @@ test.describe("Immersion program responsive editorial layout", () => {
   }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await preparePage(page, "light");
-    await page.goto("/programs/akomapa-ghip", {
+    await page.goto("/global-health-immersion-program", {
       waitUntil: "domcontentloaded",
     });
 
@@ -230,5 +230,26 @@ test.describe("Immersion contact intents", () => {
 
     await expect(page.getByLabel("Subject *", { exact: true })).toHaveValue("");
     await expect(page.getByLabel("Message *", { exact: true })).toHaveValue("");
+  });
+});
+
+test.describe("Immersion program route migration", () => {
+  test("redirects the former Programs URL to the top-level page", async ({
+    page,
+  }) => {
+    const response = await page.goto("/programs/akomapa-ghip", {
+      waitUntil: "domcontentloaded",
+    });
+
+    const redirectedRequest = response?.request().redirectedFrom();
+    expect(redirectedRequest).not.toBeNull();
+    expect((await redirectedRequest?.response())?.status()).toBe(301);
+    await expect(page).toHaveURL(/\/global-health-immersion-program$/);
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: immersionProgram.title,
+      }),
+    ).toBeVisible();
   });
 });

--- a/e2e/pages-render.spec.ts
+++ b/e2e/pages-render.spec.ts
@@ -11,6 +11,10 @@ const pages = [
   { path: '/about/team', title: 'Team' },
   { path: '/philosophy', title: 'Our Philosophy' },
   { path: '/academy', title: 'Academy' },
+  {
+    path: '/global-health-immersion-program',
+    title: 'Global Health Immersion Program',
+  },
   { path: '/programs', title: 'Programs' },
   { path: '/programs/akomapa-young-advocates', title: 'Young Advocates' },
   { path: '/community-hubs', title: 'Community Health Hubs' },

--- a/e2e/responsive-pages.spec.ts
+++ b/e2e/responsive-pages.spec.ts
@@ -12,7 +12,7 @@ import { announcementCampaign } from "../src/data/announcements";
  */
 
 const viewports = [
-  { name: "mobile-375", width: 375, height: 812 },
+  { name: "mobile-390", width: 390, height: 844 },
   { name: "tablet-768", width: 768, height: 1024 },
   { name: "ipad-pro-1024", width: 1024, height: 1366 },
   { name: "laptop-1280", width: 1280, height: 800 },
@@ -21,7 +21,7 @@ const viewports = [
 ] as const;
 
 const expectedGutterByWidth = new Map<number, number>([
-  [375, 16],
+  [390, 16],
   [768, 32],
   [1024, 40],
   [1280, 48],
@@ -47,6 +47,10 @@ const routes: ReadonlyArray<{ path: string; name: string }> = [
   { path: "/blog", name: "blog" },
   { path: "/about/team", name: "team" },
   { path: "/programs", name: "programs" },
+  {
+    path: "/programs/akomapa-ghip",
+    name: "global-health-immersion-program",
+  },
   { path: "/philosophy", name: "philosophy" },
   { path: "/privacy", name: "privacy" },
   { path: "/terms", name: "terms" },

--- a/e2e/responsive-pages.spec.ts
+++ b/e2e/responsive-pages.spec.ts
@@ -48,7 +48,7 @@ const routes: ReadonlyArray<{ path: string; name: string }> = [
   { path: "/about/team", name: "team" },
   { path: "/programs", name: "programs" },
   {
-    path: "/programs/akomapa-ghip",
+    path: "/global-health-immersion-program",
     name: "global-health-immersion-program",
   },
   { path: "/philosophy", name: "philosophy" },

--- a/e2e/typography-regression.spec.ts
+++ b/e2e/typography-regression.spec.ts
@@ -24,6 +24,7 @@ const pages = [
   { path: "/news", headingSelector: "main h1, main h2" },
   { path: "/blog", headingSelector: "main h1, main h2" },
   { path: "/programs", headingSelector: "main h1" },
+  { path: "/programs/akomapa-ghip", headingSelector: "main h1" },
   { path: "/contact", headingSelector: "main h1" },
   { path: "/privacy", headingSelector: "main h1" },
   { path: "/terms", headingSelector: "main h1" },

--- a/e2e/typography-regression.spec.ts
+++ b/e2e/typography-regression.spec.ts
@@ -24,7 +24,7 @@ const pages = [
   { path: "/news", headingSelector: "main h1, main h2" },
   { path: "/blog", headingSelector: "main h1, main h2" },
   { path: "/programs", headingSelector: "main h1" },
-  { path: "/programs/akomapa-ghip", headingSelector: "main h1" },
+  { path: "/global-health-immersion-program", headingSelector: "main h1" },
   { path: "/contact", headingSelector: "main h1" },
   { path: "/privacy", headingSelector: "main h1" },
   { path: "/terms", headingSelector: "main h1" },

--- a/next.config.ts
+++ b/next.config.ts
@@ -73,6 +73,11 @@ const nextConfig: NextConfig = {
         destination: "/about/team",
         statusCode: 301,
       },
+      {
+        source: "/programs/akomapa-ghip",
+        destination: "/global-health-immersion-program",
+        statusCode: 301,
+      },
     ];
   },
   experimental: {

--- a/scripts/lighthouse.mjs
+++ b/scripts/lighthouse.mjs
@@ -26,6 +26,7 @@ const ROUTES = [
   { path: "/about/team", name: "about-team" },
   { path: "/programs", name: "programs" },
   { path: "/programs/akomapa-ghltp", name: "programs-akomapa-ghltp" },
+  { path: "/programs/akomapa-ghip", name: "programs-akomapa-ghip" },
 ];
 
 const LABEL = process.env.LIGHTHOUSE_LABEL || "before";

--- a/scripts/lighthouse.mjs
+++ b/scripts/lighthouse.mjs
@@ -26,7 +26,10 @@ const ROUTES = [
   { path: "/about/team", name: "about-team" },
   { path: "/programs", name: "programs" },
   { path: "/programs/akomapa-ghltp", name: "programs-akomapa-ghltp" },
-  { path: "/programs/akomapa-ghip", name: "programs-akomapa-ghip" },
+  {
+    path: "/global-health-immersion-program",
+    name: "global-health-immersion-program",
+  },
 ];
 
 const LABEL = process.env.LIGHTHOUSE_LABEL || "before";

--- a/src/app/(main)/global-health-immersion-program/Content.tsx
+++ b/src/app/(main)/global-health-immersion-program/Content.tsx
@@ -55,7 +55,7 @@ function SectionHeading({
   );
 }
 
-function EditorialArrow() {
+function EditorialLinkArrow() {
   return (
     <span aria-hidden="true" className="transition-transform group-hover:translate-x-0.5">
       →
@@ -435,7 +435,7 @@ export default function Content() {
               className="group mt-6 inline-flex min-h-11 items-center gap-2 text-sm font-semibold text-[#0F4C5C] underline decoration-[#eeba2b] decoration-2 underline-offset-4 hover:text-[#0097b2] dark:text-[#66C4DC] dark:hover:text-[#F5C94D]"
             >
               Partner as a faculty mentor
-              <EditorialArrow />
+              <EditorialLinkArrow />
             </Link>
           </div>
         </div>

--- a/src/app/(main)/global-health-immersion-program/__tests__/Content.test.tsx
+++ b/src/app/(main)/global-health-immersion-program/__tests__/Content.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import Content from "../Content";
 import { immersionProgram } from "@/data/immersion-program";
 
-describe("Global Health Immersion Program page", () => {
+describe("Global Health Immersion Program top-level page", () => {
   it("renders one page heading and a logical editorial section hierarchy", () => {
     render(<Content />);
 

--- a/src/app/(main)/global-health-immersion-program/page.tsx
+++ b/src/app/(main)/global-health-immersion-program/page.tsx
@@ -2,7 +2,9 @@ import type { Metadata } from "next";
 import { buildPageMetadata } from "@/lib/seo";
 import Content from "./Content";
 
-export const metadata: Metadata = buildPageMetadata("/programs/akomapa-ghip");
+export const metadata: Metadata = buildPageMetadata(
+  "/global-health-immersion-program",
+);
 
 export default function GHIPPage() {
   return <Content />;

--- a/src/app/(main)/programs/Content.tsx
+++ b/src/app/(main)/programs/Content.tsx
@@ -1,7 +1,7 @@
 import { MotionDiv, MotionH1, MotionP } from "@/components/motion/framer";
 import { AnimatedMetric } from "@/components/motion/AnimatedMetric";
 import Image from "@/components/common/Image";
-import { ArrowRight, Globe, GraduationCap, Users, Building, ChevronsDown, Sparkles, Sprout } from "lucide-react";
+import { ArrowRight, Globe, GraduationCap, Building, ChevronsDown, Sparkles, Sprout } from "lucide-react";
 import Link from "next/link";
 import Breadcrumb from "@/components/layout/Breadcrumb";
 import { Button } from "@/components/ui/button";
@@ -93,29 +93,6 @@ const programs: Program[] = [
   },
   {
     id: 4,
-    title: "Global Health Immersion Camp",
-    description: "Starting in Ghana and expanding globally, our 3-week Summer Immersion Camp gives students hands-on exposure to community and public health in low-resource settings. Participants engage in clinical service, health education, and cultural exchange—bridging classroom learning with lived experience.",
-    details: [
-      "Three-week intensive program in Ghana combining clinical service with cultural immersion",
-      "Hands-on experience in community health, public health, and primary care delivery",
-      "Cultural exchange activities that build understanding and respect for local contexts",
-      "Designed to bridge theoretical learning with real-world application in resource-limited settings"
-    ],
-    href: "/programs/akomapa-ghip",
-    icon: Users,
-    color: "#eeba2b",
-    bgGradient: "from-[#eeba2b]/10 to-[#eeba2b]/5",
-    image: "/highlights/Akomapa-61.jpg",
-    alt: "Students participating in global health immersion program",
-    features: [
-      "Hands-On Experience",
-      "Cultural Immersion",
-      "Clinical Service",
-      "Global Expansion"
-    ]
-  },
-  {
-    id: 5,
     title: "Akomapa Young Advocates",
     description: "The Akomapa Young Advocates Program is a youth empowerment and health education initiative that brings community health, mentorship, and leadership development directly to high schools. Led by interprofessional university health professional students trained through Akomapa clinics, the program equips young people with practical knowledge about non-communicable diseases (NCDs) such as hypertension and diabetes, mental wellness, and preventive health so they can become champions of healthy living and positive change in their schools and communities.",
     details: [
@@ -138,7 +115,7 @@ const programs: Program[] = [
     ]
   },
   {
-    id: 6,
+    id: 5,
     title: "Akomapa Foods & Stores",
     description: "The Akomapa Foods & Stores Initiative is the sustainability arm of the Akomapa Health model—connecting food security, economic empowerment, and healthcare access into one self-sustaining ecosystem. We believe that health doesn't start in hospitals; it starts in homes, kitchens, and markets. By linking agriculture and nutrition to our student-powered community health hubs, Akomapa creates a cycle where communities not only receive care but also co-own the means to sustain it.",
     details: [
@@ -344,7 +321,17 @@ export default function Content() {
                       className="w-full sm:w-auto bg-[#0097b2] hover:bg-[#0097b2]/80 text-[#FCFAEF] group"
                     >
                       <Link href={program.href} className="flex items-center justify-center">
-                        {program.id === 1 ? "Explore Akomapa Clinics" : program.id === 2 ? "Discover the Akomapa Network" : program.id === 3 ? "Join the Leadership Program" : program.id === 4 ? "Experience the Immersion Camp" : program.id === 5 ? "Join the Akomapa Young Advocates" : program.id === 6 ? "Discover the Akomapa Foods & Stores" : "Learn More"}
+                        {program.id === 1
+                          ? "Explore Akomapa Clinics"
+                          : program.id === 2
+                            ? "Discover the Akomapa Network"
+                            : program.id === 3
+                              ? "Join the Leadership Program"
+                              : program.id === 4
+                                ? "Join the Akomapa Young Advocates"
+                                : program.id === 5
+                                  ? "Discover the Akomapa Foods & Stores"
+                                  : "Learn More"}
                         <ArrowRight className="ml-2 h-4 w-4 group-hover:translate-x-1 transition-transform" />
                       </Link>
                     </Button>

--- a/src/app/(main)/programs/akomapa-ghip/Content.tsx
+++ b/src/app/(main)/programs/akomapa-ghip/Content.tsx
@@ -418,7 +418,7 @@ export default function Content() {
               <PublicCta
                 href="/contact?type=immersion"
                 variant="teal"
-                className="min-h-12 justify-center"
+                className="min-h-12 justify-center !text-[#1C1F1E]"
               >
                 Register Interest
               </PublicCta>

--- a/src/app/(main)/programs/akomapa-ghip/Content.tsx
+++ b/src/app/(main)/programs/akomapa-ghip/Content.tsx
@@ -1,629 +1,445 @@
-import { MotionDiv, MotionH1, MotionP } from "@/components/motion/framer";
 import Link from "next/link";
-import { ArrowLeft, ArrowRight, SchoolIcon } from "lucide-react";
 import Breadcrumb from "@/components/layout/Breadcrumb";
 import Image from "@/components/common/Image";
-import { Button } from "@/components/ui/button";
+import { FadeIn } from "@/components/animations";
+import {
+  PublicCta,
+  SectionEyebrow,
+} from "@/components/shared/PublicPagePrimitives";
+import { immersionProgram } from "@/data/immersion-program";
+import { cn } from "@/lib/utils";
 
-const programHighlights = [
-  {
-    label: "Duration",
-    value: "3 weeks",
-    description: "Intensive experiential learning program",
-    accentColor: "#0097b2"
-  },
-  {
-    label: "First Site",
-    value: "Ghana",
-    description: "Next cohort details forthcoming",
-    accentColor: "#eeba2b"
-  },
-  {
-    label: "Certification",
-    value: "Certificate",
-    description: "Akomapa Certificate in Global Health & Community Engagement",
-    accentColor: "#0F4C5C"
-  }
-];
+const sectionContainerClass =
+  "site-container mx-auto px-4 py-16 md:py-20 lg:py-24";
 
-const learningComponents = [
-  {
-    title: "Service Learning",
-    description: "Hands-on participation in Akomapa's community-based clinics and outreach programs.",
-    color: "#0097b2"
-  },
-  {
-    title: "Community-Based Research",
-    description: "Small-group projects investigating real public-health challenges using qualitative and quantitative methods.",
-    color: "#eeba2b"
-  },
-  {
-    title: "Leadership Development",
-    description: "Peer-led discussions linking fieldwork to cultural humility, ethics, and systems thinking.",
-    color: "#0097b2"
-  },
-  {
-    title: "Expert Seminars",
-    description: "Sessions taught by faculty from partner universities and global health organizations on NCD prevention, health systems, and innovation.",
-    color: "#eeba2b"
-  },
-  {
-    title: "Capstone Reflection",
-    description: "Fellows present project findings and personal insights to peers, mentors, and community partners.",
-    color: "#0097b2"
-  }
-];
+function SectionHeading({
+  eyebrow,
+  title,
+  description,
+  tone = "dark",
+  id,
+}: {
+  eyebrow: string;
+  title: string;
+  description?: string;
+  tone?: "dark" | "light";
+  id: string;
+}) {
+  return (
+    <div className="max-w-3xl">
+      <SectionEyebrow tone={tone === "light" ? "light" : "teal"}>
+        {eyebrow}
+      </SectionEyebrow>
+      <h2
+        id={id}
+        className={cn(
+          "mt-4 max-w-3xl font-heading text-[1.9rem] font-semibold leading-[1.14] tracking-tight md:text-[2.4rem] lg:text-[2.8rem]",
+          tone === "light" ? "text-[#FCFAEF]" : "text-[#1C1F1E] dark:text-[#FCFAEF]",
+        )}
+      >
+        {title}
+      </h2>
+      {description ? (
+        <p
+          className={cn(
+            "mt-5 max-w-2xl text-base leading-7 md:text-lg",
+            tone === "light"
+              ? "text-[#FCFAEF]/78"
+              : "text-[#2F3332]/78 dark:text-[#E6E7E7]/78",
+          )}
+        >
+          {description}
+        </p>
+      ) : null}
+    </div>
+  );
+}
 
-const whatToExpect = [
-  {
-    title: "Student-Powered Community Health Hubs",
-    description: "Join Akomapa clinics delivering free screenings, counseling, and health education alongside local student teams.",
-    accentColor: "#0097b2"
-  },
-  {
-    title: "Community Engagement Projects",
-    description: "Design outreach initiatives with neighborhood partners to strengthen trust and expand preventative care.",
-    accentColor: "#eeba2b"
-  },
-  {
-    title: "Applied Research",
-    description: "Conduct field-based studies that investigate public-health challenges and propose context-driven solutions.",
-    accentColor: "#0F4C5C"
-  },
-  {
-    title: "Mentored Seminars",
-    description: "Participate in interactive case discussions led by Akomapa mentors, faculty, and visiting global health experts.",
-    accentColor: "#0097b2"
-  },
-  {
-    title: "Health Systems Immersion",
-    description: "Observe how national, regional, and community health systems work together—from policy tables to primary care sites.",
-    accentColor: "#eeba2b"
-  },
-  {
-    title: "Leadership Circles",
-    description: "Reflect daily with peers through facilitated sessions linking lived experience to ethics, leadership, and humility.",
-    accentColor: "#0F4C5C"
-  },
-  {
-    title: "Cultural Excursions",
-    description: "Explore historical and cultural landmarks that deepen cultural competence and community understanding.",
-    accentColor: "#0097b2"
-  }
-];
-
-const whoCanApply = [
-  {
-    title: "Undergraduate & Pre-Med Pathways",
-    description: "Students exploring medicine, global health, or public service who want immersive, community-centered experience.",
-    accentColor: "#0097b2"
-  },
-  {
-    title: "Health Professional Learners",
-    description: "Medical, nursing, pharmacy, public health, and allied health students eager to practice collaborative care.",
-    accentColor: "#eeba2b"
-  },
-  {
-    title: "Graduate & Early-Career Professionals",
-    description: "Emerging leaders committed to ethical, community-based global engagement and systems innovation.",
-    accentColor: "#0F4C5C"
-  }
-];
-
-const globalImpact = [
-  {
-    title: "Cross-Cultural Leadership",
-    description: "Strengthens collaboration between rising healthcare leaders across continents through shared service.",
-    accentColor: "#0097b2"
-  },
-  {
-    title: "Community-Driven Innovation",
-    description: "Advances research and interventions that originate from, and are sustained by, local partners.",
-    accentColor: "#eeba2b"
-  },
-  {
-    title: "Student-Powered Care",
-    description: "Expands Akomapa’s model where students lead with empathy under expert supervision.",
-    accentColor: "#0F4C5C"
-  },
-  {
-    title: "Global Network Building",
-    description: "Cultivates compassionate, evidence-driven changemakers connected through the Akomapa Network.",
-    accentColor: "#0097b2"
-  }
-];
-
-const ctaBaseClass =
-  "group inline-flex items-center justify-center gap-2 rounded-half px-8 py-6 h-auto text-base sm:text-lg font-medium transition-all duration-300 transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2";
-
-const primaryCtaClass =
-  `${ctaBaseClass} bg-[#0097b2] hover:bg-[#0097b2]/80 text-[#FCFAEF] shadow-lg hover:shadow-xl focus-visible:ring-[#8DD4E6]`;
-
-const secondaryCtaClass =
-  `${ctaBaseClass} bg-[#eeba2b] hover:bg-[#eeba2b]/80 text-[#FCFAEF] shadow-lg hover:shadow-xl focus-visible:ring-[#F5C94D]`;
+function EditorialArrow() {
+  return (
+    <span aria-hidden="true" className="transition-transform group-hover:translate-x-0.5">
+      →
+    </span>
+  );
+}
 
 export default function Content() {
+  const {
+    eyebrow,
+    title,
+    introduction,
+    overview,
+    vision,
+    facts,
+    experiences,
+    learningComponents,
+    audiences,
+    outcomes,
+    hostSite,
+    images,
+  } = immersionProgram;
+
   return (
-    <>
+    <div
+      data-immersion-page
+      className="bg-[#FCFAEF] text-[#1C1F1E] dark:bg-[#121514] dark:text-[#FCFAEF]"
+    >
       <div className="site-container mx-auto">
         <Breadcrumb />
       </div>
 
-      <section className="relative min-h-[80vh] py-16 sm:py-20 md:py-28 bg-gradient-to-r from-[#0097b2] to-[#0F4C5C] overflow-hidden">
-        <div className="absolute top-0 right-0 w-64 h-64 bg-[#FCFAEF]/10 rounded-full -translate-y-1/2 translate-x-1/2 blur-3xl" />
-        <div className="absolute bottom-0 left-0 w-96 h-96 bg-[#FCFAEF]/10 rounded-full translate-y-1/2 -translate-x-1/2 blur-3xl" />
-
-        <div className="site-container mx-auto px-4 sm:px-6 relative z-10 flex flex-col gap-12 sm:gap-14">
-          <MotionDiv
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            className="pt-2"
-          >
-            <Link 
-              href="/programs" 
-              className="inline-flex items-center text-[#FCFAEF]/80 hover:text-[#FCFAEF] transition-colors text-sm font-medium"
+      <section
+        aria-labelledby="immersion-title"
+        className="border-y border-[#FCFAEF]/12 bg-[#0F4C5C] text-[#FCFAEF]"
+      >
+        <div className="site-container mx-auto grid items-center gap-12 px-4 py-14 md:py-20 lg:grid-cols-12 lg:gap-16 lg:py-24">
+          <div className="lg:col-span-7">
+            <SectionEyebrow tone="light">{eyebrow}</SectionEyebrow>
+            <h1
+              id="immersion-title"
+              className="mt-5 max-w-4xl font-heading text-[2.35rem] font-semibold leading-[1.04] tracking-[-0.025em] text-[#FCFAEF] sm:text-[3.1rem] lg:text-[4.35rem]"
             >
-              <ArrowLeft className="mr-2 h-4 w-4" />
-              Back to Programs
-            </Link>
-          </MotionDiv>
-          <div className="max-w-4xl">
-            <MotionP
-              initial={{ opacity: 0, y: 40 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.8, ease: "easeOut" }}
-              className="uppercase tracking-[0.3em] text-sm font-semibold text-[#FCFAEF]/80 mb-6"
-            >
-              Akomapa Global Health Immersion Program
-            </MotionP>
-            <MotionH1
-              initial={{ opacity: 0, y: 40 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.1, duration: 0.8, ease: "easeOut" }}
-              className="text-3xl sm:text-4xl md:text-6xl lg:text-7xl font-light text-[#FCFAEF] mb-6 leading-tight"
-            >
-              Learn by Serving. Lead by Understanding.
-            </MotionH1>
-            <MotionP
-              initial={{ opacity: 0, y: 40 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.2, duration: 0.8, ease: "easeOut" }}
-              className="text-base sm:text-lg md:text-2xl text-[#FCFAEF]/85 font-light max-w-3xl"
-            >
-              A three-week experiential global health fellowship that bridges learning and service, bringing together students from across Africa, the United States, and beyond to explore how communities, health systems, and students collaborate to advance care.
-            </MotionP>
-            <MotionDiv
-              initial={{ opacity: 0, y: 40 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.3, duration: 0.8, ease: "easeOut" }}
-              className="mt-8 flex flex-wrap gap-4"
-            >
-              <Button asChild className={primaryCtaClass}>
-                <Link href="/contact?type=immersion">Register Interest</Link>
-              </Button>
-              <Button asChild className={secondaryCtaClass}>
-                <Link href="/contact?type=immersion-brochure">
-                  Request Program Brochure
-                </Link>
-              </Button>
-            </MotionDiv>
+              {title}
+            </h1>
+            <p className="mt-6 max-w-2xl text-base leading-7 text-[#FCFAEF]/82 sm:text-lg sm:leading-8">
+              {introduction}
+            </p>
+            <div className="mt-8 flex max-w-xl flex-col items-stretch gap-3 sm:flex-row sm:items-center lg:flex-col lg:items-stretch xl:flex-row xl:items-center">
+              <PublicCta
+                href="/contact?type=immersion"
+                variant="gold"
+                className="min-h-12 justify-center"
+              >
+                Register Interest
+              </PublicCta>
+              <PublicCta
+                href="/contact?type=immersion-brochure"
+                variant="outline-light"
+                className="min-h-12 justify-center"
+              >
+                Request Program Brochure
+              </PublicCta>
+            </div>
           </div>
 
-          <MotionDiv
-            initial={{ opacity: 0, y: 40 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.4, duration: 0.8, ease: "easeOut" }}
-            className="w-full"
-          >
-            <div className="relative w-full h-[280px] sm:h-[360px] md:h-[520px] lg:h-[640px] rounded-3xl overflow-hidden shadow-2xl border border-white/10">
+          <figure className="lg:col-span-5">
+            <div className="relative aspect-[4/5] overflow-hidden border-l-4 border-[#eeba2b] bg-[#121514]">
               <Image
-                src="/highlights/Akomapa-40.jpg"
-                alt="Global health immersion program participants"
+                src={images.hero.src}
+                alt={images.hero.alt}
                 fill
-                sizes="(min-width: 1024px) 50vw, 100vw"
-                className="object-cover object-center"
+                priority
+                sizes="(min-width: 1024px) 38vw, 100vw"
+                className="object-cover"
+                style={{ objectPosition: images.hero.position }}
               />
-              <div className="absolute inset-0 bg-gradient-to-t from-black/35 via-transparent to-transparent" />
             </div>
-          </MotionDiv>
+            <figcaption className="mt-3 border-t border-[#FCFAEF]/24 pt-3 text-xs font-semibold uppercase tracking-[0.18em] text-[#FCFAEF]/65">
+              Community-centered learning in Ghana
+            </figcaption>
+          </figure>
         </div>
       </section>
 
-      <section className="py-16 md:py-24 bg-[#FCFAEF] dark:bg-[#1C1F1E]">
-        <div className="site-container mx-auto px-4">
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-16 items-center">
-            <MotionDiv
-              initial={{ opacity: 0, y: 24 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6 }}
-              viewport={{ once: true, amount: 0.3 }}
-              className="order-1"
-            >
-              <h2 className="text-3xl md:text-4xl font-bold mb-6 text-[#1C1F1E] dark:text-[#FCFAEF]">
-                About the Program
+      <section
+        aria-labelledby="program-facts-title"
+        className="border-b border-[#1C1F1E]/12 bg-white dark:border-[#FCFAEF]/12 dark:bg-[#1C1F1E]"
+      >
+        <div className="site-container mx-auto px-4 py-12 md:py-16">
+          <div className="flex flex-col justify-between gap-3 border-b border-[#1C1F1E]/16 pb-6 dark:border-[#FCFAEF]/16 md:flex-row md:items-end">
+            <div>
+              <SectionEyebrow>Program overview</SectionEyebrow>
+              <h2
+                id="program-facts-title"
+                className="mt-3 font-heading text-2xl font-semibold tracking-tight md:text-3xl"
+              >
+                At a glance
               </h2>
-              <div className="space-y-5 text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed">
-                <p>
-                  The Akomapa Immersion Program is a three-week experiential global health fellowship that bridges learning and service. It brings together undergraduate, pre-medical, and health professional students from across Africa, the United States, and beyond to explore how communities, health systems, and students collaborate to advance care.
-                </p>
-                <p>
-                  The program will expand across several countries through the Akomapa Network, beginning with its inaugural cohort in Ghana. Each site immerses participants in community health delivery, systems learning, and cultural exchange—preparing future leaders to translate experience into impact.
-                </p>
-              </div>
-            </MotionDiv>
-            <MotionDiv
-              initial={{ opacity: 0, y: 24 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.1, duration: 0.6 }}
-              viewport={{ once: true, amount: 0.3 }}
-              className="order-2"
-            >
-              <div className="relative w-full min-h-[320px] h-[320px] sm:h-[380px] md:h-[420px] lg:h-[460px] rounded-3xl overflow-hidden shadow-2xl">
-                <Image
-                  src="/highlights/Akomapa-66.jpg"
-                  alt="Students participating in global health immersion program"
-                  fill
-                  sizes="(min-width: 1024px) 50vw, 100vw"
-                  className="object-cover object-center"
-                />
-                <div className="absolute inset-0 bg-gradient-to-t from-black/25 via-transparent to-transparent" />
-              </div>
-            </MotionDiv>
+            </div>
+            <p className="max-w-md text-sm leading-6 text-[#2F3332]/65 dark:text-[#E6E7E7]/68">
+              Confirmed program details are shown separately from information
+              that has not yet been announced.
+            </p>
           </div>
+
+          <dl className="grid md:grid-cols-2 xl:grid-cols-4">
+            {facts.map((fact, index) => (
+              <div
+                key={fact.label}
+                className={cn(
+                  "border-b border-[#1C1F1E]/12 py-7 dark:border-[#FCFAEF]/12 md:px-6 xl:border-b-0",
+                  index % 2 === 0 && "md:border-r",
+                  index > 0 && "xl:border-l xl:border-r-0",
+                  index === 0 && "md:pl-0 xl:border-l-0",
+                )}
+              >
+                <dt className="text-xs font-bold uppercase tracking-[0.18em] text-[#0097b2] dark:text-[#66C4DC]">
+                  {fact.label}
+                </dt>
+                <dd className="mt-3">
+                  <span className="block font-heading text-2xl font-semibold leading-tight">
+                    {fact.value}
+                  </span>
+                  <span className="mt-2 block text-sm leading-6 text-[#2F3332]/68 dark:text-[#E6E7E7]/68">
+                    {fact.description}
+                  </span>
+                </dd>
+              </div>
+            ))}
+          </dl>
         </div>
       </section>
 
-      <section className="py-16 md:py-24 bg-gradient-to-r from-[#0097b2] to-[#0F4C5C] text-[#FCFAEF] relative overflow-hidden">
-        <div className="absolute inset-0 pointer-events-none">
-          <div className="absolute -top-24 -left-24 h-64 w-64 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
-          <div className="absolute bottom-0 right-0 h-80 w-80 rounded-full bg-[#F5C94D]/10 blur-3xl" />
-        </div>
-        <div className="relative site-container mx-auto px-4">
-          <MotionDiv
-            initial={{ opacity: 0, y: 24 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true, amount: 0.4 }}
-            className="text-center max-w-3xl mx-auto mb-12 space-y-4"
-          >
-            <h2 className="text-3xl md:text-4xl font-bold">
-              Our Vision
-            </h2>
-            <p className="text-base sm:text-lg text-[#FCFAEF]/90 leading-relaxed">
-              To cultivate global health leaders who are grounded in empathy, cultural humility, and community partnership, and who can transform firsthand experience into sustainable solutions for health equity.
-            </p>
-          </MotionDiv>
-        </div>
-      </section>
-
-      <section className="py-16 md:py-24 bg-[#FCFAEF] dark:bg-[#1C1F1E]">
-        <div className="site-container mx-auto px-4">
-          <MotionDiv
-            initial={{ opacity: 0, y: 24 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true, amount: 0.3 }}
-            className="text-center max-w-4xl mx-auto mb-12 space-y-4"
-          >
-            <h2 className="text-3xl md:text-4xl font-bold text-[#1C1F1E] dark:text-[#FCFAEF]">
-              What to Expect
-            </h2>
-            <p className="text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed">
-              The Akomapa Immersion Program combines classroom learning, clinical exposure, and cultural discovery. While details vary by country, participants can expect to:
-            </p>
-          </MotionDiv>
-
-          <div className="max-w-6xl mx-auto">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-8">
-              {whatToExpect.map((item, index) => (
-                <MotionDiv
-                  key={item.title}
-                  initial={{ opacity: 0, y: 20 }}
-                  whileInView={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.6, delay: index * 0.1 }}
-                  viewport={{ once: true, amount: 0.3 }}
-                  className="relative rounded-2xl bg-white dark:bg-[#2F3332] p-6 md:p-8 shadow-lg border border-[#E6E7E7]/30 dark:border-[#4F5554]/30 flex flex-col"
-                >
-                  <div
-                    className="h-1 w-16 rounded-full mb-4"
-                    style={{ backgroundColor: item.accentColor }}
-                  />
-                  <h3 className="text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF] mb-3">
-                    {item.title}
-                  </h3>
-                  <p className="text-sm md:text-base text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed flex-1">
-                    {item.description}
-                  </p>
-                </MotionDiv>
+      <section
+        aria-labelledby="program-purpose-title"
+        className="bg-[#FCFAEF] dark:bg-[#121514]"
+      >
+        <div
+          className={cn(
+            sectionContainerClass,
+            "grid items-center gap-12 lg:grid-cols-12 lg:gap-16",
+          )}
+        >
+          <FadeIn className="lg:col-span-6">
+            <SectionHeading
+              eyebrow="The program"
+              title="Global health education grounded in place and partnership."
+              id="program-purpose-title"
+            />
+            <div className="mt-7 max-w-2xl space-y-5 text-base leading-7 text-[#2F3332]/82 dark:text-[#E6E7E7]/80 md:text-lg md:leading-8">
+              {overview.map((paragraph) => (
+                <p key={paragraph}>{paragraph}</p>
               ))}
             </div>
-          </div>
-        </div>
-      </section>
-
-      <section className="py-16 md:py-24 bg-gradient-to-r from-[#0097b2] to-[#0F4C5C] text-[#FCFAEF] relative overflow-hidden">
-        <div className="absolute inset-0 pointer-events-none">
-          <div className="absolute -top-24 -left-24 h-64 w-64 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
-          <div className="absolute bottom-0 right-0 h-80 w-80 rounded-full bg-[#F5C94D]/10 blur-3xl" />
-        </div>
-        <div className="relative site-container mx-auto px-4">
-          <MotionDiv
-            initial={{ opacity: 0, y: 24 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true, amount: 0.4 }}
-            className="text-center max-w-3xl mx-auto mb-12 space-y-4"
-          >
-            <h2 className="text-3xl md:text-4xl font-bold">
-              Program Highlights
-            </h2>
-          </MotionDiv>
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 md:gap-8">
-            {programHighlights.map((highlight, index) => (
-              <MotionDiv
-                key={highlight.label}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: index * 0.1 }}
-                viewport={{ once: true, amount: 0.4 }}
-                className="relative rounded-2xl bg-[#FCFAEF]/95 text-[#1C1F1E] shadow-xl border border-[#E6E7E7]/40 overflow-hidden p-6 md:p-8 flex flex-col"
-              >
-                <div
-                  className="h-1 w-16 rounded-full mb-4"
-                  style={{ backgroundColor: highlight.accentColor }}
-                />
-                <span
-                  className="text-4xl font-semibold tracking-tight"
-                  style={{ color: highlight.accentColor }}
-                >
-                  {highlight.value}
-                </span>
-                <h3 className="mt-4 text-lg font-semibold uppercase tracking-[0.2em] text-[#1C1F1E]/70">
-                  {highlight.label}
-                </h3>
-                <p className="mt-3 text-sm md:text-base text-[#2F3332]/85 leading-relaxed flex-1">
-                  {highlight.description}
-                </p>
-              </MotionDiv>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      <section className="py-16 md:py-24 bg-[#FCFAEF] dark:bg-[#1C1F1E]">
-        <div className="site-container mx-auto px-4">
-          <MotionDiv
-            initial={{ opacity: 0, y: 24 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true, amount: 0.3 }}
-            className="text-center max-w-4xl mx-auto mb-12 space-y-4"
-          >
-            <h2 className="text-3xl md:text-4xl font-bold text-[#1C1F1E] dark:text-[#FCFAEF]">
-              Learning Components
-            </h2>
-          </MotionDiv>
-
-          <div className="max-w-6xl mx-auto">
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8">
-              {learningComponents.map((component, index) => (
-                <MotionDiv
-                  key={component.title}
-                  initial={{ opacity: 0, y: 24 }}
-                  whileInView={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.6, delay: index * 0.1 }}
-                  viewport={{ once: true, amount: 0.3 }}
-                  className="group relative rounded-2xl bg-white dark:bg-[#2F3332] p-6 md:p-8 shadow-lg hover:shadow-xl transition-all duration-300 border border-[#E6E7E7]/20 dark:border-[#4F5554]/20 hover:-translate-y-1"
-                >
-                  <div className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300 bg-gradient-to-br from-[#0097b2]/5 via-transparent to-[#eeba2b]/5 rounded-2xl" />
-                  <div className="relative">
-                    <div 
-                      className="h-1 w-16 rounded-full mb-4"
-                      style={{ backgroundColor: component.color }}
-                    />
-                    <h3 className="text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF] mb-3">
-                      {component.title}
-                    </h3>
-                    <p className="text-sm md:text-base text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed">
-                      {component.description}
-                    </p>
-                  </div>
-                </MotionDiv>
-              ))}
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section className="py-16 md:py-24 bg-gradient-to-r from-[#0097b2] to-[#0F4C5C] text-[#FCFAEF] relative overflow-hidden">
-        <div className="absolute inset-0 pointer-events-none">
-          <div className="absolute -top-24 -left-24 h-64 w-64 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
-          <div className="absolute bottom-0 right-0 h-80 w-80 rounded-full bg-[#F5C94D]/10 blur-3xl" />
-        </div>
-        <div className="relative site-container mx-auto px-4">
-          <MotionDiv
-            initial={{ opacity: 0, y: 24 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true, amount: 0.3 }}
-            className="text-center max-w-4xl mx-auto mb-12 space-y-4"
-          >
-            <h2 className="text-3xl md:text-4xl font-bold">
-              Who Can Apply
-            </h2>
-            <p className="text-lg text-[#FCFAEF]/90 leading-relaxed">
-              We welcome applicants who are curious, humble, and committed to health equity.
-            </p>
-          </MotionDiv>
-
-          <div className="max-w-6xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-6 md:gap-8">
-            {whoCanApply.map((item, index) => (
-              <MotionDiv
-                key={item.title}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: index * 0.1 }}
-                viewport={{ once: true, amount: 0.3 }}
-                className="rounded-2xl bg-white/10 backdrop-blur-md border border-white/20 p-6 md:p-8 shadow-xl flex flex-col gap-3"
-              >
-                <div
-                  className="h-1 w-16 rounded-full"
-                  style={{ backgroundColor: item.accentColor }}
-                />
-                <h3 className="text-xl font-semibold text-white">
-                  {item.title}
-                </h3>
-                <p className="text-sm md:text-base text-[#FCFAEF]/85 leading-relaxed">
-                  {item.description}
-                </p>
-              </MotionDiv>
-            ))}
-          </div>
-
-          <p className="text-center text-base text-[#FCFAEF]/85 italic mt-10">
-            Participants are selected for their curiosity, humility, and commitment to health equity.
-          </p>
-        </div>
-      </section>
-
-      <section className="py-16 md:py-24 bg-[#FCFAEF] dark:bg-[#1C1F1E]">
-        <div className="site-container mx-auto px-4">
-          <MotionDiv
-            initial={{ opacity: 0, y: 24 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true, amount: 0.3 }}
-            className="text-center max-w-4xl mx-auto mb-12 space-y-4"
-          >
-            <h2 className="text-3xl md:text-4xl font-bold text-[#1C1F1E] dark:text-[#FCFAEF]">
-              Global Impact
-            </h2>
-            <p className="text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed">
-              By embedding students directly within community systems, the Akomapa Immersion Program:
-            </p>
-          </MotionDiv>
-
-          <div className="max-w-5xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-8">
-            {globalImpact.map((item, index) => (
-              <MotionDiv
-                key={item.title}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: index * 0.1 }}
-                viewport={{ once: true, amount: 0.3 }}
-                className="rounded-2xl bg-white dark:bg-[#2F3332] p-6 md:p-8 shadow-lg border border-[#E6E7E7]/30 dark:border-[#4F5554]/30 flex flex-col gap-3"
-              >
-                <div
-                  className="h-1 w-16 rounded-full"
-                  style={{ backgroundColor: item.accentColor }}
-                />
-              <h3 className="text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
-                {item.title}
-              </h3>
-              <p className="text-sm md:text-base text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed">
-                {item.description}
+            <blockquote className="mt-9 border-l-4 border-[#eeba2b] pl-5">
+              <p className="font-heading text-xl font-semibold leading-8 text-[#0F4C5C] dark:text-[#FCFAEF] md:text-2xl">
+                {vision}
               </p>
-            </MotionDiv>
-          ))}
-        </div>
-          </div>
-      </section>
+            </blockquote>
+          </FadeIn>
 
-      <section className="py-16 md:py-24 bg-[#F4F1E8] dark:bg-[#1C1F1E]">
-        <div className="site-container mx-auto px-4">
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-16 items-center">
-            <MotionDiv
-              initial={{ opacity: 0, y: 24 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6 }}
-              viewport={{ once: true, amount: 0.3 }}
-              className="order-1"
-            >
-              <h2 className="text-3xl md:text-4xl font-bold mb-6 text-[#1C1F1E] dark:text-[#FCFAEF]">
-                First host site
-              </h2>
-              <div className="space-y-5 text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed">
-                <div className="flex items-center">
-                <SchoolIcon className="w-6 h-6 text-[#0097b2] dark:text-[#66C4DC] mr-2 flex-shrink-0" />
-                  <span className="font-semibold text-[#0097b2] dark:text-[#66C4DC] mr-2">University of Cape Coast, Ghana</span>
-                </div>
-                <p>
-                  <span className="font-semibold text-[#0097b2] dark:text-[#66C4DC]">
-                    Next cohort details forthcoming.
-                  </span>{" "}
-                  Dates, fees, and application timing will be published after
-                  they are confirmed.
-                </p>
-              </div>
-            </MotionDiv>
-            <MotionDiv
-              initial={{ opacity: 0, y: 24 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.1, duration: 0.6 }}
-              viewport={{ once: true, amount: 0.3 }}
-              className="order-2"
-            >
-              <div className="relative w-full min-h-[320px] h-[320px] sm:h-[380px] md:h-[420px] lg:h-[460px] rounded-3xl overflow-hidden shadow-2xl">
+          <FadeIn delay={0.08} className="lg:col-span-6">
+            <figure>
+              <div className="relative aspect-[16/11] overflow-hidden border border-[#1C1F1E]/14 bg-[#E6E7E7] dark:border-[#FCFAEF]/14 dark:bg-[#2F3332]">
                 <Image
-                  src="/highlights/Akomapa-12.jpg"
-                  alt="Akomapa participants at the first host site in Ghana"
+                  src={images.overview.src}
+                  alt={images.overview.alt}
                   fill
-                  sizes="(min-width: 1024px) 50vw, 100vw"
-                  className="object-cover object-center"
+                  sizes="(min-width: 1024px) 48vw, 100vw"
+                  className="object-cover"
+                  style={{ objectPosition: images.overview.position }}
                 />
-                <div className="absolute inset-0 bg-gradient-to-t from-black/25 via-transparent to-transparent" />
               </div>
-            </MotionDiv>
+              <figcaption className="mt-3 text-xs font-semibold uppercase tracking-[0.18em] text-[#2F3332]/58 dark:text-[#FCFAEF]/58">
+                Supervised practice, research, and reflection
+              </figcaption>
+            </figure>
+          </FadeIn>
+        </div>
+      </section>
+
+      <section
+        aria-labelledby="participant-experience-title"
+        className="border-y border-[#1C1F1E]/10 bg-white dark:border-[#FCFAEF]/10 dark:bg-[#1C1F1E]"
+      >
+        <div className={sectionContainerClass}>
+          <FadeIn>
+            <SectionHeading
+              eyebrow="The experience"
+              title="What participants experience"
+              description="The program combines supervised community health practice, academic study, research, reflection, and cultural learning."
+              id="participant-experience-title"
+            />
+          </FadeIn>
+
+          <ol className="mt-12 grid lg:grid-cols-2 lg:gap-x-12">
+            {experiences.map((experience, index) => (
+              <li
+                key={experience.title}
+                className="grid grid-cols-[2.75rem_1fr] gap-4 border-t border-[#1C1F1E]/16 py-6 dark:border-[#FCFAEF]/16 md:grid-cols-[3.5rem_1fr] md:py-7"
+              >
+                <span
+                  aria-hidden="true"
+                  className="font-heading text-sm font-semibold tracking-[0.14em] text-[#C9920F] dark:text-[#F5C94D]"
+                >
+                  {String(index + 1).padStart(2, "0")}
+                </span>
+                <div>
+                  <h3 className="font-heading text-lg font-semibold leading-7 md:text-xl">
+                    {experience.title}
+                  </h3>
+                  <p className="mt-2 max-w-xl text-sm leading-6 text-[#2F3332]/72 dark:text-[#E6E7E7]/72 md:text-base md:leading-7">
+                    {experience.description}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </section>
+
+      <section
+        aria-labelledby="learning-components-title"
+        className="bg-[#121514] text-[#FCFAEF]"
+      >
+        <div className={sectionContainerClass}>
+          <FadeIn>
+            <SectionHeading
+              eyebrow="Learning model"
+              title="How participants learn"
+              description="Each component connects practical experience with disciplined inquiry and guided reflection."
+              tone="light"
+              id="learning-components-title"
+            />
+          </FadeIn>
+
+          <ol className="mt-12 border-b border-[#FCFAEF]/18">
+            {learningComponents.map((component, index) => (
+              <li
+                key={component.title}
+                className="grid gap-4 border-t border-[#FCFAEF]/18 py-7 md:grid-cols-[4rem_minmax(13rem,0.75fr)_1.25fr] md:items-baseline md:gap-8"
+              >
+                <span
+                  aria-hidden="true"
+                  className="text-xs font-bold tracking-[0.2em] text-[#F5C94D]"
+                >
+                  {String(index + 1).padStart(2, "0")}
+                </span>
+                <h3 className="font-heading text-xl font-semibold leading-7 text-[#FCFAEF]">
+                  {component.title}
+                </h3>
+                <p className="max-w-2xl text-sm leading-6 text-[#FCFAEF]/70 md:text-base md:leading-7">
+                  {component.description}
+                </p>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </section>
+
+      <section
+        aria-labelledby="eligibility-title"
+        className="bg-[#FCFAEF] dark:bg-[#121514]"
+      >
+        <div className={cn(sectionContainerClass, "grid gap-14 lg:grid-cols-2 lg:gap-20")}>
+          <div>
+            <FadeIn>
+              <SectionHeading
+                eyebrow="Eligibility"
+                title="Who the program is for"
+                description="The experience is designed for learners prepared to approach community health with curiosity, humility, and care."
+                id="eligibility-title"
+              />
+            </FadeIn>
+            <ul className="mt-10 border-b border-[#1C1F1E]/14 dark:border-[#FCFAEF]/14">
+              {audiences.map((audience) => (
+                <li
+                  key={audience.title}
+                  className="border-t border-[#1C1F1E]/14 py-6 dark:border-[#FCFAEF]/14"
+                >
+                  <h3 className="font-heading text-lg font-semibold leading-7">
+                    {audience.title}
+                  </h3>
+                  <p className="mt-2 text-sm leading-6 text-[#2F3332]/72 dark:text-[#E6E7E7]/72 md:text-base md:leading-7">
+                    {audience.description}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div aria-labelledby="participant-outcomes-title">
+            <FadeIn delay={0.08}>
+              <SectionHeading
+                eyebrow="Participant development"
+                title="What participants develop"
+                description="These are learning outcomes, not claims of achieved community impact."
+                id="participant-outcomes-title"
+              />
+            </FadeIn>
+            <ul className="mt-10 border-b border-[#1C1F1E]/14 dark:border-[#FCFAEF]/14">
+              {outcomes.map((outcome) => (
+                <li
+                  key={outcome.title}
+                  className="border-t border-[#1C1F1E]/14 py-6 dark:border-[#FCFAEF]/14"
+                >
+                  <h3 className="font-heading text-lg font-semibold leading-7">
+                    {outcome.title}
+                  </h3>
+                  <p className="mt-2 text-sm leading-6 text-[#2F3332]/72 dark:text-[#E6E7E7]/72 md:text-base md:leading-7">
+                    {outcome.description}
+                  </p>
+                </li>
+              ))}
+            </ul>
           </div>
         </div>
       </section>
 
-      <section className="py-16 md:py-24 bg-gradient-to-r from-[#0F4C5C] via-[#0097b2] to-[#0B2F3A] text-[#FCFAEF]">
-        <div className="site-container mx-auto px-4">
-          <MotionDiv
-            initial={{ opacity: 0, y: 24 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true, amount: 0.3 }}
-            className="max-w-3xl mx-auto text-center space-y-6"
-          >
-            <h2 className="text-3xl md:text-4xl font-bold">Apply or Partner</h2>
-            <p className="text-lg text-[#FCFAEF]/85 leading-relaxed">
-              Join us in building the next generation of global health leaders through immersive, community-centered learning.
-            </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Button
-                asChild
-                className={primaryCtaClass}
-              >
-                <Link
-                  href="/contact?type=immersion"
-                  className="flex items-center"
-                >
-                  Register Interest
-                  <ArrowRight className="ml-2 h-5 w-5" />
-                </Link>
-              </Button>
-              <Button asChild className={secondaryCtaClass}>
-                <Link
-                  href="/contact?type=immersion-brochure"
-                  className="flex items-center"
-                >
-                  Request Program Brochure
-                  <ArrowRight className="ml-2 h-5 w-5" />
-                </Link>
-              </Button>
-              <Button asChild className={secondaryCtaClass}>
-                <Link href="/partnerships" className="flex items-center">
-                  Partner as a Faculty Mentor
-                  <ArrowRight className="ml-2 h-5 w-5" />
-                </Link>
-              </Button>
+      <section
+        aria-labelledby="host-site-title"
+        className="border-t border-[#1C1F1E]/12 bg-white dark:border-[#FCFAEF]/12 dark:bg-[#1C1F1E]"
+      >
+        <div
+          className={cn(
+            sectionContainerClass,
+            "grid items-center gap-12 lg:grid-cols-12 lg:gap-16",
+          )}
+        >
+          <figure className="lg:col-span-6">
+            <div className="relative aspect-[16/11] overflow-hidden border-b-4 border-[#eeba2b] bg-[#E6E7E7] dark:bg-[#2F3332]">
+              <Image
+                src={images.hostSite.src}
+                alt={images.hostSite.alt}
+                fill
+                sizes="(min-width: 1024px) 48vw, 100vw"
+                className="object-cover"
+                style={{ objectPosition: images.hostSite.position }}
+              />
             </div>
-          </MotionDiv>
+          </figure>
+
+          <div className="lg:col-span-6">
+            <SectionEyebrow>{hostSite.heading}</SectionEyebrow>
+            <h2
+              id="host-site-title"
+              className="mt-4 font-heading text-[1.9rem] font-semibold leading-[1.14] tracking-tight md:text-[2.4rem] lg:text-[2.8rem]"
+            >
+              {hostSite.name}
+            </h2>
+            <p className="mt-6 inline-flex border-y border-[#0097b2]/28 py-3 text-sm font-bold uppercase tracking-[0.14em] text-[#0F4C5C] dark:text-[#66C4DC]">
+              {hostSite.status}
+            </p>
+            <p className="mt-6 max-w-xl text-base leading-7 text-[#2F3332]/76 dark:text-[#E6E7E7]/76 md:text-lg">
+              {hostSite.description}
+            </p>
+
+            <div className="mt-8 flex max-w-xl flex-col gap-3 sm:flex-row lg:flex-col 2xl:flex-row">
+              <PublicCta
+                href="/contact?type=immersion"
+                variant="teal"
+                className="min-h-12 justify-center"
+              >
+                Register Interest
+              </PublicCta>
+              <PublicCta
+                href="/contact?type=immersion-brochure"
+                variant="outline"
+                className="min-h-12 justify-center"
+              >
+                Request Program Brochure
+              </PublicCta>
+            </div>
+            <Link
+              href="/partnerships"
+              className="group mt-6 inline-flex min-h-11 items-center gap-2 text-sm font-semibold text-[#0F4C5C] underline decoration-[#eeba2b] decoration-2 underline-offset-4 hover:text-[#0097b2] dark:text-[#66C4DC] dark:hover:text-[#F5C94D]"
+            >
+              Partner as a faculty mentor
+              <EditorialArrow />
+            </Link>
+          </div>
         </div>
       </section>
-    </>
+    </div>
   );
 }

--- a/src/app/(main)/programs/akomapa-ghip/Content.tsx
+++ b/src/app/(main)/programs/akomapa-ghip/Content.tsx
@@ -1,6 +1,6 @@
 import { MotionDiv, MotionH1, MotionP } from "@/components/motion/framer";
 import Link from "next/link";
-import { ArrowLeft, ArrowRight, CalendarIcon, DollarSignIcon, MailIcon, SchoolIcon } from "lucide-react";
+import { ArrowLeft, ArrowRight, SchoolIcon } from "lucide-react";
 import Breadcrumb from "@/components/layout/Breadcrumb";
 import Image from "@/components/common/Image";
 import { Button } from "@/components/ui/button";
@@ -15,7 +15,7 @@ const programHighlights = [
   {
     label: "First Site",
     value: "Ghana",
-    description: "2026, Dates TBD",
+    description: "Next cohort details forthcoming",
     accentColor: "#eeba2b"
   },
   {
@@ -200,10 +200,12 @@ export default function Content() {
               className="mt-8 flex flex-wrap gap-4"
             >
               <Button asChild className={primaryCtaClass}>
-                <Link href="/get-involved">Apply Now</Link>
+                <Link href="/contact?type=immersion">Register Interest</Link>
               </Button>
               <Button asChild className={secondaryCtaClass}>
-                <Link href="/contact">Request Program Brochure</Link>
+                <Link href="/contact?type=immersion-brochure">
+                  Request Program Brochure
+                </Link>
               </Button>
             </MotionDiv>
           </div>
@@ -539,28 +541,20 @@ export default function Content() {
               className="order-1"
             >
               <h2 className="text-3xl md:text-4xl font-bold mb-6 text-[#1C1F1E] dark:text-[#FCFAEF]">
-                2026 Pilot Cohort
+                First host site
               </h2>
               <div className="space-y-5 text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed">
                 <div className="flex items-center">
                 <SchoolIcon className="w-6 h-6 text-[#0097b2] dark:text-[#66C4DC] mr-2 flex-shrink-0" />
                   <span className="font-semibold text-[#0097b2] dark:text-[#66C4DC] mr-2">University of Cape Coast, Ghana</span>
                 </div>
-                <div className="flex items-center">
-                  <CalendarIcon className="w-6 h-6 text-[#0097b2] dark:text-[#66C4DC] mr-2 flex-shrink-0" />
-                  <span className="font-semibold text-[#0097b2] dark:text-[#66C4DC] mr-2">Exact Dates: </span>
-                  TBD (Summer 2026)
-                </div>
-                <div className="flex items-center">
-                  <MailIcon className="w-6 h-6 text-[#0097b2] dark:text-[#66C4DC] mr-2 flex-shrink-0" />
-                  <span className="font-semibold text-[#0097b2] dark:text-[#66C4DC] mr-2">Applications open: </span>
-                  January 2026
-                </div>
-                <div className="flex items-center">
-                  <DollarSignIcon className="w-6 h-6 text-[#0097b2] dark:text-[#66C4DC] mr-2 flex-shrink-0" />
-                  <span className="font-semibold text-[#0097b2] dark:text-[#66C4DC] mr-2">Program Fees: </span>
-                  TBD
-                </div>
+                <p>
+                  <span className="font-semibold text-[#0097b2] dark:text-[#66C4DC]">
+                    Next cohort details forthcoming.
+                  </span>{" "}
+                  Dates, fees, and application timing will be published after
+                  they are confirmed.
+                </p>
               </div>
             </MotionDiv>
             <MotionDiv
@@ -573,7 +567,7 @@ export default function Content() {
               <div className="relative w-full min-h-[320px] h-[320px] sm:h-[380px] md:h-[420px] lg:h-[460px] rounded-3xl overflow-hidden shadow-2xl">
                 <Image
                   src="/highlights/Akomapa-12.jpg"
-                  alt="2026 Pilot Cohort in Ghana"
+                  alt="Akomapa participants at the first host site in Ghana"
                   fill
                   sizes="(min-width: 1024px) 50vw, 100vw"
                   className="object-cover object-center"
@@ -603,13 +597,19 @@ export default function Content() {
                 asChild
                 className={primaryCtaClass}
               >
-                <Link href="/get-involved" className="flex items-center">
-                  Apply Now
+                <Link
+                  href="/contact?type=immersion"
+                  className="flex items-center"
+                >
+                  Register Interest
                   <ArrowRight className="ml-2 h-5 w-5" />
                 </Link>
               </Button>
               <Button asChild className={secondaryCtaClass}>
-                <Link href="/contact" className="flex items-center">
+                <Link
+                  href="/contact?type=immersion-brochure"
+                  className="flex items-center"
+                >
                   Request Program Brochure
                   <ArrowRight className="ml-2 h-5 w-5" />
                 </Link>

--- a/src/app/(main)/programs/akomapa-ghip/__tests__/Content.test.tsx
+++ b/src/app/(main)/programs/akomapa-ghip/__tests__/Content.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import Content from "../Content";
+import { immersionProgram } from "@/data/immersion-program";
+
+describe("Global Health Immersion Program page", () => {
+  it("renders one page heading and a logical editorial section hierarchy", () => {
+    render(<Content />);
+
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: immersionProgram.title,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
+
+    [
+      "At a glance",
+      "Global health education grounded in place and partnership.",
+      "What participants experience",
+      "How participants learn",
+      "Who the program is for",
+      "What participants develop",
+      immersionProgram.hostSite.name,
+    ].forEach((heading) => {
+      expect(
+        screen.getByRole("heading", { level: 2, name: heading }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("uses semantic facts and preserves every program concept", () => {
+    const { container } = render(<Content />);
+    const factList = container.querySelector("dl");
+
+    expect(factList).not.toBeNull();
+    const factScope = within(factList as HTMLElement);
+    immersionProgram.facts.forEach((fact) => {
+      expect(factScope.getByText(fact.label)).toBeInTheDocument();
+      expect(factScope.getByText(fact.value)).toBeInTheDocument();
+    });
+
+    [
+      ...immersionProgram.experiences,
+      ...immersionProgram.learningComponents,
+      ...immersionProgram.audiences,
+      ...immersionProgram.outcomes,
+    ].forEach((item) => {
+      expect(
+        screen.getByRole("heading", { level: 3, name: item.title }),
+      ).toBeInTheDocument();
+    });
+
+    expect(container.querySelectorAll("ol")).toHaveLength(2);
+    expect(container.querySelectorAll("ul")).toHaveLength(2);
+  });
+
+  it("provides accurate inquiry actions without stale cohort language", () => {
+    const { container } = render(<Content />);
+
+    screen.getAllByRole("link", { name: "Register Interest" }).forEach((link) => {
+      expect(link).toHaveAttribute("href", "/contact?type=immersion");
+    });
+    screen
+      .getAllByRole("link", { name: "Request Program Brochure" })
+      .forEach((link) => {
+        expect(link).toHaveAttribute(
+          "href",
+          "/contact?type=immersion-brochure",
+        );
+      });
+    expect(
+      screen.getByRole("link", { name: /Partner as a faculty mentor/ }),
+    ).toHaveAttribute("href", "/partnerships");
+
+    expect(container.textContent).not.toMatch(
+      /January 2026|Summer 2026|2026 Pilot Cohort|Program Fees|TBD/,
+    );
+  });
+});

--- a/src/components/contact/ContactForm.tsx
+++ b/src/components/contact/ContactForm.tsx
@@ -14,6 +14,7 @@ import {
   CONTACT_NETWORK_ERROR_MESSAGE,
   getContactErrorMessage,
 } from "@/lib/contact-errors";
+import { getContactIntent } from "@/lib/contact-intents";
 
 function ContactFormContent() {
   const searchParams = useSearchParams();
@@ -30,23 +31,15 @@ function ContactFormContent() {
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [error, setError] = useState("");
 
-  // Handle URL parameters for partnership types
+  // Apply only known inquiry intents. Unknown values leave the form untouched.
   useEffect(() => {
-    const type = searchParams.get('type');
-    if (type) {
-      const partnershipTypes = {
-        'outreach': 'Host Community Engagement Programs',
-        'partnership': 'Strategic Partnerships',
-        'donation': 'Monetary Sponsorship'
-      };
-      
-      setFormData(prev => ({
-        ...prev,
-        subject: `Partnership Inquiry - ${partnershipTypes[type as keyof typeof partnershipTypes] || 'General'}`,
-        partnershipType: partnershipTypes[type as keyof typeof partnershipTypes] || '',
-        message: `I&apos;m interested in learning more about ${partnershipTypes[type as keyof typeof partnershipTypes] || 'partnership opportunities'} with Akomapa Health Foundation.`
-      }));
-    }
+    const intent = getContactIntent(searchParams.get("type"));
+    if (!intent) return;
+
+    setFormData((previous) => ({
+      ...previous,
+      ...intent,
+    }));
   }, [searchParams]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {

--- a/src/components/layout/Breadcrumb.tsx
+++ b/src/components/layout/Breadcrumb.tsx
@@ -43,6 +43,7 @@ function BreadcrumbContent() {
       "ncd-impact": "NCD Impact",
       "community-hubs": "Community Health Hubs",
       "get-involved": "Get Involved",
+      "akomapa-ghip": "Global Health Immersion Program",
       blog: "Thought Leadership",
     };
 

--- a/src/components/layout/Breadcrumb.tsx
+++ b/src/components/layout/Breadcrumb.tsx
@@ -43,7 +43,7 @@ function BreadcrumbContent() {
       "ncd-impact": "NCD Impact",
       "community-hubs": "Community Health Hubs",
       "get-involved": "Get Involved",
-      "akomapa-ghip": "Global Health Immersion Program",
+      "global-health-immersion-program": "Global Health Immersion Program",
       blog: "Thought Leadership",
     };
 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -14,39 +14,13 @@ import {
 import MobileNav from "./MobileNav";
 import { ThemeToggle } from "@/components/theme/ThemeToggle";
 import BrandLogo from "@/components/shared/BrandLogo";
-
-type NavChild = { name: string; href: string };
-type NavItem = { name: string; href: string; children?: NavChild[] };
-
-// Navigation structure
-const navigation: NavItem[] = [
-  { name: "Home", href: "/" },
-  {
-    name: "About",
-    href: "/about",
-    children: [
-      { name: "Our Story", href: "/about" },
-      { name: "Our Team", href: "/about/team" },
-      { name: "Our Philosophy", href: "/philosophy" },
-      { name: "Thought Leadership", href: "/blog" },
-    ],
-  },
-  { name: "Academy", href: "/academy" },
-  {
-    name: "Community Health Hubs",
-    href: "/community-hubs",
-    children: [
-      { name: "All Hubs", href: "/community-hubs" },
-      { name: "Akomapa UCC Hub", href: "/community-hubs/ucc" },
-      { name: "Akomapa UG Hub", href: "/community-hubs/ug" },
-      { name: "Akomapa NHP Yale Hub", href: "/community-hubs/nhp" },
-    ],
-  },
-  { name: "Research & Innovation", href: "/research" },
-  { name: "Impact", href: "/impact" },
-  { name: "Partnerships", href: "/partnerships" },
-  { name: "Get Involved", href: "/get-involved" },
-];
+import {
+  isNavigationItemActive,
+  isNavigationGroup,
+  isNavigationPathActive,
+  mainNavigation,
+  type NavigationGroup,
+} from "@/config/navigation";
 
 const navLinkClass = (isActive: boolean) =>
   `flex items-center gap-1 whitespace-nowrap text-[13px] 2xl:text-sm font-subheading font-medium leading-none transition-colors hover:text-[#eeba2b] dark:hover:text-[#eeba2b] ${
@@ -63,9 +37,14 @@ const dropdownItemClass = (isActive: boolean) =>
       : "text-[#2F3332] dark:text-[#FCFAEF] hover:bg-[#eeba2b]/10 dark:hover:bg-[#eeba2b]/20 hover:text-[#eeba2b]"
   }`;
 
-function NavDropdown({ item, pathname }: { item: NavItem; pathname: string }) {
-  const isActive =
-    pathname === item.href || pathname.startsWith(`${item.href}/`);
+function NavDropdown({
+  item,
+  pathname,
+}: {
+  item: NavigationGroup;
+  pathname: string;
+}) {
+  const isActive = isNavigationItemActive(pathname, item);
 
   return (
     <DropdownMenu>
@@ -82,7 +61,17 @@ function NavDropdown({ item, pathname }: { item: NavItem; pathname: string }) {
       <DropdownMenuContent align="start" className={dropdownPanelClass}>
         {item.children!.map((child) => (
           <DropdownMenuItem key={child.name} asChild>
-            <Link href={child.href} className={dropdownItemClass(pathname === child.href)}>
+            <Link
+              href={child.href}
+              aria-current={
+                isNavigationPathActive(pathname, child.href)
+                  ? "page"
+                  : undefined
+              }
+              className={dropdownItemClass(
+                isNavigationPathActive(pathname, child.href),
+              )}
+            >
               {child.name}
             </Link>
           </DropdownMenuItem>
@@ -124,17 +113,19 @@ function HeaderContent() {
 
           <div className="hidden xl:flex items-center gap-4 ml-auto 2xl:gap-8">
             <nav className="flex items-center gap-x-2.5 2xl:gap-5" aria-label="Main">
-              {navigation.map((item) =>
-                item.children ? (
+              {mainNavigation.map((item) =>
+                isNavigationGroup(item) ? (
                   <NavDropdown key={item.name} item={item} pathname={pathname} />
                 ) : (
                   <Link
                     key={item.name}
                     href={item.href}
-                    className={navLinkClass(
-                      pathname === item.href ||
-                        (item.href !== "/" && pathname.startsWith(`${item.href}/`))
-                    )}
+                    aria-current={
+                      isNavigationPathActive(pathname, item.href)
+                        ? "page"
+                        : undefined
+                    }
+                    className={navLinkClass(isNavigationItemActive(pathname, item))}
                   >
                     {item.name}
                   </Link>
@@ -169,7 +160,7 @@ function HeaderContent() {
       <MobileNav
         isOpen={isMobileMenuOpen}
         onClose={() => setIsMobileMenuOpen(false)}
-        navigation={navigation}
+        navigation={mainNavigation}
       />
     </header>
   );

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -111,7 +111,7 @@ function HeaderContent() {
         <div className="flex items-center gap-4">
           <BrandLogo className="flex-shrink-0" priority />
 
-          <div className="hidden xl:flex items-center gap-4 ml-auto 2xl:gap-8">
+          <div className="ml-auto hidden items-center gap-4 min-[1360px]:flex 2xl:gap-8">
             <nav className="flex items-center gap-x-2.5 2xl:gap-5" aria-label="Main">
               {mainNavigation.map((item) =>
                 isNavigationGroup(item) ? (
@@ -144,7 +144,7 @@ function HeaderContent() {
             </div>
           </div>
 
-          <div className="xl:hidden flex items-center ml-auto space-x-2">
+          <div className="ml-auto flex items-center space-x-2 min-[1360px]:hidden">
             <ThemeToggle />
             <button
               onClick={() => setIsMobileMenuOpen(true)}
@@ -174,7 +174,7 @@ export default function Header() {
           <div className="site-container mx-auto px-4">
             <div className="flex items-center">
               <div className="animate-pulse bg-gray-200 dark:bg-gray-700 h-12 w-48 rounded"></div>
-              <div className="hidden xl:flex items-center ml-auto space-x-4">
+              <div className="ml-auto hidden items-center space-x-4 min-[1360px]:flex">
                 <div className="animate-pulse bg-gray-200 dark:bg-gray-700 h-10 w-32 rounded"></div>
               </div>
             </div>

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -25,7 +25,11 @@ function MobileNavContent({ isOpen, onClose, navigation }: MobileNavProps) {
   
   return (
     <Transition show={isOpen} as={Fragment}>
-      <Dialog as="div" className="relative z-50 xl:hidden" onClose={onClose}>
+      <Dialog
+        as="div"
+        className="relative z-50 min-[1360px]:hidden"
+        onClose={onClose}
+      >
         {/* Backdrop */}
         <TransitionChild 
           as={Fragment}

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -7,17 +7,17 @@ import { Dialog, DialogPanel, Transition, TransitionChild } from "@headlessui/re
 import { X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import BrandLogo from "@/components/shared/BrandLogo";
-
-type NavigationItem = {
-  name: string;
-  href: string;
-  children?: NavigationItem[];
-};
+import {
+  isNavigationItemActive,
+  isNavigationGroup,
+  isNavigationPathActive,
+  type NavigationItem,
+} from "@/config/navigation";
 
 type MobileNavProps = {
   isOpen: boolean;
   onClose: () => void;
-  navigation: NavigationItem[];
+  navigation: readonly NavigationItem[];
 };
 
 function MobileNavContent({ isOpen, onClose, navigation }: MobileNavProps) {
@@ -72,29 +72,51 @@ function MobileNavContent({ isOpen, onClose, navigation }: MobileNavProps) {
               <div className="mt-6 px-4 space-y-2.5">
                 {navigation.map((item) => (
                   <div key={item.name} className="space-y-2">
-                    <Link 
-                      href={item.href}
-                      onClick={onClose}
-                      className={`block rounded-md px-3 py-2.5 font-subheading text-[15px] font-medium leading-none ${
-                        pathname === item.href || pathname.startsWith(`${item.href}/`) 
-                          ? 'bg-[#0097b2]/10 dark:bg-[#0097b2]/20 text-[#0097b2] dark:text-[#FCFAEF]' 
-                          : 'text-[#252828] dark:text-[#FCFAEF] hover:bg-[#eeba2b]/10 dark:hover:bg-[#eeba2b]/20 hover:text-[#eeba2b]'
-                      }`}
-                    >
-                      {item.name}
-                    </Link>
+                    {item.href ? (
+                      <Link
+                        href={item.href}
+                        onClick={onClose}
+                        aria-current={
+                          isNavigationPathActive(pathname, item.href)
+                            ? "page"
+                            : undefined
+                        }
+                        className={`flex min-h-11 items-center rounded-md px-3 py-2.5 font-subheading text-[15px] font-medium leading-none ${
+                          isNavigationItemActive(pathname, item)
+                            ? "bg-[#0097b2]/10 text-[#0097b2] dark:bg-[#0097b2]/20 dark:text-[#FCFAEF]"
+                            : "text-[#252828] hover:bg-[#eeba2b]/10 hover:text-[#eeba2b] dark:text-[#FCFAEF] dark:hover:bg-[#eeba2b]/20"
+                        }`}
+                      >
+                        {item.name}
+                      </Link>
+                    ) : (
+                      <p
+                        className={`flex min-h-11 items-center rounded-md px-3 py-2.5 font-subheading text-[15px] font-medium leading-none ${
+                          isNavigationItemActive(pathname, item)
+                            ? "bg-[#0097b2]/10 text-[#0097b2] dark:bg-[#0097b2]/20 dark:text-[#FCFAEF]"
+                            : "text-[#252828] dark:text-[#FCFAEF]"
+                        }`}
+                      >
+                        {item.name}
+                      </p>
+                    )}
                     
-                    {item.children && (
+                    {isNavigationGroup(item) && (
                       <div className="pl-4 space-y-1 border-l-2 border-[#E6E7E7] dark:border-[#757A79]">
                         {item.children.map((child) => (
                           <Link
                             key={child.name}
                             href={child.href}
                             onClick={onClose}
-                            className={`block rounded-md px-3 py-2 font-body text-sm leading-snug ${
-                              pathname === child.href 
-                                ? 'bg-[#0097b2]/10 dark:bg-[#0097b2]/20 text-[#0097b2] dark:text-[#FCFAEF]' 
-                                : 'text-[#252828] dark:text-[#FCFAEF] hover:bg-[#eeba2b]/10 dark:hover:bg-[#eeba2b]/20 hover:text-[#eeba2b]'
+                            aria-current={
+                              isNavigationPathActive(pathname, child.href)
+                                ? "page"
+                                : undefined
+                            }
+                            className={`flex min-h-11 items-center rounded-md px-3 py-2 font-body text-sm leading-snug ${
+                              isNavigationPathActive(pathname, child.href)
+                                ? "bg-[#0097b2]/10 text-[#0097b2] dark:bg-[#0097b2]/20 dark:text-[#FCFAEF]"
+                                : "text-[#252828] hover:bg-[#eeba2b]/10 hover:text-[#eeba2b] dark:text-[#FCFAEF] dark:hover:bg-[#eeba2b]/20"
                             }`}
                           >
                             {child.name}

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -34,7 +34,7 @@ export const mainNavigation: readonly NavigationItem[] = [
       { name: "Akomapa Academy", href: "/academy" },
       {
         name: "Global Health Immersion Program",
-        href: "/programs/akomapa-ghip",
+        href: "/global-health-immersion-program",
       },
     ],
   },

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -1,0 +1,81 @@
+export type NavigationChild = {
+  name: string;
+  href: string;
+};
+
+export type NavigationLink = {
+  name: string;
+  href: string;
+};
+
+export type NavigationGroup = {
+  name: string;
+  href?: string;
+  children: readonly NavigationChild[];
+};
+
+export type NavigationItem = NavigationLink | NavigationGroup;
+
+export const mainNavigation: readonly NavigationItem[] = [
+  { name: "Home", href: "/" },
+  {
+    name: "About",
+    href: "/about",
+    children: [
+      { name: "Our Story", href: "/about" },
+      { name: "Our Team", href: "/about/team" },
+      { name: "Our Philosophy", href: "/philosophy" },
+      { name: "Thought Leadership", href: "/blog" },
+    ],
+  },
+  {
+    name: "Learning Experiences",
+    children: [
+      { name: "Akomapa Academy", href: "/academy" },
+      {
+        name: "Global Health Immersion Program",
+        href: "/programs/akomapa-ghip",
+      },
+    ],
+  },
+  {
+    name: "Community Health Hubs",
+    href: "/community-hubs",
+    children: [
+      { name: "All Hubs", href: "/community-hubs" },
+      { name: "Akomapa UCC Hub", href: "/community-hubs/ucc" },
+      { name: "Akomapa UG Hub", href: "/community-hubs/ug" },
+      { name: "Akomapa NHP Yale Hub", href: "/community-hubs/nhp" },
+    ],
+  },
+  { name: "Research & Innovation", href: "/research" },
+  { name: "Impact", href: "/impact" },
+  { name: "Partnerships", href: "/partnerships" },
+  { name: "Get Involved", href: "/get-involved" },
+] as const;
+
+export function isNavigationGroup(
+  item: NavigationItem,
+): item is NavigationGroup {
+  return "children" in item;
+}
+
+export function isNavigationPathActive(pathname: string, href: string) {
+  return pathname === href || (href !== "/" && pathname.startsWith(`${href}/`));
+}
+
+export function isNavigationItemActive(
+  pathname: string,
+  item: NavigationItem,
+) {
+  if (item.href && isNavigationPathActive(pathname, item.href)) {
+    return true;
+  }
+
+  return (
+    isNavigationGroup(item) &&
+    item.children.some((child) =>
+      isNavigationPathActive(pathname, child.href),
+    )
+  );
+}

--- a/src/data/__tests__/immersion-program.test.ts
+++ b/src/data/__tests__/immersion-program.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { immersionProgram } from "@/data/immersion-program";
+
+describe("immersion program content", () => {
+  it("preserves the verified program facts and complete learning model", () => {
+    expect(immersionProgram.facts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: "Duration", value: "3 weeks" }),
+        expect.objectContaining({ label: "First host site", value: "Ghana" }),
+        expect.objectContaining({ label: "Credential", value: "Certificate" }),
+      ]),
+    );
+    expect(immersionProgram.hostSite.name).toBe(
+      "University of Cape Coast, Ghana",
+    );
+    expect(immersionProgram.experiences).toHaveLength(7);
+    expect(immersionProgram.learningComponents).toHaveLength(5);
+    expect(immersionProgram.audiences).toHaveLength(3);
+    expect(immersionProgram.outcomes).toHaveLength(4);
+  });
+
+  it("does not publish expired or placeholder cohort details", () => {
+    const serializedContent = JSON.stringify(immersionProgram);
+
+    expect(serializedContent).not.toMatch(
+      /January 2026|Summer 2026|2026 Pilot Cohort|Program Fees|TBD/,
+    );
+    expect(serializedContent).toContain("Next cohort details forthcoming");
+  });
+});

--- a/src/data/immersion-program.ts
+++ b/src/data/immersion-program.ts
@@ -186,7 +186,7 @@ export const immersionProgram: ImmersionProgramContent = {
   images: {
     hero: {
       src: "/highlights/Akomapa-40.jpg",
-      alt: "Akomapa students and health professionals learning together in Ghana",
+      alt: "A community member receiving an eye examination during an Akomapa health program",
       position: "center",
     },
     overview: {

--- a/src/data/immersion-program.ts
+++ b/src/data/immersion-program.ts
@@ -1,0 +1,203 @@
+export type ImmersionProgramFact = {
+  label: string;
+  value: string;
+  description: string;
+};
+
+export type ImmersionProgramItem = {
+  title: string;
+  description: string;
+};
+
+export type ImmersionProgramImage = {
+  src: string;
+  alt: string;
+  position?: string;
+};
+
+export type ImmersionProgramContent = {
+  eyebrow: string;
+  title: string;
+  introduction: string;
+  overview: readonly string[];
+  vision: string;
+  facts: readonly ImmersionProgramFact[];
+  experiences: readonly ImmersionProgramItem[];
+  learningComponents: readonly ImmersionProgramItem[];
+  audiences: readonly ImmersionProgramItem[];
+  outcomes: readonly ImmersionProgramItem[];
+  hostSite: {
+    heading: string;
+    name: string;
+    status: string;
+    description: string;
+  };
+  images: {
+    hero: ImmersionProgramImage;
+    overview: ImmersionProgramImage;
+    hostSite: ImmersionProgramImage;
+  };
+};
+
+export const immersionProgram: ImmersionProgramContent = {
+  eyebrow: "Global Health Immersion Program",
+  title: "Learn through partnership. Lead with understanding.",
+  introduction:
+    "A three-week global health learning experience in Ghana that brings students and emerging health professionals into supervised community health practice, applied research, seminars, and structured reflection.",
+  overview: [
+    "The Akomapa Global Health Immersion Program connects learning with supervised practice. Participants work alongside local student teams, faculty, and community partners to understand how prevention, primary care, research, and health systems meet in everyday settings.",
+    "Ghana is the program's first host country. The experience is designed to help participants examine global health work with cultural humility, ethical discipline, and respect for local knowledge.",
+  ],
+  vision:
+    "Participants leave with a clearer understanding of community-centered health practice and a stronger foundation for ethical collaboration across cultures, disciplines, and health systems.",
+  facts: [
+    {
+      label: "Duration",
+      value: "3 weeks",
+      description: "An intensive, structured learning experience.",
+    },
+    {
+      label: "First host site",
+      value: "Ghana",
+      description: "Beginning at the University of Cape Coast.",
+    },
+    {
+      label: "Credential",
+      value: "Certificate",
+      description:
+        "Akomapa Certificate in Global Health and Community Engagement.",
+    },
+    {
+      label: "Next cohort",
+      value: "Details forthcoming",
+      description: "Dates, fees, and application timing are not yet announced.",
+    },
+  ],
+  experiences: [
+    {
+      title: "Student-Powered Community Health Hubs",
+      description:
+        "Take part in supervised screening, counseling, health education, and follow-up alongside local student teams.",
+    },
+    {
+      title: "Community Partnership Projects",
+      description:
+        "Develop engagement activities with local partners around priorities they identify.",
+    },
+    {
+      title: "Applied Research",
+      description:
+        "Investigate public health questions through field-based qualitative and quantitative work.",
+    },
+    {
+      title: "Mentored Seminars",
+      description:
+        "Work through cases with Akomapa mentors, university faculty, and global health practitioners.",
+    },
+    {
+      title: "Health Systems Learning",
+      description:
+        "Study how national, regional, and community health services connect from policy to primary care.",
+    },
+    {
+      title: "Leadership Circles",
+      description:
+        "Use facilitated reflection to examine ethics, power, responsibility, and cultural humility.",
+    },
+    {
+      title: "Cultural Learning",
+      description:
+        "Engage Ghana's history and culture as essential context for responsible partnership.",
+    },
+  ],
+  learningComponents: [
+    {
+      title: "Community-Based Practice",
+      description:
+        "Supervised participation in Akomapa's community health and education activities.",
+    },
+    {
+      title: "Community-Based Research",
+      description:
+        "Small-group inquiry into real public health questions using qualitative and quantitative methods.",
+    },
+    {
+      title: "Ethical Leadership",
+      description:
+        "Peer discussion that connects field experience with cultural humility, ethics, and systems thinking.",
+    },
+    {
+      title: "Expert Seminars",
+      description:
+        "Faculty-led sessions on NCD prevention, health systems, research, and responsible practice.",
+    },
+    {
+      title: "Capstone Reflection",
+      description:
+        "A final presentation of project findings and personal learning to peers, mentors, and community partners.",
+    },
+  ],
+  audiences: [
+    {
+      title: "Undergraduate and Pre-Medical Students",
+      description:
+        "Students exploring medicine, global health, public health, or public service through community-centered learning.",
+    },
+    {
+      title: "Health Professional Students",
+      description:
+        "Medical, nursing, pharmacy, public health, and allied health students seeking interprofessional experience.",
+    },
+    {
+      title: "Graduate Students and Early-Career Professionals",
+      description:
+        "Emerging professionals committed to ethical global engagement and stronger health systems.",
+    },
+  ],
+  outcomes: [
+    {
+      title: "Cross-Cultural Collaboration",
+      description:
+        "Practice listening, communicating, and working responsibly across cultures and disciplines.",
+    },
+    {
+      title: "Community-Defined Problem Solving",
+      description:
+        "Learn to begin with local priorities and build responses with community partners.",
+    },
+    {
+      title: "Supervised, Student-Powered Care",
+      description:
+        "Understand how students contribute meaningfully while licensed professionals retain clinical oversight.",
+    },
+    {
+      title: "Reflective Leadership",
+      description:
+        "Connect practical experience with ethical reasoning, humility, and professional responsibility.",
+    },
+  ],
+  hostSite: {
+    heading: "First host site",
+    name: "University of Cape Coast, Ghana",
+    status: "Next cohort details forthcoming",
+    description:
+      "Dates, fees, and application timing will be published after they are confirmed. Prospective participants can register interest now to request an update.",
+  },
+  images: {
+    hero: {
+      src: "/highlights/Akomapa-40.jpg",
+      alt: "Akomapa students and health professionals learning together in Ghana",
+      position: "center",
+    },
+    overview: {
+      src: "/highlights/Akomapa-66.jpg",
+      alt: "Students taking part in a supervised community health learning experience",
+      position: "center",
+    },
+    hostSite: {
+      src: "/highlights/Akomapa-12.jpg",
+      alt: "Akomapa participants gathered at the University of Cape Coast in Ghana",
+      position: "center",
+    },
+  },
+};

--- a/src/lib/__tests__/contact-intents.test.ts
+++ b/src/lib/__tests__/contact-intents.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { getContactIntent } from "@/lib/contact-intents";
+
+describe("contact intents", () => {
+  it("returns allow-listed Immersion inquiry details", () => {
+    expect(getContactIntent("immersion")).toEqual({
+      subject: "Global Health Immersion Program Interest",
+      partnershipType: "General Inquiry",
+      message:
+        "I'm interested in the Akomapa Global Health Immersion Program. Please notify me when the next cohort details are available.",
+    });
+    expect(getContactIntent("immersion-brochure")).toEqual(
+      expect.objectContaining({
+        subject: "Global Health Immersion Program Brochure Request",
+        partnershipType: "General Inquiry",
+      }),
+    );
+  });
+
+  it("rejects unknown and missing intent values", () => {
+    expect(getContactIntent(null)).toBeNull();
+    expect(getContactIntent("not-allowed")).toBeNull();
+    expect(getContactIntent("__proto__")).toBeNull();
+  });
+});

--- a/src/lib/__tests__/seo.test.ts
+++ b/src/lib/__tests__/seo.test.ts
@@ -54,7 +54,8 @@ describe("SEO metadata contract", () => {
 
   it("describes the Immersion program without implying open enrollment", () => {
     const route = canonicalSeoRoutes.find(
-      (candidate) => candidate.path === "/programs/akomapa-ghip",
+      (candidate) =>
+        candidate.path === "/global-health-immersion-program",
     );
 
     expect(route).toBeDefined();

--- a/src/lib/__tests__/seo.test.ts
+++ b/src/lib/__tests__/seo.test.ts
@@ -52,6 +52,19 @@ describe("SEO metadata contract", () => {
     }
   });
 
+  it("describes the Immersion program without implying open enrollment", () => {
+    const route = canonicalSeoRoutes.find(
+      (candidate) => candidate.path === "/programs/akomapa-ghip",
+    );
+
+    expect(route).toBeDefined();
+    expect(route?.title).toBe("Global Health Immersion Program");
+    expect(route?.description).toContain("three-week learning experience");
+    expect(route?.description).not.toMatch(
+      /apply now|applications open|enroll now|join the next cohort/i,
+    );
+  });
+
   it("keeps sitemap canonical and excludes redirected routes", async () => {
     const urls = sitemap().map((entry) => entry.url);
     const nextConfig = await createNextConfig();

--- a/src/lib/contact-intents.ts
+++ b/src/lib/contact-intents.ts
@@ -1,0 +1,48 @@
+export type ContactIntent = {
+  subject: string;
+  partnershipType: string;
+  message: string;
+};
+
+const contactIntents = {
+  outreach: {
+    subject: "Partnership Inquiry - Host Community Engagement Programs",
+    partnershipType: "Host Community Engagement Programs",
+    message:
+      "I'm interested in learning more about hosting community engagement programs with Akomapa Health Foundation.",
+  },
+  partnership: {
+    subject: "Partnership Inquiry - Strategic Partnerships",
+    partnershipType: "Strategic Partnerships",
+    message:
+      "I'm interested in learning more about strategic partnership opportunities with Akomapa Health Foundation.",
+  },
+  donation: {
+    subject: "Partnership Inquiry - Monetary Sponsorship",
+    partnershipType: "Monetary Sponsorship",
+    message:
+      "I'm interested in learning more about monetary sponsorship opportunities with Akomapa Health Foundation.",
+  },
+  immersion: {
+    subject: "Global Health Immersion Program Interest",
+    partnershipType: "General Inquiry",
+    message:
+      "I'm interested in the Akomapa Global Health Immersion Program. Please notify me when the next cohort details are available.",
+  },
+  "immersion-brochure": {
+    subject: "Global Health Immersion Program Brochure Request",
+    partnershipType: "General Inquiry",
+    message:
+      "Please send me the latest available information about the Akomapa Global Health Immersion Program.",
+  },
+} as const satisfies Record<string, ContactIntent>;
+
+export type ContactIntentKey = keyof typeof contactIntents;
+
+export function getContactIntent(value: string | null): ContactIntent | null {
+  if (!value || !Object.prototype.hasOwnProperty.call(contactIntents, value)) {
+    return null;
+  }
+
+  return contactIntents[value as ContactIntentKey];
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -186,7 +186,7 @@ export const canonicalSeoRoutes = [
     priority: 0.7,
   },
   {
-    path: "/programs/akomapa-ghip",
+    path: "/global-health-immersion-program",
     title: "Global Health Immersion Program",
     description:
       "Explore Akomapa's three-week learning experience in Ghana centered on supervised community health practice, research, ethical leadership, and cultural learning.",

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -189,7 +189,7 @@ export const canonicalSeoRoutes = [
     path: "/programs/akomapa-ghip",
     title: "Global Health Immersion Program",
     description:
-      "Join Akomapa's immersion experience in Ghana for hands-on community health service, research, leadership, and cultural learning.",
+      "Explore Akomapa's three-week learning experience in Ghana centered on supervised community health practice, research, ethical leadership, and cultural learning.",
     changeFrequency: "monthly",
     priority: 0.7,
   },


### PR DESCRIPTION
# Restore and redesign the Global Health Immersion Program

Relates to #182

## Summary

Restores the Global Health Immersion Program to the global navigation and redesigns `/programs/akomapa-ghip` using Akomapa’s current editorial visual language.

The implementation preserves verified program information while removing expired 2026 recruitment details, introduces safe interest and brochure inquiry flows, and expands responsive and accessibility regression coverage.

## What changed

### Navigation

- Replaced the standalone Academy navigation item with a non-destination “Learning Experiences” group.
- Added links to Akomapa Academy and the Global Health Immersion Program.
- Preserved desktop keyboard navigation, Escape handling, focus restoration, and active-child styling.
- Added a clearly labeled mobile navigation group with 44px minimum child targets.
- Updated the breadcrumb to use the full program name.
- Adjusted the desktop navigation transition to 1360px to prevent crowding at narrower laptop widths.

### Program content and inquiries

- Moved verified program information into a dedicated typed data module.
- Preserved the three-week duration, Ghana first host site, certificate, audiences, learning components, activities, photography, and faculty partnership path.
- Removed expired 2026 recruitment language and unannounced fee/date placeholders.
- Added a clear “Next cohort details forthcoming” status.
- Replaced application language with “Register Interest.”
- Added allow-listed contact intent mappings for:
  - `/contact?type=immersion`
  - `/contact?type=immersion-brochure`
- Preserved existing contact validation, API payloads, logging, and submission behavior.
- Updated metadata so it does not imply that enrollment is currently open.

### Editorial redesign

- Rebuilt the route as a server-rendered editorial page with small existing motion islands.
- Added a split hero, semantic fact ledger, purpose and vision section, seven participant-experience rows, five learning components, eligibility and development outcomes, and Ghana host-site context.
- Replaced decorative gradients, glow effects, floating cards, and icon-led facts with flat color bands, rules, numbering, structured lists, and restrained borders.
- Added responsive image and text arrangements without fixed content heights.
- Preserved semantic headings, meaningful alternative text, visible focus, dark-mode hierarchy, reduced-motion behavior, and content comprehension without animation or color alone.

### Tests and quality

- Added unit coverage for verified program facts, stale-language removal, semantic structures, inquiry mappings, CTA destinations, and metadata.
- Added desktop and mobile navigation accessibility coverage.
- Added focused GHIP coverage for themes, reduced motion, keyboard focus, inquiry prefills, CTA target sizes, heading structure, overflow, and 200%-zoom-equivalent reflow.
- Added GHIP to responsive, typography, and Lighthouse matrices.
- Corrected CTA contrast identified during Lighthouse validation.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` — 139 tests passed
- [x] `npm run build`
- [x] Focused Immersion, navigation, CTA, responsive, and typography Playwright specs
- [x] `npm run test:e2e` — 562 tests passed
- [x] `npm run security:verify-rsc-patch`
- [x] Full pre-push hook
- [x] Light and dark responsive inspection
- [x] Reduced-motion inspection
- [x] 200%-zoom-equivalent reflow inspection
- [x] Mobile Lighthouse audit
- [x] Dependency audit

## Known limitations

- Lighthouse continues to report site-wide announcement-modal contrast/link-text findings and layout shift associated with the theme-swapped header logo and announcement trigger.
- `npm audit` reports transitive PostCSS and Sharp advisories with no currently available fix, plus an ESLint-chain advisory whose automated fix requires a breaking major upgrade.
- The existing `next lint` deprecation warning remains and should be handled in a separate tooling migration.