### PR TITLE
Restore the Global Health Immersion Program and refine global navigation

### DIFF
--- a/e2e/header-nav-a11y.spec.ts
+++ b/e2e/header-nav-a11y.spec.ts
@@ -86,20 +86,27 @@ test.describe("desktop header dropdown keyboard accessibility", () => {
     await expect(aboutTrigger).toBeFocused();
   });
 
-  test("Community Health Hubs dropdown opens with keyboard and reaches hub link", async ({
+  test("Our Work dropdown opens with keyboard and reaches Research", async ({
     page,
   }) => {
-    const hubsTrigger = page.getByRole("button", {
-      name: "Community Health Hubs",
+    const workTrigger = page.getByRole("button", {
+      name: "Our Work",
     });
-    await hubsTrigger.focus();
+    await workTrigger.focus();
     await page.keyboard.press("Enter");
 
-    const uccLink = page.getByRole("menuitem", { name: "Akomapa UCC Hub" });
-    await expect(uccLink).toBeVisible();
+    const hubsLink = page.getByRole("menuitem", {
+      name: "Community Health Hubs",
+    });
+    const researchLink = page.getByRole("menuitem", {
+      name: "Research & Innovation",
+    });
+    await expect(hubsLink).toBeFocused();
+    await page.keyboard.press("ArrowDown");
+    await expect(researchLink).toBeFocused();
 
-    await uccLink.click();
-    await expect(page).toHaveURL(/\/community-hubs\/ucc$/);
+    await page.keyboard.press("Enter");
+    await expect(page).toHaveURL(/\/research$/);
   });
 
   test("Learning Experiences reaches the Immersion program by keyboard", async ({
@@ -128,10 +135,69 @@ test.describe("desktop header dropdown keyboard accessibility", () => {
     await expect(immersionLink).toBeVisible();
     await expect(immersionLink).toHaveAttribute("aria-current", "page");
   });
+
+  test("Join Us reaches Partnerships and exposes its active child", async ({
+    page,
+  }) => {
+    const joinTrigger = page.getByRole("button", { name: "Join Us" });
+    await joinTrigger.focus();
+    await page.keyboard.press("Enter");
+
+    const involvementLink = page.getByRole("menuitem", {
+      name: "Get Involved",
+    });
+    const partnershipsLink = page.getByRole("menuitem", {
+      name: "Partnerships",
+    });
+
+    await expect(involvementLink).toBeFocused();
+    await page.keyboard.press("ArrowDown");
+    await expect(partnershipsLink).toBeFocused();
+    await page.keyboard.press("Enter");
+
+    await expect(page).toHaveURL(/\/partnerships$/);
+    await joinTrigger.click();
+    await expect(partnershipsLink).toHaveAttribute("aria-current", "page");
+  });
+
+  test("desktop navigation is spacious and overflow-free at its breakpoint", async ({
+    page,
+  }) => {
+    for (const width of [1280, 1440, 1536]) {
+      await page.setViewportSize({ width, height: 900 });
+      await page.reload();
+
+      const header = page.locator("header").first();
+      const logo = header.locator("a").first();
+      const nav = header.getByRole("navigation", { name: "Main" });
+      const menuButton = header.getByRole("button", {
+        name: "Open main menu",
+      });
+
+      await expect(nav).toBeVisible();
+      await expect(menuButton).toBeHidden();
+
+      const logoBox = await logo.boundingBox();
+      const navBox = await nav.boundingBox();
+      expect(logoBox).not.toBeNull();
+      expect(navBox).not.toBeNull();
+      expect(navBox!.x - (logoBox!.x + logoBox!.width)).toBeGreaterThanOrEqual(
+        24,
+      );
+
+      const dimensions = await page.evaluate(() => ({
+        documentWidth: document.documentElement.scrollWidth,
+        viewportWidth: window.innerWidth,
+      }));
+      expect(dimensions.documentWidth).toBeLessThanOrEqual(
+        dimensions.viewportWidth + 1,
+      );
+    }
+  });
 });
 
-test.describe("mobile learning experiences navigation", () => {
-  test("shows both destinations and closes after navigation", async ({ page }) => {
+test.describe("mobile grouped navigation", () => {
+  test("shows every group and closes after child navigation", async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await dismissAnnouncementIfPresent(page);
     await page.goto("/");
@@ -140,7 +206,28 @@ test.describe("mobile learning experiences navigation", () => {
     const drawer = page.getByRole("dialog");
 
     await expect(
+      drawer.getByText("Our Work", { exact: true }),
+    ).toBeVisible();
+    await expect(
       drawer.getByText("Learning Experiences", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      drawer.getByText("Join Us", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      drawer.getByRole("link", { name: "Community Health Hubs" }),
+    ).toBeVisible();
+    await expect(
+      drawer.getByRole("link", { name: "Research & Innovation" }),
+    ).toBeVisible();
+    await expect(
+      drawer.getByRole("link", { name: "Impact", exact: true }),
+    ).toBeVisible();
+    await expect(
+      drawer.getByRole("link", { name: "Get Involved" }),
+    ).toBeVisible();
+    await expect(
+      drawer.getByRole("link", { name: "Partnerships" }),
     ).toBeVisible();
     await expect(
       drawer.getByRole("link", { name: "Akomapa Academy" }),
@@ -150,6 +237,9 @@ test.describe("mobile learning experiences navigation", () => {
       name: "Global Health Immersion Program",
     });
     await expect(immersionLink).toBeVisible();
+    expect((await immersionLink.boundingBox())?.height).toBeGreaterThanOrEqual(
+      44,
+    );
     await immersionLink.click();
 
     await expect(page).toHaveURL(/\/global-health-immersion-program$/);

--- a/e2e/header-nav-a11y.spec.ts
+++ b/e2e/header-nav-a11y.spec.ts
@@ -109,6 +109,35 @@ test.describe("desktop header dropdown keyboard accessibility", () => {
     await expect(page).toHaveURL(/\/research$/);
   });
 
+  test("Community Health Hubs retains keyboard access to individual hubs", async ({
+    page,
+  }) => {
+    const workTrigger = page.getByRole("button", { name: "Our Work" });
+    await workTrigger.focus();
+    await page.keyboard.press("Enter");
+
+    const hubsSubmenu = page.getByRole("menuitem", {
+      name: "Community Health Hubs",
+      exact: true,
+    });
+    await expect(hubsSubmenu).toBeFocused();
+    await page.keyboard.press("ArrowRight");
+
+    const allHubsLink = page.getByRole("menuitem", {
+      name: "All Community Health Hubs",
+    });
+    const uccLink = page.getByRole("menuitem", { name: "Akomapa UCC Hub" });
+    await expect(allHubsLink).toBeFocused();
+    await page.keyboard.press("ArrowDown");
+    await expect(uccLink).toBeFocused();
+    await page.keyboard.press("Enter");
+
+    await expect(page).toHaveURL(/\/community-hubs\/ucc$/);
+    await workTrigger.click();
+    await hubsSubmenu.hover();
+    await expect(uccLink).toHaveAttribute("aria-current", "page");
+  });
+
   test("Learning Experiences reaches the Immersion program by keyboard", async ({
     page,
   }) => {
@@ -170,6 +199,7 @@ test.describe("desktop header dropdown keyboard accessibility", () => {
       const header = page.locator("header").first();
       const logo = header.locator("a").first();
       const nav = header.getByRole("navigation", { name: "Main" });
+      const donate = header.getByRole("link", { name: "Donate" });
       const menuButton = header.getByRole("button", {
         name: "Open main menu",
       });
@@ -179,10 +209,18 @@ test.describe("desktop header dropdown keyboard accessibility", () => {
 
       const logoBox = await logo.boundingBox();
       const navBox = await nav.boundingBox();
+      const donateBox = await donate.boundingBox();
       expect(logoBox).not.toBeNull();
       expect(navBox).not.toBeNull();
+      expect(donateBox).not.toBeNull();
       expect(navBox!.x - (logoBox!.x + logoBox!.width)).toBeGreaterThanOrEqual(
         24,
+      );
+      const availableCenter =
+        (logoBox!.x + logoBox!.width + donateBox!.x) / 2;
+      const navigationCenter = navBox!.x + navBox!.width / 2;
+      expect(Math.abs(navigationCenter - availableCenter)).toBeLessThanOrEqual(
+        4,
       );
 
       const dimensions = await page.evaluate(() => ({
@@ -215,7 +253,16 @@ test.describe("mobile grouped navigation", () => {
       drawer.getByText("Join Us", { exact: true }),
     ).toBeVisible();
     await expect(
-      drawer.getByRole("link", { name: "Community Health Hubs" }),
+      drawer.getByRole("link", { name: "All Community Health Hubs" }),
+    ).toBeVisible();
+    await expect(
+      drawer.getByRole("link", { name: "Akomapa UCC Hub" }),
+    ).toBeVisible();
+    await expect(
+      drawer.getByRole("link", { name: "Akomapa UG Hub" }),
+    ).toBeVisible();
+    await expect(
+      drawer.getByRole("link", { name: "Akomapa NHP Yale Hub" }),
     ).toBeVisible();
     await expect(
       drawer.getByRole("link", { name: "Research & Innovation" }),
@@ -243,6 +290,25 @@ test.describe("mobile grouped navigation", () => {
     await immersionLink.click();
 
     await expect(page).toHaveURL(/\/global-health-immersion-program$/);
+    await expect(drawer).toBeHidden();
+  });
+
+  test("individual hub links remain touch-friendly and close the drawer", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await dismissAnnouncementIfPresent(page);
+    await page.goto("/");
+
+    await page.getByRole("button", { name: "Open main menu" }).click();
+    const drawer = page.getByRole("dialog");
+    const uccLink = drawer.getByRole("link", { name: "Akomapa UCC Hub" });
+
+    await expect(uccLink).toBeVisible();
+    expect((await uccLink.boundingBox())?.height).toBeGreaterThanOrEqual(44);
+    await uccLink.click();
+
+    await expect(page).toHaveURL(/\/community-hubs\/ucc$/);
     await expect(drawer).toBeHidden();
   });
 });

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -9,6 +9,9 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import MobileNav from "./MobileNav";
@@ -20,22 +23,71 @@ import {
   isNavigationPathActive,
   mainNavigation,
   type NavigationGroup,
+  type NavigationNode,
 } from "@/config/navigation";
 
 const navLinkClass = (isActive: boolean) =>
-  `flex min-h-11 items-center gap-1.5 whitespace-nowrap text-sm font-subheading font-medium leading-none transition-colors hover:text-[#eeba2b] dark:hover:text-[#eeba2b] ${
-    isActive ? "text-[#0097b2]" : "text-[#2F3332] dark:text-[#FCFAEF]"
+  `relative flex min-h-11 items-center gap-1.5 whitespace-nowrap rounded-md px-2 font-subheading text-sm font-medium leading-none transition-colors after:absolute after:inset-x-2 after:bottom-0 after:h-0.5 after:origin-center after:scale-x-0 after:bg-[#0097b2] after:transition-transform hover:bg-[#eeba2b]/8 hover:text-[#9A6A00] dark:hover:bg-[#eeba2b]/10 dark:hover:text-[#F5C94D] ${
+    isActive
+      ? "bg-[#0097b2]/8 text-[#007F96] after:scale-x-100 dark:bg-[#66C4DC]/10 dark:text-[#66C4DC]"
+      : "text-[#2F3332] dark:text-[#FCFAEF]"
   }`;
 
 const dropdownPanelClass =
-  "min-w-60 rounded-md bg-[#FCFAEF] p-1.5 shadow-lg ring-1 ring-[#C1C3C3] ring-opacity-5 dark:bg-[#2F3332] dark:ring-[#FCFAEF] dark:ring-opacity-10";
+  "min-w-64 rounded-lg border border-[#0F4C5C]/12 bg-[#FCFAEF] p-1.5 shadow-[0_18px_45px_rgba(15,76,92,0.16)] dark:border-[#FCFAEF]/10 dark:bg-[#202423]";
 
 const dropdownItemClass = (isActive: boolean) =>
-  `flex min-h-11 items-center rounded-sm px-3.5 py-2.5 text-sm font-body cursor-pointer ${
+  `flex min-h-11 items-center rounded-md px-3.5 py-2.5 text-sm font-body cursor-pointer outline-none transition-colors ${
     isActive
-      ? "bg-[#0097b2]/10 dark:bg-[#0097b2]/20 text-[#0097b2] dark:text-[#FCFAEF]"
-      : "text-[#2F3332] dark:text-[#FCFAEF] hover:bg-[#eeba2b]/10 dark:hover:bg-[#eeba2b]/20 hover:text-[#eeba2b]"
+      ? "bg-[#0097b2]/10 text-[#007F96] dark:bg-[#66C4DC]/12 dark:text-[#66C4DC]"
+      : "text-[#2F3332] hover:bg-[#eeba2b]/10 hover:text-[#8A6100] dark:text-[#FCFAEF] dark:hover:bg-[#eeba2b]/12 dark:hover:text-[#F5C94D]"
   }`;
+
+function NavDropdownNode({
+  item,
+  pathname,
+}: {
+  item: NavigationNode;
+  pathname: string;
+}) {
+  const isActive = isNavigationItemActive(pathname, item);
+
+  if (isNavigationGroup(item)) {
+    return (
+      <DropdownMenuSub>
+        <DropdownMenuSubTrigger className={dropdownItemClass(isActive)}>
+          {item.name}
+        </DropdownMenuSubTrigger>
+        <DropdownMenuSubContent
+          sideOffset={6}
+          className={dropdownPanelClass}
+        >
+          {item.children.map((child) => (
+            <NavDropdownNode
+              key={child.name}
+              item={child}
+              pathname={pathname}
+            />
+          ))}
+        </DropdownMenuSubContent>
+      </DropdownMenuSub>
+    );
+  }
+
+  return (
+    <DropdownMenuItem asChild>
+      <Link
+        href={item.href}
+        aria-current={
+          isNavigationPathActive(pathname, item.href) ? "page" : undefined
+        }
+        className={dropdownItemClass(isActive)}
+      >
+        {item.name}
+      </Link>
+    </DropdownMenuItem>
+  );
+}
 
 function NavDropdown({
   item,
@@ -59,22 +111,12 @@ function NavDropdown({
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className={dropdownPanelClass}>
-        {item.children!.map((child) => (
-          <DropdownMenuItem key={child.name} asChild>
-            <Link
-              href={child.href}
-              aria-current={
-                isNavigationPathActive(pathname, child.href)
-                  ? "page"
-                  : undefined
-              }
-              className={dropdownItemClass(
-                isNavigationPathActive(pathname, child.href),
-              )}
-            >
-              {child.name}
-            </Link>
-          </DropdownMenuItem>
+        {item.children.map((child) => (
+          <NavDropdownNode
+            key={child.name}
+            item={child}
+            pathname={pathname}
+          />
         ))}
       </DropdownMenuContent>
     </DropdownMenu>
@@ -101,50 +143,51 @@ function HeaderContent() {
 
   return (
     <header
-      className={`sticky top-0 z-50 w-full transition-all duration-300 ${
+      className={`sticky top-0 z-50 w-full border-b border-[#0F4C5C]/10 backdrop-blur-xl transition-all duration-300 dark:border-[#FCFAEF]/10 ${
         isScrolled
-          ? "bg-[#FCFAEF] shadow-md py-2 dark:bg-[#121514]"
-          : "bg-[#FCFAEF]/80 backdrop-blur-md py-4 dark:bg-[#121514]/90"
+          ? "bg-[#FCFAEF]/98 py-2 shadow-[0_8px_24px_rgba(15,76,92,0.08)] dark:bg-[#121514]/98"
+          : "bg-[#FCFAEF]/94 py-3 dark:bg-[#121514]/94"
       }`}
     >
       <div className="site-container mx-auto px-4">
-        <div className="flex items-center gap-6 2xl:gap-10">
+        <div className="grid grid-cols-[auto_1fr_auto] items-center gap-6 2xl:gap-10">
           <BrandLogo className="flex-shrink-0" priority />
 
-          <div className="ml-auto hidden items-center gap-5 xl:flex 2xl:gap-8">
-            <nav className="flex items-center gap-x-4 2xl:gap-7" aria-label="Main">
-              {mainNavigation.map((item) =>
-                isNavigationGroup(item) ? (
-                  <NavDropdown key={item.name} item={item} pathname={pathname} />
-                ) : (
-                  <Link
-                    key={item.name}
-                    href={item.href}
-                    aria-current={
-                      isNavigationPathActive(pathname, item.href)
-                        ? "page"
-                        : undefined
-                    }
-                    className={navLinkClass(isNavigationItemActive(pathname, item))}
-                  >
-                    {item.name}
-                  </Link>
-                )
-              )}
-            </nav>
+          <nav
+            className="hidden items-center justify-self-center gap-x-3 xl:flex 2xl:gap-x-5"
+            aria-label="Main"
+          >
+            {mainNavigation.map((item) =>
+              isNavigationGroup(item) ? (
+                <NavDropdown key={item.name} item={item} pathname={pathname} />
+              ) : (
+                <Link
+                  key={item.name}
+                  href={item.href}
+                  aria-current={
+                    isNavigationPathActive(pathname, item.href)
+                      ? "page"
+                      : undefined
+                  }
+                  className={navLinkClass(isNavigationItemActive(pathname, item))}
+                >
+                  {item.name}
+                </Link>
+              )
+            )}
+          </nav>
 
-            <div className="flex items-center gap-2.5">
-              <Button
-                asChild
-                className="bg-[#0097b2] px-4 text-[#FCFAEF] hover:bg-[#0097b2]/80 hover:text-[#FCFAEF] font-subheading font-medium"
-              >
-                <Link href="/donate">Donate</Link>
-              </Button>
-              <ThemeToggle />
-            </div>
+          <div className="col-start-3 hidden items-center gap-2.5 xl:flex">
+            <Button
+              asChild
+              className="min-h-11 rounded-md bg-[#0097b2] px-5 font-subheading font-semibold text-[#FCFAEF] shadow-sm hover:bg-[#007F96] hover:text-[#FCFAEF]"
+            >
+              <Link href="/donate">Donate</Link>
+            </Button>
+            <ThemeToggle />
           </div>
 
-          <div className="ml-auto flex items-center space-x-2 xl:hidden">
+          <div className="col-start-3 flex items-center space-x-2 xl:hidden">
             <ThemeToggle />
             <button
               onClick={() => setIsMobileMenuOpen(true)}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -23,15 +23,15 @@ import {
 } from "@/config/navigation";
 
 const navLinkClass = (isActive: boolean) =>
-  `flex items-center gap-1 whitespace-nowrap text-[13px] 2xl:text-sm font-subheading font-medium leading-none transition-colors hover:text-[#eeba2b] dark:hover:text-[#eeba2b] ${
+  `flex min-h-11 items-center gap-1.5 whitespace-nowrap text-sm font-subheading font-medium leading-none transition-colors hover:text-[#eeba2b] dark:hover:text-[#eeba2b] ${
     isActive ? "text-[#0097b2]" : "text-[#2F3332] dark:text-[#FCFAEF]"
   }`;
 
 const dropdownPanelClass =
-  "w-56 rounded-md shadow-lg bg-[#FCFAEF] dark:bg-[#2F3332] ring-1 ring-[#C1C3C3] ring-opacity-5 dark:ring-[#FCFAEF] dark:ring-opacity-10";
+  "min-w-60 rounded-md bg-[#FCFAEF] p-1.5 shadow-lg ring-1 ring-[#C1C3C3] ring-opacity-5 dark:bg-[#2F3332] dark:ring-[#FCFAEF] dark:ring-opacity-10";
 
 const dropdownItemClass = (isActive: boolean) =>
-  `block px-4 py-2 text-sm font-body cursor-pointer ${
+  `flex min-h-11 items-center rounded-sm px-3.5 py-2.5 text-sm font-body cursor-pointer ${
     isActive
       ? "bg-[#0097b2]/10 dark:bg-[#0097b2]/20 text-[#0097b2] dark:text-[#FCFAEF]"
       : "text-[#2F3332] dark:text-[#FCFAEF] hover:bg-[#eeba2b]/10 dark:hover:bg-[#eeba2b]/20 hover:text-[#eeba2b]"
@@ -108,11 +108,11 @@ function HeaderContent() {
       }`}
     >
       <div className="site-container mx-auto px-4">
-        <div className="flex items-center gap-4">
+        <div className="flex items-center gap-6 2xl:gap-10">
           <BrandLogo className="flex-shrink-0" priority />
 
-          <div className="ml-auto hidden items-center gap-4 min-[1360px]:flex 2xl:gap-8">
-            <nav className="flex items-center gap-x-2.5 2xl:gap-5" aria-label="Main">
+          <div className="ml-auto hidden items-center gap-5 xl:flex 2xl:gap-8">
+            <nav className="flex items-center gap-x-4 2xl:gap-7" aria-label="Main">
               {mainNavigation.map((item) =>
                 isNavigationGroup(item) ? (
                   <NavDropdown key={item.name} item={item} pathname={pathname} />
@@ -144,7 +144,7 @@ function HeaderContent() {
             </div>
           </div>
 
-          <div className="ml-auto flex items-center space-x-2 min-[1360px]:hidden">
+          <div className="ml-auto flex items-center space-x-2 xl:hidden">
             <ThemeToggle />
             <button
               onClick={() => setIsMobileMenuOpen(true)}
@@ -174,7 +174,7 @@ export default function Header() {
           <div className="site-container mx-auto px-4">
             <div className="flex items-center">
               <div className="animate-pulse bg-gray-200 dark:bg-gray-700 h-12 w-48 rounded"></div>
-              <div className="ml-auto hidden items-center space-x-4 min-[1360px]:flex">
+              <div className="ml-auto hidden items-center space-x-4 xl:flex">
                 <div className="animate-pulse bg-gray-200 dark:bg-gray-700 h-10 w-32 rounded"></div>
               </div>
             </div>

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -27,7 +27,7 @@ function MobileNavContent({ isOpen, onClose, navigation }: MobileNavProps) {
     <Transition show={isOpen} as={Fragment}>
       <Dialog
         as="div"
-        className="relative z-50 min-[1360px]:hidden"
+        className="relative z-50 xl:hidden"
         onClose={onClose}
       >
         {/* Backdrop */}
@@ -73,7 +73,7 @@ function MobileNavContent({ isOpen, onClose, navigation }: MobileNavProps) {
                 </button>
               </div>
 
-              <div className="mt-6 px-4 space-y-2.5">
+              <div className="mt-6 space-y-5 px-4">
                 {navigation.map((item) => (
                   <div key={item.name} className="space-y-2">
                     {item.href ? (
@@ -95,10 +95,10 @@ function MobileNavContent({ isOpen, onClose, navigation }: MobileNavProps) {
                       </Link>
                     ) : (
                       <p
-                        className={`flex min-h-11 items-center rounded-md px-3 py-2.5 font-subheading text-[15px] font-medium leading-none ${
+                        className={`px-3 font-subheading text-xs font-bold uppercase leading-5 tracking-[0.14em] ${
                           isNavigationItemActive(pathname, item)
-                            ? "bg-[#0097b2]/10 text-[#0097b2] dark:bg-[#0097b2]/20 dark:text-[#FCFAEF]"
-                            : "text-[#252828] dark:text-[#FCFAEF]"
+                            ? "text-[#0097b2] dark:text-[#66C4DC]"
+                            : "text-[#5F6463] dark:text-[#FCFAEF]/70"
                         }`}
                       >
                         {item.name}
@@ -106,7 +106,7 @@ function MobileNavContent({ isOpen, onClose, navigation }: MobileNavProps) {
                     )}
                     
                     {isNavigationGroup(item) && (
-                      <div className="pl-4 space-y-1 border-l-2 border-[#E6E7E7] dark:border-[#757A79]">
+                      <div className="space-y-1 border-l-2 border-[#0097b2]/20 pl-3 dark:border-[#66C4DC]/25">
                         {item.children.map((child) => (
                           <Link
                             key={child.name}

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -12,6 +12,7 @@ import {
   isNavigationGroup,
   isNavigationPathActive,
   type NavigationItem,
+  type NavigationNode,
 } from "@/config/navigation";
 
 type MobileNavProps = {
@@ -19,6 +20,66 @@ type MobileNavProps = {
   onClose: () => void;
   navigation: readonly NavigationItem[];
 };
+
+function MobileNavigationNodes({
+  items,
+  pathname,
+  onClose,
+  depth = 0,
+}: {
+  items: readonly NavigationNode[];
+  pathname: string;
+  onClose: () => void;
+  depth?: number;
+}) {
+  return (
+    <div
+      className={`space-y-1 border-l-2 pl-3 ${
+        depth === 0
+          ? "border-[#0097b2]/20 dark:border-[#66C4DC]/25"
+          : "ml-3 border-[#0F4C5C]/12 dark:border-[#FCFAEF]/12"
+      }`}
+    >
+      {items.map((item) =>
+        isNavigationGroup(item) ? (
+          <div key={item.name} className="space-y-1.5 py-1">
+            <p
+              className={`px-3 py-1 font-subheading text-sm font-semibold ${
+                isNavigationItemActive(pathname, item)
+                  ? "text-[#007F96] dark:text-[#66C4DC]"
+                  : "text-[#3F4443] dark:text-[#FCFAEF]/85"
+              }`}
+            >
+              {item.name}
+            </p>
+            <MobileNavigationNodes
+              items={item.children}
+              pathname={pathname}
+              onClose={onClose}
+              depth={depth + 1}
+            />
+          </div>
+        ) : (
+          <Link
+            key={item.name}
+            href={item.href}
+            onClick={onClose}
+            aria-current={
+              isNavigationPathActive(pathname, item.href) ? "page" : undefined
+            }
+            className={`flex min-h-11 items-center rounded-md px-3 py-2 font-body text-sm leading-snug transition-colors ${
+              isNavigationPathActive(pathname, item.href)
+                ? "bg-[#0097b2]/10 font-medium text-[#007F96] dark:bg-[#66C4DC]/12 dark:text-[#66C4DC]"
+                : "text-[#252828] hover:bg-[#eeba2b]/10 hover:text-[#8A6100] dark:text-[#FCFAEF] dark:hover:bg-[#eeba2b]/12 dark:hover:text-[#F5C94D]"
+            }`}
+          >
+            {item.name}
+          </Link>
+        ),
+      )}
+    </div>
+  );
+}
 
 function MobileNavContent({ isOpen, onClose, navigation }: MobileNavProps) {
   const pathname = usePathname();
@@ -57,15 +118,15 @@ function MobileNavContent({ isOpen, onClose, navigation }: MobileNavProps) {
             leaveTo="translate-x-full opacity-0"
           >
             <DialogPanel 
-              className="relative ml-auto flex h-full w-full max-w-sm flex-col overflow-y-auto bg-[#FCFAEF] dark:bg-[#2F3332] py-4 pb-12 shadow-xl"
+              className="relative ml-auto flex h-full w-full max-w-[22rem] flex-col overflow-hidden border-l border-[#0F4C5C]/12 bg-[#FCFAEF] shadow-[-16px_0_40px_rgba(15,76,92,0.14)] dark:border-[#FCFAEF]/10 dark:bg-[#202423]"
             >
-              <div className="flex items-center justify-between px-4">
+              <div className="flex shrink-0 items-center justify-between border-b border-[#0F4C5C]/10 bg-[#FCFAEF]/96 px-5 py-4 backdrop-blur-xl dark:border-[#FCFAEF]/10 dark:bg-[#202423]/96">
                 <Link href="/" onClick={onClose} className="flex items-center">
                   <BrandLogo href="" width={150} height={42} imageClassName="h-8" />
                 </Link>
                 <button
                   type="button"
-                  className="-mr-2 inline-flex items-center justify-center rounded-md p-2 text-[#757A79] dark:text-[#FCFAEF]/70 hover:bg-[#eeba2b]/10 hover:text-[#eeba2b] focus:outline-none"
+                  className="-mr-2 inline-flex min-h-11 min-w-11 items-center justify-center rounded-md p-2 text-[#5F6463] transition-colors hover:bg-[#eeba2b]/10 hover:text-[#8A6100] focus:outline-none dark:text-[#FCFAEF]/70 dark:hover:bg-[#eeba2b]/12 dark:hover:text-[#F5C94D]"
                   onClick={onClose}
                 >
                   <span className="sr-only">Close menu</span>
@@ -73,7 +134,7 @@ function MobileNavContent({ isOpen, onClose, navigation }: MobileNavProps) {
                 </button>
               </div>
 
-              <div className="mt-6 space-y-5 px-4">
+              <div className="flex-1 space-y-6 overflow-y-auto px-5 py-6">
                 {navigation.map((item) => (
                   <div key={item.name} className="space-y-2">
                     {item.href ? (
@@ -87,8 +148,8 @@ function MobileNavContent({ isOpen, onClose, navigation }: MobileNavProps) {
                         }
                         className={`flex min-h-11 items-center rounded-md px-3 py-2.5 font-subheading text-[15px] font-medium leading-none ${
                           isNavigationItemActive(pathname, item)
-                            ? "bg-[#0097b2]/10 text-[#0097b2] dark:bg-[#0097b2]/20 dark:text-[#FCFAEF]"
-                            : "text-[#252828] hover:bg-[#eeba2b]/10 hover:text-[#eeba2b] dark:text-[#FCFAEF] dark:hover:bg-[#eeba2b]/20"
+                            ? "bg-[#0097b2]/10 text-[#007F96] dark:bg-[#66C4DC]/12 dark:text-[#66C4DC]"
+                            : "text-[#252828] hover:bg-[#eeba2b]/10 hover:text-[#8A6100] dark:text-[#FCFAEF] dark:hover:bg-[#eeba2b]/12 dark:hover:text-[#F5C94D]"
                         }`}
                       >
                         {item.name}
@@ -97,7 +158,7 @@ function MobileNavContent({ isOpen, onClose, navigation }: MobileNavProps) {
                       <p
                         className={`px-3 font-subheading text-xs font-bold uppercase leading-5 tracking-[0.14em] ${
                           isNavigationItemActive(pathname, item)
-                            ? "text-[#0097b2] dark:text-[#66C4DC]"
+                            ? "text-[#007F96] dark:text-[#66C4DC]"
                             : "text-[#5F6463] dark:text-[#FCFAEF]/70"
                         }`}
                       >
@@ -106,39 +167,23 @@ function MobileNavContent({ isOpen, onClose, navigation }: MobileNavProps) {
                     )}
                     
                     {isNavigationGroup(item) && (
-                      <div className="space-y-1 border-l-2 border-[#0097b2]/20 pl-3 dark:border-[#66C4DC]/25">
-                        {item.children.map((child) => (
-                          <Link
-                            key={child.name}
-                            href={child.href}
-                            onClick={onClose}
-                            aria-current={
-                              isNavigationPathActive(pathname, child.href)
-                                ? "page"
-                                : undefined
-                            }
-                            className={`flex min-h-11 items-center rounded-md px-3 py-2 font-body text-sm leading-snug ${
-                              isNavigationPathActive(pathname, child.href)
-                                ? "bg-[#0097b2]/10 text-[#0097b2] dark:bg-[#0097b2]/20 dark:text-[#FCFAEF]"
-                                : "text-[#252828] hover:bg-[#eeba2b]/10 hover:text-[#eeba2b] dark:text-[#FCFAEF] dark:hover:bg-[#eeba2b]/20"
-                            }`}
-                          >
-                            {child.name}
-                          </Link>
-                        ))}
-                      </div>
+                      <MobileNavigationNodes
+                        items={item.children}
+                        pathname={pathname}
+                        onClose={onClose}
+                      />
                     )}
                   </div>
                 ))}
-                
-                <div className="mt-4 space-y-3 border-t border-[#E6E7E7] pt-4 dark:border-[#757A79]">
-                  <Button
-                    asChild
-                    className="min-h-12 w-full bg-[#0097b2] text-[#FCFAEF] hover:bg-[#0097b2]/80 hover:text-[#FCFAEF] font-subheading font-medium"
-                  >
-                    <Link href="/donate" onClick={onClose}>Donate</Link>
-                  </Button>
-                </div>
+              </div>
+
+              <div className="shrink-0 border-t border-[#0F4C5C]/10 bg-[#FCFAEF]/96 p-5 backdrop-blur-xl dark:border-[#FCFAEF]/10 dark:bg-[#202423]/96">
+                <Button
+                  asChild
+                  className="min-h-12 w-full rounded-md bg-[#0097b2] font-subheading font-semibold text-[#FCFAEF] shadow-sm hover:bg-[#007F96] hover:text-[#FCFAEF]"
+                >
+                  <Link href="/donate" onClick={onClose}>Donate</Link>
+                </Button>
               </div>
             </DialogPanel>
           </TransitionChild>

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -29,6 +29,14 @@ export const mainNavigation: readonly NavigationItem[] = [
     ],
   },
   {
+    name: "Our Work",
+    children: [
+      { name: "Community Health Hubs", href: "/community-hubs" },
+      { name: "Research & Innovation", href: "/research" },
+      { name: "Impact", href: "/impact" },
+    ],
+  },
+  {
     name: "Learning Experiences",
     children: [
       { name: "Akomapa Academy", href: "/academy" },
@@ -39,19 +47,12 @@ export const mainNavigation: readonly NavigationItem[] = [
     ],
   },
   {
-    name: "Community Health Hubs",
-    href: "/community-hubs",
+    name: "Join Us",
     children: [
-      { name: "All Hubs", href: "/community-hubs" },
-      { name: "Akomapa UCC Hub", href: "/community-hubs/ucc" },
-      { name: "Akomapa UG Hub", href: "/community-hubs/ug" },
-      { name: "Akomapa NHP Yale Hub", href: "/community-hubs/nhp" },
+      { name: "Get Involved", href: "/get-involved" },
+      { name: "Partnerships", href: "/partnerships" },
     ],
   },
-  { name: "Research & Innovation", href: "/research" },
-  { name: "Impact", href: "/impact" },
-  { name: "Partnerships", href: "/partnerships" },
-  { name: "Get Involved", href: "/get-involved" },
 ] as const;
 
 export function isNavigationGroup(

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -1,8 +1,3 @@
-export type NavigationChild = {
-  name: string;
-  href: string;
-};
-
 export type NavigationLink = {
   name: string;
   href: string;
@@ -11,10 +6,11 @@ export type NavigationLink = {
 export type NavigationGroup = {
   name: string;
   href?: string;
-  children: readonly NavigationChild[];
+  children: readonly NavigationNode[];
 };
 
-export type NavigationItem = NavigationLink | NavigationGroup;
+export type NavigationNode = NavigationLink | NavigationGroup;
+export type NavigationItem = NavigationNode;
 
 export const mainNavigation: readonly NavigationItem[] = [
   { name: "Home", href: "/" },
@@ -31,7 +27,16 @@ export const mainNavigation: readonly NavigationItem[] = [
   {
     name: "Our Work",
     children: [
-      { name: "Community Health Hubs", href: "/community-hubs" },
+      {
+        name: "Community Health Hubs",
+        href: "/community-hubs",
+        children: [
+          { name: "All Community Health Hubs", href: "/community-hubs" },
+          { name: "Akomapa UCC Hub", href: "/community-hubs/ucc" },
+          { name: "Akomapa UG Hub", href: "/community-hubs/ug" },
+          { name: "Akomapa NHP Yale Hub", href: "/community-hubs/nhp" },
+        ],
+      },
       { name: "Research & Innovation", href: "/research" },
       { name: "Impact", href: "/impact" },
     ],
@@ -56,7 +61,7 @@ export const mainNavigation: readonly NavigationItem[] = [
 ] as const;
 
 export function isNavigationGroup(
-  item: NavigationItem,
+  item: NavigationNode,
 ): item is NavigationGroup {
   return "children" in item;
 }
@@ -67,8 +72,8 @@ export function isNavigationPathActive(pathname: string, href: string) {
 
 export function isNavigationItemActive(
   pathname: string,
-  item: NavigationItem,
-) {
+  item: NavigationNode,
+): boolean {
   if (item.href && isNavigationPathActive(pathname, item.href)) {
     return true;
   }
@@ -76,7 +81,7 @@ export function isNavigationItemActive(
   return (
     isNavigationGroup(item) &&
     item.children.some((child) =>
-      isNavigationPathActive(pathname, child.href),
+      isNavigationItemActive(pathname, child),
     )
   );
 }


### PR DESCRIPTION
## Summary

Completes the focused portion of #182 by restoring and redesigning the Global
Health Immersion Program, promoting it to a top-level route, and reorganizing
the global navigation into a clearer and more responsive information
architecture.

## What changed

### Global Health Immersion Program

- Added the redesigned program page at
  `/global-health-immersion-program`.
- Retained a permanent 301 redirect from
  `/programs/akomapa-ghip`.
- Reworked the page using Akomapa's flat editorial design language.
- Preserved verified program details, including:
  - Three-week duration
  - Ghana as the first host site
  - Certificate in Global Health and Community Engagement
  - Eligibility groups
  - Participant activities
  - Five learning components
  - Faculty and institutional partnership pathway
- Removed expired 2026 recruitment details and unannounced fee/date
  placeholders.
- Added "Register Interest" and brochure-request contact flows.
- Added safe allow-listed contact form prefill mappings.
- Updated route metadata without implying that applications are open.
- Added semantic fact, eligibility, activity, and learning structures.

### Navigation architecture

- Replaced the standalone Academy navigation item with a
  "Learning Experiences" group containing:
  - Akomapa Academy
  - Global Health Immersion Program
- Consolidated related destinations into:
  - About
  - Our Work
  - Learning Experiences
  - Join Us
- Preserved Community Health Hubs as a nested dropdown within "Our Work."
- Retained direct access to:
  - All Community Health Hubs
  - Akomapa UCC Hub
  - Akomapa UG Hub
  - Akomapa NHP Yale Hub
- Introduced a recursive typed navigation model to support links and nested
  non-destination groups.
- Preserved active-child propagation throughout the hierarchy.

### Desktop header

- Centered the primary navigation within the space between the logo and
  right-side actions.
- Reduced visual crowding near the logo.
- Refined dropdown borders, shadows, spacing, and active states.
- Added restrained hover backgrounds and active underline indicators.
- Preserved keyboard navigation, focus movement, Escape handling, and nested
  submenu behavior.
- Retained the Donate and theme controls as stable right-aligned actions.

### Mobile navigation

- Restyled the drawer with a fixed header, independently scrollable content,
  and anchored Donate action.
- Rendered navigation groups as clear labeled sections.
- Exposed every Community Health Hub destination without requiring nested
  touch interactions.
- Added visible active states and restrained hierarchy rules.
- Ensured navigation links and controls meet the 44px minimum touch-target
  requirement.
- Preserved drawer closing after navigation.

## Accessibility and responsive behavior

- Preserved logical headings, semantic structures, visible focus, and
  reduced-motion behavior.
- Verified navigation keyboard access, nested submenu behavior, Escape
  handling, and active states.
- Verified that the header and page layouts do not introduce horizontal
  overflow.
- Covered light and dark themes across mobile, tablet, laptop, desktop, and
  wide-desktop layouts.

## Test plan

- [x] Pre-commit ESLint
- [x] TypeScript typecheck
- [x] Production build
- [x] Focused navigation Playwright tests
- [x] Immersion Program structural and contact-intent tests
- [x] Legacy 301 redirect test
- [x] Responsive and typography regression matrices
- [x] Light and dark theme coverage
- [x] Keyboard and touch-target coverage
- [x] Full Playwright suite: 568 tests passed
- [x] Full pre-push hook

## Notes

- No dependencies, generated icons, brochure files, or additional landing
  pages were introduced.
- The existing Programs page remains available for possible future reuse but
  is not part of the visible global navigation.
- The existing `next lint` deprecation warning remains unchanged and should
  be handled separately as a repository-wide tooling migration.