### PR TITLE
Design restyle community hubs listing and detail pages

### DIFF
--- a/e2e/about-family-editorial.spec.ts
+++ b/e2e/about-family-editorial.spec.ts
@@ -232,27 +232,56 @@ for (const theme of themes) {
     for (const route of routes) {
       await page.goto(route, { waitUntil: "domcontentloaded" });
       await expect(page.locator("main h1")).toBeVisible();
+      await expect(page.locator("html")).toHaveClass(
+        new RegExp(`\\b${theme}\\b`),
+      );
+
       const creamHeading = page
         .locator("[data-editorial-band][data-editorial-tone='cream'] h2")
         .first();
+      const creamBand = page
+        .locator("[data-editorial-band][data-editorial-tone='cream']")
+        .first();
+      const expectedCreamHeading =
+        theme === "dark" ? "rgb(252, 250, 239)" : "rgb(28, 31, 30)";
+      const expectedCreamBandBg =
+        theme === "dark" ? "rgb(18, 21, 20)" : "rgb(252, 250, 239)";
       await expect
         .poll(() =>
           creamHeading.evaluate((element) => getComputedStyle(element).color),
         )
-        .toBe(
-          theme === "dark"
-            ? "rgb(252, 250, 239)"
-            : "rgb(28, 31, 30)",
-        );
+        .toBe(expectedCreamHeading);
+      await expect
+        .poll(() =>
+          creamBand.evaluate(
+            (element) => getComputedStyle(element).backgroundColor,
+          ),
+        )
+        .toBe(expectedCreamBandBg);
+
       await page.addStyleTag({
         content:
           "*, *::before, *::after { transition-duration: 0s !important; transition-delay: 0s !important; }",
       });
 
+      // Re-assert after transition kill so contrast reads never sample mid-theme paint.
+      await expect
+        .poll(() =>
+          creamHeading.evaluate((element) => getComputedStyle(element).color),
+        )
+        .toBe(expectedCreamHeading);
+      await expect
+        .poll(() =>
+          creamBand.evaluate(
+            (element) => getComputedStyle(element).backgroundColor,
+          ),
+        )
+        .toBe(expectedCreamBandBg);
+
       const selectors = [
         "main h1",
         "[data-editorial-band][data-editorial-tone='cream'] h2",
-        "[data-editorial-band] a",
+        "[data-editorial-band][data-editorial-tone='cream'] a, [data-editorial-band][data-editorial-tone='onyx'] a, [data-editorial-band][data-editorial-tone='teal'] a",
       ];
       const ratios = await page.evaluate((sampleSelectors) => {
         type Rgba = { r: number; g: number; b: number; a: number };

--- a/e2e/community-hubs-editorial.spec.ts
+++ b/e2e/community-hubs-editorial.spec.ts
@@ -1,0 +1,356 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+import { announcementCampaign } from "../src/data/announcements";
+import {
+  communityHubs,
+  communityHubsListing,
+  getHubHref,
+  hubMissions,
+  hubRouteSlugs,
+} from "../src/data/community-hubs";
+
+const listingRoute = "/community-hubs";
+const detailRoutes = hubRouteSlugs.map((slug) => `/community-hubs/${slug}`);
+const routes = [listingRoute, ...detailRoutes] as const;
+
+const viewports = [
+  { name: "mobile-390", width: 390, height: 844 },
+  { name: "boundary-640", width: 640, height: 900 },
+  { name: "tablet-768", width: 768, height: 1024 },
+  { name: "boundary-900", width: 900, height: 1024 },
+  { name: "ipad-pro-1024", width: 1024, height: 1366 },
+  { name: "laptop-1280", width: 1280, height: 800 },
+  { name: "desktop-1440", width: 1440, height: 900 },
+  { name: "wide-1536", width: 1536, height: 960 },
+] as const;
+
+const themes = ["light", "dark"] as const;
+
+const statusLabels = {
+  active: "Active",
+  "in-development": "In development",
+  planned: "Planned",
+  future: "Future",
+} as const;
+
+async function preparePage(page: Page, theme: (typeof themes)[number]) {
+  await page.addInitScript(
+    ({ version, storedTheme }) => {
+      localStorage.setItem("akomapa-announcements-dismissed", version);
+      localStorage.setItem("akomapa-theme", storedTheme);
+      document.documentElement.classList.remove("light", "dark");
+      document.documentElement.classList.add(storedTheme);
+
+      const style = document.createElement("style");
+      style.textContent =
+        "*,*::before,*::after{transition-duration:0s!important;animation-duration:0s!important}";
+      document.documentElement.append(style);
+    },
+    { version: announcementCampaign.version, storedTheme: theme },
+  );
+}
+
+async function expectNoOverflow(page: Page) {
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => document.documentElement.scrollWidth <= window.innerWidth + 1,
+      ),
+    )
+    .toBe(true);
+}
+
+async function expectElementInViewport(locator: Locator) {
+  const contained = await locator.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    return rect.left >= -1 && rect.right <= window.innerWidth + 1;
+  });
+  expect(contained).toBe(true);
+}
+
+for (const viewport of viewports) {
+  for (const theme of themes) {
+    test(`${viewport.name} · ${theme} · Community hubs editorial contracts`, async ({
+      page,
+    }) => {
+      test.setTimeout(60_000);
+      await preparePage(page, theme);
+      await page.setViewportSize(viewport);
+
+      for (const route of routes) {
+        await page.goto(route, { waitUntil: "domcontentloaded" });
+        await expect(page.locator("main h1")).toHaveCount(1);
+        await expectElementInViewport(page.locator("main h1"));
+        await expectNoOverflow(page);
+
+        const bands = page.locator("[data-editorial-band]");
+        await expect(bands.first()).toBeVisible();
+
+        const standaloneControls = page.locator(
+          "[data-editorial-band] a, [data-editorial-band] button",
+        );
+        const undersized = await standaloneControls.evaluateAll((controls) =>
+          controls
+            .filter((control) => {
+              const style = getComputedStyle(control);
+              const rect = control.getBoundingClientRect();
+              return (
+                style.display !== "none" &&
+                style.visibility !== "hidden" &&
+                (rect.width < 44 || rect.height < 44)
+              );
+            })
+            .map((control) => control.textContent?.trim() ?? control.tagName),
+        );
+        expect(undersized).toEqual([]);
+      }
+    });
+  }
+}
+
+test("listing preserves mission order, hub status text, and destinations", async ({
+  page,
+}) => {
+  await preparePage(page, "light");
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto(listingRoute, { waitUntil: "domcontentloaded" });
+
+  await expect(
+    page.getByRole("heading", {
+      level: 1,
+      name: communityHubsListing.headline,
+    }),
+  ).toHaveCount(1);
+
+  const missionTitles = await page
+    .locator("#five-missions ol li h3")
+    .allTextContents();
+  expect(missionTitles).toEqual(hubMissions.map((mission) => mission.title));
+
+  const listingTones = await page
+    .locator("[data-editorial-band]")
+    .evaluateAll((bands) =>
+      bands.map((band) => band.getAttribute("data-editorial-tone")),
+    );
+  expect(listingTones).toEqual(["teal", "cream", "white", "cream", "teal"]);
+
+  for (const hub of communityHubs) {
+    const card = page.locator(
+      `[data-testid="community-hub-card"][data-hub-id="${hub.id}"]`,
+    );
+    await expect(card).toHaveAttribute("data-hub-status", hub.status);
+    await expect(card.getByText(statusLabels[hub.status], { exact: true })).toBeVisible();
+    await expect(
+      card.getByRole("link", { name: new RegExp(hub.name) }),
+    ).toHaveAttribute("href", getHubHref(hub));
+  }
+});
+
+for (const routeSlug of hubRouteSlugs) {
+  test(`detail /community-hubs/${routeSlug} preserves status and semantic metrics`, async ({
+    page,
+  }) => {
+    const hub = communityHubs.find(({ routeSlug: slug }) => slug === routeSlug)!;
+
+    await preparePage(page, "light");
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(`/community-hubs/${routeSlug}`, {
+      waitUntil: "domcontentloaded",
+    });
+
+    await expect(
+      page.getByRole("heading", { level: 1, name: hub.name, exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByText(statusLabels[hub.status], { exact: true }),
+    ).toBeVisible();
+
+    const metrics = page.locator("[data-hub-metrics]");
+    await expect(metrics).toHaveCount(1);
+    await expect(metrics.locator("dt")).toHaveCount(4);
+    await expect(metrics.locator("dd")).toHaveCount(4);
+    await expect(page.getByText("Community members served")).toBeVisible();
+    await expect(page.getByText("Students trained")).toBeVisible();
+    await expect(page.getByText("Communities reached")).toBeVisible();
+    await expect(page.getByText("Partners engaged")).toBeVisible();
+
+    if (hub.status === "in-development") {
+      await expect(page.getByText(/This hub is in development/i)).toBeVisible();
+    }
+
+    await expect(page.locator("[data-hub-empty-state]")).toHaveCount(4);
+  });
+}
+
+test("supports reduced motion and 200% zoom-equivalent reflow", async ({
+  browser,
+}) => {
+  const context = await browser.newContext({
+    reducedMotion: "reduce",
+    colorScheme: "light",
+    viewport: { width: 720, height: 900 },
+  });
+  const page = await context.newPage();
+  await preparePage(page, "light");
+
+  for (const width of [720, 320]) {
+    await page.setViewportSize({ width, height: 900 });
+    for (const route of routes) {
+      await page.goto(route, { waitUntil: "domcontentloaded" });
+      await expectNoOverflow(page);
+
+      const motionState = await page
+        .locator("[data-editorial-band]")
+        .evaluateAll((bands) =>
+          bands.map((band) => {
+            const style = getComputedStyle(band);
+            return { opacity: style.opacity, transform: style.transform };
+          }),
+        );
+      expect(
+        motionState.every(
+          ({ opacity, transform }) =>
+            opacity === "1" && transform === "none",
+        ),
+      ).toBe(true);
+    }
+  }
+
+  await context.close();
+});
+
+test("preserves visible keyboard focus on hub destination links", async ({
+  page,
+}) => {
+  await preparePage(page, "dark");
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto(listingRoute, { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle");
+
+  const firstHubLink = page
+    .locator("#our-hubs [data-testid='community-hub-card'] a")
+    .first();
+  await firstHubLink.focus();
+  await expect(firstHubLink).toBeFocused();
+
+  const focusStyle = await firstHubLink.evaluate((element) => {
+    const style = getComputedStyle(element);
+    return {
+      boxShadow: style.boxShadow,
+      outlineStyle: style.outlineStyle,
+    };
+  });
+  expect(
+    focusStyle.boxShadow !== "none" || focusStyle.outlineStyle !== "none",
+  ).toBe(true);
+});
+
+for (const theme of themes) {
+  test(`${theme} representative hub editorial text meets AA contrast`, async ({
+    page,
+  }) => {
+    await preparePage(page, theme);
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(listingRoute, { waitUntil: "domcontentloaded" });
+    await expect(page.locator("main h1")).toBeVisible();
+
+    const creamHeading = page
+      .locator("[data-editorial-band][data-editorial-tone='cream'] h2")
+      .first();
+    await expect
+      .poll(() =>
+        creamHeading.evaluate((element) => getComputedStyle(element).color),
+      )
+      .toBe(
+        theme === "dark" ? "rgb(252, 250, 239)" : "rgb(28, 31, 30)",
+      );
+
+    await page.addStyleTag({
+      content:
+        "*, *::before, *::after { transition-duration: 0s !important; transition-delay: 0s !important; }",
+    });
+
+    const selectors = [
+      "main h1",
+      "[data-editorial-band][data-editorial-tone='cream'] h2",
+      "#our-hubs [data-testid='community-hub-card'] a",
+    ];
+    const ratios = await page.evaluate((sampleSelectors) => {
+      type Rgba = { r: number; g: number; b: number; a: number };
+
+      const parse = (value: string): Rgba => {
+        if (value === "transparent") {
+          return { r: 0, g: 0, b: 0, a: 0 };
+        }
+        const channels = value.match(/[\d.]+/g)?.map(Number) ?? [];
+        return {
+          r: channels[0] ?? 0,
+          g: channels[1] ?? 0,
+          b: channels[2] ?? 0,
+          a: channels[3] ?? 1,
+        };
+      };
+      const composite = (front: Rgba, back: Rgba): Rgba => {
+        const alpha = front.a + back.a * (1 - front.a);
+        return {
+          r: (front.r * front.a + back.r * back.a * (1 - front.a)) / alpha,
+          g: (front.g * front.a + back.g * back.a * (1 - front.a)) / alpha,
+          b: (front.b * front.a + back.b * back.a * (1 - front.a)) / alpha,
+          a: alpha,
+        };
+      };
+      const backgroundFor = (element: Element): Rgba => {
+        let background: Rgba = { r: 255, g: 255, b: 255, a: 1 };
+        const ancestors: Element[] = [];
+        for (let node: Element | null = element; node; node = node.parentElement) {
+          ancestors.unshift(node);
+        }
+        for (const ancestor of ancestors) {
+          const layer = parse(getComputedStyle(ancestor).backgroundColor);
+          if (layer.a > 0) background = composite(layer, background);
+        }
+        return background;
+      };
+      const luminance = ({ r, g, b }: Rgba) => {
+        const linear = [r, g, b].map((channel) => {
+          const value = channel / 255;
+          return value <= 0.04045
+            ? value / 12.92
+            : ((value + 0.055) / 1.055) ** 2.4;
+        });
+        return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2];
+      };
+
+      return sampleSelectors.map((selector) => {
+        const element = document.querySelector<HTMLElement>(selector);
+        if (!element) {
+          return {
+            selector,
+            ratio: 0,
+            foregroundCss: "",
+            backgroundCss: "",
+          };
+        }
+        const background = backgroundFor(element);
+        const foregroundCss = getComputedStyle(element).color;
+        const foreground = composite(parse(foregroundCss), background);
+        const light = Math.max(luminance(foreground), luminance(background));
+        const dark = Math.min(luminance(foreground), luminance(background));
+        return {
+          selector,
+          ratio: (light + 0.05) / (dark + 0.05),
+          foregroundCss,
+          backgroundCss: getComputedStyle(element).backgroundColor,
+        };
+      });
+    }, selectors);
+
+    for (const { selector, ratio, foregroundCss, backgroundCss } of ratios) {
+      expect
+        .soft(
+          ratio,
+          `${theme} contrast: ${selector} (${foregroundCss} on ${backgroundCss})`,
+        )
+        .toBeGreaterThanOrEqual(4.5);
+    }
+  });
+}

--- a/e2e/community-hubs-editorial.spec.ts
+++ b/e2e/community-hubs-editorial.spec.ts
@@ -252,22 +252,48 @@ for (const theme of themes) {
     await page.setViewportSize({ width: 1280, height: 900 });
     await page.goto(listingRoute, { waitUntil: "domcontentloaded" });
     await expect(page.locator("main h1")).toBeVisible();
+    await expect(page.locator("html")).toHaveClass(new RegExp(`\\b${theme}\\b`));
 
     const creamHeading = page
       .locator("[data-editorial-band][data-editorial-tone='cream'] h2")
       .first();
+    const creamBand = page
+      .locator("[data-editorial-band][data-editorial-tone='cream']")
+      .first();
+    const expectedCreamHeading =
+      theme === "dark" ? "rgb(252, 250, 239)" : "rgb(28, 31, 30)";
+    const expectedCreamBandBg =
+      theme === "dark" ? "rgb(18, 21, 20)" : "rgb(252, 250, 239)";
     await expect
       .poll(() =>
         creamHeading.evaluate((element) => getComputedStyle(element).color),
       )
-      .toBe(
-        theme === "dark" ? "rgb(252, 250, 239)" : "rgb(28, 31, 30)",
-      );
+      .toBe(expectedCreamHeading);
+    await expect
+      .poll(() =>
+        creamBand.evaluate(
+          (element) => getComputedStyle(element).backgroundColor,
+        ),
+      )
+      .toBe(expectedCreamBandBg);
 
     await page.addStyleTag({
       content:
         "*, *::before, *::after { transition-duration: 0s !important; transition-delay: 0s !important; }",
     });
+
+    await expect
+      .poll(() =>
+        creamHeading.evaluate((element) => getComputedStyle(element).color),
+      )
+      .toBe(expectedCreamHeading);
+    await expect
+      .poll(() =>
+        creamBand.evaluate(
+          (element) => getComputedStyle(element).backgroundColor,
+        ),
+      )
+      .toBe(expectedCreamBandBg);
 
     const selectors = [
       "main h1",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -162,20 +162,17 @@ select {
     @apply bg-background text-foreground font-body;
   }
   
-  /* Add transitions for smooth dark mode changes - in base layer so utilities can override */
   html {
     transition: background-color 0.3s ease;
   }
-  
-  html.dark body * {
-    transition-property: background-color, border-color, color, fill, stroke;
-    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-    transition-duration: 0.2s;
+
+  body {
+    transition: background-color 0.3s ease;
   }
 
   @media (prefers-reduced-motion: reduce) {
     html,
-    html.dark body * {
+    body {
       transition-duration: 0s;
     }
   }

--- a/src/components/community-hubs/FiveMissions.tsx
+++ b/src/components/community-hubs/FiveMissions.tsx
@@ -1,65 +1,59 @@
 "use client";
 
+import { FadeIn } from "@/components/animations";
 import {
-  FlaskConical,
-  GraduationCap,
-  Handshake,
-  Heart,
-  Lightbulb,
-  type LucideIcon,
-} from "lucide-react";
-import { FadeIn, FadeInStagger, FadeInStaggerItem } from "@/components/animations";
-import {
-  IconBadge,
-  PublicSection,
-  PublicSectionHeader,
-} from "@/components/shared/PublicPagePrimitives";
+  EditorialBand,
+  EditorialEyebrow,
+  EditorialHeading,
+  EditorialLead,
+} from "@/components/shared/EditorialPrimitives";
 import { hubMissions } from "@/data/community-hubs";
-
-const missionIcons: LucideIcon[] = [
-  Heart,
-  GraduationCap,
-  Handshake,
-  FlaskConical,
-  Lightbulb,
-];
 
 export default function FiveMissions() {
   return (
-    <PublicSection tone="cream" spacing="normal" withTexture id="five-missions">
+    <EditorialBand
+      tone="cream"
+      marker="01"
+      id="five-missions"
+      aria-labelledby="five-missions-heading"
+    >
       <FadeIn>
-        <PublicSectionHeader
-          eyebrow="Every Hub, Five Missions"
-          title="What Our Hubs Are Built to Do"
-          description="Each Community Learning & Care Hub is a platform for healthcare delivery, leadership development, partnership, research, and innovation."
-          titleId="five-missions-heading"
-        />
+        <div className="max-w-3xl">
+          <EditorialEyebrow className="text-[#0F4C5C] dark:text-[#66C4DC]">
+            Every Hub, Five Missions
+          </EditorialEyebrow>
+          <EditorialHeading id="five-missions-heading" className="mt-4">
+            What Our Hubs Are Built to Do
+          </EditorialHeading>
+          <EditorialLead className="mt-5">
+            Each Community Learning & Care Hub is a platform for healthcare
+            delivery, leadership development, partnership, research, and
+            innovation.
+          </EditorialLead>
+        </div>
       </FadeIn>
 
-      <FadeInStagger className="mt-12 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
-        {hubMissions.map((mission, index) => {
-          const Icon = missionIcons[index] ?? Heart;
-
-          return (
-            <FadeInStaggerItem key={mission.id} direction="up">
-              <div className="flex h-full flex-col items-center rounded-xl border border-[#E6E7E7] bg-white/88 p-6 text-center shadow-sm dark:border-[#2F3332] dark:bg-[#2F3332]/70">
-                <IconBadge className="h-12 w-12">
-                  <Icon className="h-5 w-5" aria-hidden="true" />
-                </IconBadge>
-                <p className="mt-4 text-sm font-semibold uppercase tracking-wide text-[#0097b2] dark:text-[#66C4DC]">
-                  {String(mission.id).padStart(2, "0")}
-                </p>
-                <h3 className="mt-2 text-lg font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
-                  {mission.title}
-                </h3>
-                <p className="mt-2 text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
-                  {mission.description}
-                </p>
-              </div>
-            </FadeInStaggerItem>
-          );
-        })}
-      </FadeInStagger>
-    </PublicSection>
+      <ol className="mt-12 grid border-t border-[#1C1F1E]/15 md:grid-cols-2 xl:grid-cols-5 dark:border-[#FCFAEF]/20">
+        {hubMissions.map((mission, index) => (
+          <li
+            key={mission.id}
+            className="border-b border-[#1C1F1E]/15 px-1 py-7 md:odd:border-r md:px-6 xl:border-r xl:px-5 xl:last:border-r-0 dark:border-[#FCFAEF]/20"
+          >
+            <span
+              aria-hidden="true"
+              className="font-heading text-4xl font-semibold tracking-[-0.06em] text-[#0097b2]/55 dark:text-[#66C4DC]/65"
+            >
+              {String(index + 1).padStart(2, "0")}
+            </span>
+            <h3 className="mt-5 font-heading text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+              {mission.title}
+            </h3>
+            <p className="mt-3 text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
+              {mission.description}
+            </p>
+          </li>
+        ))}
+      </ol>
+    </EditorialBand>
   );
 }

--- a/src/components/community-hubs/HubActivities.tsx
+++ b/src/components/community-hubs/HubActivities.tsx
@@ -1,69 +1,59 @@
 "use client";
 
+import { FadeIn } from "@/components/animations";
 import {
-  ArrowRightLeft,
-  BookOpen,
-  FlaskConical,
-  GraduationCap,
-  HeartHandshake,
-  Lightbulb,
-  Stethoscope,
-  Users,
-  type LucideIcon,
-} from "lucide-react";
-import { FadeIn, FadeInStagger, FadeInStaggerItem } from "@/components/animations";
-import {
-  IconBadge,
-  PublicSection,
-  PublicSectionHeader,
-  SurfaceCard,
-} from "@/components/shared/PublicPagePrimitives";
-import { hubActivities, type HubActivityIcon } from "@/data/community-hubs";
-
-const activityIconMap: Record<HubActivityIcon, LucideIcon> = {
-  Stethoscope,
-  ArrowRightLeft,
-  BookOpen,
-  Users,
-  GraduationCap,
-  HeartHandshake,
-  FlaskConical,
-  Lightbulb,
-};
+  EditorialBand,
+  EditorialEyebrow,
+  EditorialHeading,
+  EditorialLead,
+} from "@/components/shared/EditorialPrimitives";
+import { hubActivities } from "@/data/community-hubs";
 
 export default function HubActivities() {
   return (
-    <PublicSection tone="white" spacing="normal" id="hub-activities">
+    <EditorialBand
+      tone="white"
+      marker="02"
+      id="hub-activities"
+      aria-labelledby="hub-activities-heading"
+    >
       <FadeIn>
-        <PublicSectionHeader
-          eyebrow="What Happens at Each Hub"
-          title="Learning, Care, and Partnership in Action"
-          description="From screening and education to mentorship and innovation pilots, hub activity connects community priorities with student leadership development."
-          titleId="hub-activities-heading"
-        />
+        <div className="max-w-3xl">
+          <EditorialEyebrow className="text-[#0F4C5C] dark:text-[#66C4DC]">
+            What Happens at Each Hub
+          </EditorialEyebrow>
+          <EditorialHeading id="hub-activities-heading" className="mt-4">
+            Learning, Care, and Partnership in Action
+          </EditorialHeading>
+          <EditorialLead className="mt-5">
+            From screening and education to mentorship and innovation pilots,
+            hub activity connects community priorities with student leadership
+            development.
+          </EditorialLead>
+        </div>
       </FadeIn>
 
-      <FadeInStagger className="mt-12 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
-        {hubActivities.map((activity) => {
-          const Icon = activityIconMap[activity.icon];
-
-          return (
-            <FadeInStaggerItem key={activity.id} direction="up">
-              <SurfaceCard className="h-full p-6">
-                <IconBadge>
-                  <Icon className="h-5 w-5" aria-hidden="true" />
-                </IconBadge>
-                <h3 className="mt-4 text-lg font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
-                  {activity.title}
-                </h3>
-                <p className="mt-2 text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
-                  {activity.description}
-                </p>
-              </SurfaceCard>
-            </FadeInStaggerItem>
-          );
-        })}
-      </FadeInStagger>
-    </PublicSection>
+      <ol className="mt-12 grid border-t border-[#1C1F1E]/15 sm:grid-cols-2 dark:border-[#FCFAEF]/20">
+        {hubActivities.map((activity, index) => (
+          <li
+            key={activity.id}
+            className="border-b border-[#1C1F1E]/15 px-1 py-7 sm:odd:border-r sm:px-6 dark:border-[#FCFAEF]/20"
+          >
+            <span
+              aria-hidden="true"
+              className="font-subheading text-xs font-bold tracking-[0.2em] text-[#0097b2] dark:text-[#66C4DC]"
+            >
+              {String(index + 1).padStart(2, "0")}
+            </span>
+            <h3 className="mt-4 font-heading text-lg font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+              {activity.title}
+            </h3>
+            <p className="mt-2 text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
+              {activity.description}
+            </p>
+          </li>
+        ))}
+      </ol>
+    </EditorialBand>
   );
 }

--- a/src/components/community-hubs/HubCard.tsx
+++ b/src/components/community-hubs/HubCard.tsx
@@ -71,7 +71,10 @@ export default function HubCard({ hub }: HubCardProps) {
           </div>
         </dl>
 
-        <EditorialArrowLink href={href} className="mt-6">
+        <EditorialArrowLink
+          href={href}
+          className="mt-6 text-[#0F4C5C] hover:text-[#0097b2] dark:text-[#66C4DC] dark:hover:text-[#F5C94D]"
+        >
           <span className="sr-only">{hub.name}: </span>
           Learn More
         </EditorialArrowLink>

--- a/src/components/community-hubs/HubCard.tsx
+++ b/src/components/community-hubs/HubCard.tsx
@@ -1,26 +1,11 @@
 "use client";
 
-import Link from "next/link";
-import { ArrowRight, MapPin } from "lucide-react";
 import type { CSSProperties } from "react";
 import Image from "@/components/common/Image";
-import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import type { CommunityHub } from "@/lib/types";
+import { EditorialArrowLink } from "@/components/shared/EditorialPrimitives";
+import { getHubStatusLabel } from "@/components/community-hubs/hub-status";
 import { getHubHref } from "@/data/community-hubs";
-
-const statusLabels = {
-  active: "Active",
-  "in-development": "In development",
-  planned: "Planned",
-  future: "Future",
-} as const;
+import type { CommunityHub } from "@/lib/types";
 
 type HubCardProps = {
   hub: CommunityHub;
@@ -28,84 +13,69 @@ type HubCardProps = {
 
 export default function HubCard({ hub }: HubCardProps) {
   const href = getHubHref(hub);
+  const statusLabel = getHubStatusLabel(hub.status);
 
   return (
-    <article className="h-full">
-      <Card
-        data-testid="community-hub-card"
-        data-hub-id={hub.id}
-        data-accent-color={hub.color}
-        className="homepage-hover-card h-full gap-0 overflow-hidden rounded-xl border-x border-b border-t-4 border-[#E6E7E7] bg-white py-0 text-[#1C1F1E] shadow-sm dark:border-[#2F3332] dark:bg-[#1C1F1E] dark:text-[#FCFAEF] dark:shadow-lg"
-        style={
-          {
-            borderTopColor: hub.color,
-            "--homepage-hover-border-color": hub.color,
-          } as CSSProperties
-        }
-      >
-        <div className="relative aspect-[16/10] overflow-hidden">
-          <Image
-            src={hub.image}
-            alt={`${hub.name} in ${hub.location}`}
-            fill
-            sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
-            className="object-cover transition-transform duration-500 motion-safe:hover:scale-[1.03]"
-          />
-          <div
-            aria-hidden="true"
-            className="absolute inset-0 bg-gradient-to-t from-[#121514]/55 via-transparent to-transparent"
-          />
-          <span className="absolute right-4 top-4 rounded-full bg-[#FCFAEF]/95 px-3 py-1 text-xs font-bold text-[#1C1F1E] shadow-sm">
-            {statusLabels[hub.status]}
-          </span>
-        </div>
+    <article
+      data-testid="community-hub-card"
+      data-hub-id={hub.id}
+      data-accent-color={hub.color}
+      data-hub-status={hub.status}
+      className="flex h-full flex-col border border-[#1C1F1E]/15 bg-transparent dark:border-[#FCFAEF]/20"
+      style={
+        {
+          borderTopWidth: "3px",
+          borderTopColor: hub.color,
+        } as CSSProperties
+      }
+    >
+      <div className="relative aspect-[16/10] overflow-hidden bg-[#0F4C5C]/10">
+        <Image
+          src={hub.image}
+          alt={`${hub.name} in ${hub.location}`}
+          fill
+          sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
+          className="object-cover transition-transform duration-500 motion-safe:group-hover:scale-[1.02]"
+        />
+      </div>
 
-        <CardHeader className="px-6 pb-4 pt-6">
-          <CardTitle>
-            <h3 className="text-2xl leading-tight text-[#1C1F1E] dark:text-[#FCFAEF]">
-              {hub.name}
-            </h3>
-          </CardTitle>
-          <div className="mt-3 flex items-start gap-2 text-sm font-medium text-[#0097b2] dark:text-[#66C4DC]">
-            <MapPin className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
-            <span>
-              {hub.location}, {hub.country}
-            </span>
+      <div className="flex flex-1 flex-col px-5 py-6 sm:px-6">
+        <p className="font-subheading text-xs font-bold uppercase tracking-[0.2em] text-[#0F4C5C] dark:text-[#66C4DC]">
+          {statusLabel}
+        </p>
+
+        <h3 className="mt-3 font-heading text-2xl font-semibold leading-tight text-[#1C1F1E] dark:text-[#FCFAEF]">
+          {hub.name}
+        </h3>
+
+        <p className="mt-3 text-sm font-medium text-[#0097b2] dark:text-[#66C4DC]">
+          {hub.location}, {hub.country}
+        </p>
+
+        <p className="mt-4 flex-1 text-base leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
+          {hub.description}
+        </p>
+
+        <dl className="mt-5 grid grid-cols-2 gap-4 border-t border-[#1C1F1E]/10 pt-5 text-sm dark:border-[#FCFAEF]/15">
+          <div>
+            <dt className="text-[#2F3332]/60 dark:text-[#E6E7E7]/60">Served</dt>
+            <dd className="mt-1 font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+              {hub.metrics.communityMembersServed.toLocaleString()}
+            </dd>
           </div>
-        </CardHeader>
+          <div>
+            <dt className="text-[#2F3332]/60 dark:text-[#E6E7E7]/60">Students</dt>
+            <dd className="mt-1 font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+              {hub.metrics.studentsTrained.toLocaleString()}
+            </dd>
+          </div>
+        </dl>
 
-        <CardContent className="flex flex-1 flex-col px-6 pb-6">
-          <CardDescription className="flex-1 text-base leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]">
-            {hub.description}
-          </CardDescription>
-
-          <dl className="mt-4 grid grid-cols-2 gap-3 text-sm">
-            <div>
-              <dt className="text-[#2F3332]/60 dark:text-[#E6E7E7]/60">Served</dt>
-              <dd className="font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
-                {hub.metrics.communityMembersServed.toLocaleString()}
-              </dd>
-            </div>
-            <div>
-              <dt className="text-[#2F3332]/60 dark:text-[#E6E7E7]/60">Students</dt>
-              <dd className="font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
-                {hub.metrics.studentsTrained.toLocaleString()}
-              </dd>
-            </div>
-          </dl>
-
-          <Button
-            asChild
-            variant="link"
-            className="mt-6 h-auto w-fit justify-start p-0 text-base font-bold text-[#0097b2] hover:text-[#eeba2b] dark:text-[#66C4DC] dark:hover:text-[#F5C94D]"
-          >
-            <Link href={href} aria-label={`Learn more about ${hub.name}`}>
-              Learn More
-              <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
-            </Link>
-          </Button>
-        </CardContent>
-      </Card>
+        <EditorialArrowLink href={href} className="mt-6">
+          <span className="sr-only">{hub.name}: </span>
+          Learn More
+        </EditorialArrowLink>
+      </div>
     </article>
   );
 }

--- a/src/components/community-hubs/HubCardGrid.tsx
+++ b/src/components/community-hubs/HubCardGrid.tsx
@@ -1,20 +1,36 @@
 "use client";
 
 import { FadeIn, FadeInStagger, FadeInStaggerItem } from "@/components/animations";
-import { PublicSection, PublicSectionHeader } from "@/components/shared/PublicPagePrimitives";
-import { communityHubs } from "@/data/community-hubs";
 import HubCard from "@/components/community-hubs/HubCard";
+import {
+  EditorialBand,
+  EditorialEyebrow,
+  EditorialHeading,
+  EditorialLead,
+} from "@/components/shared/EditorialPrimitives";
+import { communityHubs } from "@/data/community-hubs";
 
 export default function HubCardGrid() {
   return (
-    <PublicSection tone="cream" spacing="normal" withTexture id="our-hubs">
+    <EditorialBand
+      tone="cream"
+      marker="03"
+      id="our-hubs"
+      aria-labelledby="our-hubs-heading"
+    >
       <FadeIn>
-        <PublicSectionHeader
-          eyebrow="Our Hubs"
-          title="Three Platforms, One Movement"
-          description="Explore Akomapa's active and in-development community health hubs across Ghana and the United States."
-          titleId="our-hubs-heading"
-        />
+        <div className="max-w-3xl">
+          <EditorialEyebrow className="text-[#0F4C5C] dark:text-[#66C4DC]">
+            Our Hubs
+          </EditorialEyebrow>
+          <EditorialHeading id="our-hubs-heading" className="mt-4">
+            Three Platforms, One Movement
+          </EditorialHeading>
+          <EditorialLead className="mt-5">
+            Explore Akomapa&apos;s active and in-development community health hubs
+            across Ghana and the United States.
+          </EditorialLead>
+        </div>
       </FadeIn>
 
       <FadeInStagger className="mt-12 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
@@ -24,6 +40,6 @@ export default function HubCardGrid() {
           </FadeInStaggerItem>
         ))}
       </FadeInStagger>
-    </PublicSection>
+    </EditorialBand>
   );
 }

--- a/src/components/community-hubs/HubDetailHero.tsx
+++ b/src/components/community-hubs/HubDetailHero.tsx
@@ -1,68 +1,70 @@
 "use client";
 
 import Image from "@/components/common/Image";
-import { MapPin } from "lucide-react";
 import { FadeIn } from "@/components/animations";
+import { getHubStatusLabel } from "@/components/community-hubs/hub-status";
+import {
+  EditorialBand,
+  EditorialEyebrow,
+  EditorialHeading,
+  EditorialLead,
+} from "@/components/shared/EditorialPrimitives";
 import type { CommunityHub } from "@/lib/types";
-
-const statusLabels = {
-  active: "Active",
-  "in-development": "In development",
-  planned: "Planned",
-  future: "Future",
-} as const;
 
 type HubDetailHeroProps = {
   hub: CommunityHub;
 };
 
 export default function HubDetailHero({ hub }: HubDetailHeroProps) {
-  return (
-    <section
-      className="relative overflow-hidden py-16 sm:py-20 md:py-24"
-      style={{
-        background: `linear-gradient(135deg, ${hub.color} 0%, #0F4C5C 100%)`,
-      }}
-      aria-labelledby="hub-detail-hero-heading"
-    >
-      <div className="site-container relative z-10 mx-auto px-4 sm:px-6">
-        <div className="grid items-center gap-10 lg:grid-cols-12 lg:gap-14">
-          <FadeIn className="lg:col-span-7">
-            <span className="inline-flex rounded-full bg-[#FCFAEF]/15 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-[#FCFAEF]">
-              {statusLabels[hub.status as keyof typeof statusLabels]}
-            </span>
-            <h1
-              id="hub-detail-hero-heading"
-              className="mt-4 text-3xl font-light leading-tight text-[#FCFAEF] sm:text-4xl md:text-5xl lg:text-6xl"
-            >
-              {hub.name}
-            </h1>
-            <div className="mt-4 flex items-start gap-2 text-[#FCFAEF]/85">
-              <MapPin className="mt-1 h-5 w-5 shrink-0" aria-hidden="true" />
-              <p className="text-base sm:text-lg">
-                {hub.location}, {hub.country}
-              </p>
-            </div>
-            <p className="mt-6 max-w-2xl text-base leading-relaxed text-[#FCFAEF]/85 sm:text-lg">
-              {hub.description}
-            </p>
-          </FadeIn>
+  const statusLabel = getHubStatusLabel(hub.status);
 
-          <FadeIn direction="left" delay={0.2} className="lg:col-span-5">
-            <div className="relative aspect-[4/3] overflow-hidden rounded-3xl border border-white/10 shadow-2xl">
-              <Image
-                src={hub.image}
-                alt={`${hub.name} community health hub`}
-                fill
-                priority
-                sizes="(min-width: 1024px) 42vw, 100vw"
-                className="object-cover"
-              />
-              <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-transparent" />
-            </div>
-          </FadeIn>
-        </div>
+  return (
+    <EditorialBand
+      tone="teal"
+      aria-labelledby="hub-detail-hero-heading"
+      className="border-b border-[#FCFAEF]/20 bg-[#0F4C5C]"
+      containerClassName="py-14 sm:py-16 md:py-20 lg:py-24"
+      data-hub-id={hub.id}
+      data-hub-status={hub.status}
+    >
+      <div className="grid gap-12 lg:grid-cols-12 lg:items-end lg:gap-16">
+        <FadeIn className="lg:col-span-7 lg:pb-8">
+          <EditorialEyebrow tone="gold" className="text-[#F5C94D]">
+            {statusLabel}
+          </EditorialEyebrow>
+          <EditorialHeading
+            as="h1"
+            id="hub-detail-hero-heading"
+            className="mt-5 max-w-4xl text-[2.35rem] text-[#FCFAEF] sm:text-[3rem] md:text-[3.5rem] lg:text-[4rem]"
+          >
+            {hub.name}
+          </EditorialHeading>
+          <p className="mt-4 text-base font-medium text-[#FCFAEF]/85 sm:text-lg">
+            {hub.location}, {hub.country}
+          </p>
+          <EditorialLead className="mt-6 max-w-2xl text-[#FCFAEF]/88 dark:text-[#FCFAEF]/88">
+            {hub.description}
+          </EditorialLead>
+        </FadeIn>
+
+        <FadeIn direction="left" delay={0.15} className="relative lg:col-span-5">
+          <span
+            aria-hidden="true"
+            className="absolute -top-3 left-0 z-10 h-1 w-24 md:w-36"
+            style={{ backgroundColor: hub.color }}
+          />
+          <div className="relative aspect-[4/3] overflow-hidden rounded-md border border-[#FCFAEF]/25 bg-[#0F4C5C]">
+            <Image
+              src={hub.image}
+              alt={`${hub.name} community health hub`}
+              fill
+              priority
+              sizes="(min-width: 1024px) 38vw, 100vw"
+              className="object-cover"
+            />
+          </div>
+        </FadeIn>
       </div>
-    </section>
+    </EditorialBand>
   );
 }

--- a/src/components/community-hubs/HubEmptyState.tsx
+++ b/src/components/community-hubs/HubEmptyState.tsx
@@ -1,0 +1,38 @@
+import {
+  EditorialButton,
+  EditorialHeading,
+  EditorialLead,
+} from "@/components/shared/EditorialPrimitives";
+
+type HubEmptyStateProps = {
+  title: string;
+  description: string;
+  cta: { label: string; href: string };
+  headingId?: string;
+};
+
+export default function HubEmptyState({
+  title,
+  description,
+  cta,
+  headingId,
+}: HubEmptyStateProps) {
+  return (
+    <div
+      data-hub-empty-state
+      className="max-w-2xl border-l-2 border-[#eeba2b] pl-6 sm:pl-8"
+    >
+      <EditorialHeading
+        as="h3"
+        id={headingId}
+        className="text-[1.35rem] md:text-[1.5rem] lg:text-[1.65rem]"
+      >
+        {title}
+      </EditorialHeading>
+      <EditorialLead className="mt-3">{description}</EditorialLead>
+      <EditorialButton href={cta.href} variant="solid" className="mt-6">
+        {cta.label}
+      </EditorialButton>
+    </div>
+  );
+}

--- a/src/components/community-hubs/HubInnovation.tsx
+++ b/src/components/community-hubs/HubInnovation.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { FadeIn, FadeInStagger, FadeInStaggerItem } from "@/components/animations";
+import HubEmptyState from "@/components/community-hubs/HubEmptyState";
 import {
-  PublicSection,
-  PublicSectionHeader,
-  PublicCta,
-  SurfaceCard,
-} from "@/components/shared/PublicPagePrimitives";
+  EditorialBand,
+  EditorialEyebrow,
+  EditorialHeading,
+} from "@/components/shared/EditorialPrimitives";
 import type { InnovationItem } from "@/lib/types";
 
 type EmptyState = {
@@ -30,48 +30,50 @@ export default function HubInnovation({ items = [], emptyState }: HubInnovationP
   const hasItems = items.length > 0;
 
   return (
-    <PublicSection tone="cream" spacing="normal" withTexture id="hub-innovation">
+    <EditorialBand
+      tone="cream"
+      marker="04"
+      id="hub-innovation"
+      aria-labelledby="hub-innovation-heading"
+    >
       <FadeIn>
-        <PublicSectionHeader
-          eyebrow="Innovation"
-          title="Testing What Works in Community Settings"
-          titleId="hub-innovation-heading"
-        />
+        <div className="max-w-3xl">
+          <EditorialEyebrow className="text-[#0F4C5C] dark:text-[#66C4DC]">
+            Innovation
+          </EditorialEyebrow>
+          <EditorialHeading id="hub-innovation-heading" className="mt-4">
+            Testing What Works in Community Settings
+          </EditorialHeading>
+        </div>
       </FadeIn>
 
       {hasItems ? (
-        <FadeInStagger className="mt-12 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        <FadeInStagger className="mt-12 grid gap-0 border-t border-[#1C1F1E]/15 md:grid-cols-2 lg:grid-cols-3 dark:border-[#FCFAEF]/20">
           {items.map((item) => (
             <FadeInStaggerItem key={item.id} direction="up">
-              <SurfaceCard className="h-full p-6">
-                <p className="text-xs font-semibold uppercase tracking-wide text-[#0097b2] dark:text-[#66C4DC]">
+              <article className="flex h-full flex-col border-b border-[#1C1F1E]/15 px-1 py-7 md:border-r md:px-6 dark:border-[#FCFAEF]/20">
+                <p className="font-subheading text-xs font-bold uppercase tracking-[0.2em] text-[#0097b2] dark:text-[#66C4DC]">
                   {categoryLabels[item.category]}
                 </p>
-                <h3 className="mt-2 text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+                <h3 className="mt-3 font-heading text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
                   {item.title}
                 </h3>
                 <p className="mt-3 text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
                   {item.description}
                 </p>
-              </SurfaceCard>
+              </article>
             </FadeInStaggerItem>
           ))}
         </FadeInStagger>
       ) : (
-        <FadeIn className="mt-12">
-          <SurfaceCard className="mx-auto max-w-3xl p-8 text-center">
-            <h3 className="text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
-              {emptyState.title}
-            </h3>
-            <p className="mt-3 text-base leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
-              {emptyState.description}
-            </p>
-            <PublicCta href={emptyState.cta.href} variant="teal" className="mt-6">
-              {emptyState.cta.label}
-            </PublicCta>
-          </SurfaceCard>
+        <FadeIn className="mt-10">
+          <HubEmptyState
+            title={emptyState.title}
+            description={emptyState.description}
+            cta={emptyState.cta}
+          />
         </FadeIn>
       )}
-    </PublicSection>
+    </EditorialBand>
   );
 }

--- a/src/components/community-hubs/HubMetrics.tsx
+++ b/src/components/community-hubs/HubMetrics.tsx
@@ -1,8 +1,13 @@
 "use client";
 
-import { FadeIn, FadeInStagger, FadeInStaggerItem } from "@/components/animations";
+import { FadeIn } from "@/components/animations";
 import { AnimatedMetric } from "@/components/motion/AnimatedMetric";
-import { PublicSection, PublicSectionHeader, SurfaceCard } from "@/components/shared/PublicPagePrimitives";
+import {
+  EditorialBand,
+  EditorialEyebrow,
+  EditorialHeading,
+  EditorialLead,
+} from "@/components/shared/EditorialPrimitives";
 import type { CommunityHub } from "@/lib/types";
 
 const metricConfig = [
@@ -10,45 +15,65 @@ const metricConfig = [
   { key: "studentsTrained" as const, label: "Students trained" },
   { key: "communitiesReached" as const, label: "Communities reached" },
   { key: "partnersEngaged" as const, label: "Partners engaged" },
-];
+] as const;
+
+const metricDividerClasses = [
+  "",
+  "border-t sm:border-l sm:border-t-0",
+  "border-t lg:border-l lg:border-t-0",
+  "border-t sm:border-l lg:border-l",
+] as const;
 
 type HubMetricsProps = {
   hub: CommunityHub;
 };
 
 export default function HubMetrics({ hub }: HubMetricsProps) {
+  const description =
+    hub.status === "in-development"
+      ? "This hub is in development. Metrics will grow as programs launch and community partnerships expand."
+      : "Key indicators of community reach, student leadership development, and partnership engagement at this hub.";
+
   return (
-    <PublicSection tone="cream" spacing="normal" withTexture id="hub-metrics">
+    <EditorialBand
+      tone="cream"
+      marker="01"
+      id="hub-metrics"
+      aria-labelledby="hub-metrics-heading"
+    >
       <FadeIn>
-        <PublicSectionHeader
-          eyebrow="Impact at a Glance"
-          title="Hub Metrics"
-          description={
-            hub.status === "in-development"
-              ? "This hub is in development. Metrics will grow as programs launch and community partnerships expand."
-              : "Key indicators of community reach, student leadership development, and partnership engagement at this hub."
-          }
-          titleId="hub-metrics-heading"
-        />
+        <div className="max-w-3xl">
+          <EditorialEyebrow className="text-[#0F4C5C] dark:text-[#66C4DC]">
+            Impact at a Glance
+          </EditorialEyebrow>
+          <EditorialHeading id="hub-metrics-heading" className="mt-4">
+            Hub Metrics
+          </EditorialHeading>
+          <EditorialLead className="mt-5">{description}</EditorialLead>
+        </div>
       </FadeIn>
 
-      <FadeInStagger className="mt-12 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
-        {metricConfig.map(({ key, label }) => (
-          <FadeInStaggerItem key={key} direction="up">
-            <SurfaceCard className="p-6 text-center">
-              <p
-                className="text-3xl font-bold sm:text-4xl"
-                style={{ color: hub.color }}
-              >
-                <AnimatedMetric value={hub.metrics[key]} />
-              </p>
-              <p className="mt-2 text-sm font-medium text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
-                {label}
-              </p>
-            </SurfaceCard>
-          </FadeInStaggerItem>
+      <dl
+        data-hub-metrics
+        className="mt-12 grid border-y border-[#1C1F1E]/15 sm:grid-cols-2 lg:grid-cols-4 dark:border-[#FCFAEF]/20"
+      >
+        {metricConfig.map(({ key, label }, index) => (
+          <div
+            key={key}
+            className={`flex min-h-36 flex-col justify-between border-[#1C1F1E]/15 px-1 py-7 sm:px-6 dark:border-[#FCFAEF]/20 ${metricDividerClasses[index]}`}
+          >
+            <dt className="font-subheading text-xs font-bold uppercase tracking-[0.2em] text-[#2F3332]/70 dark:text-[#E6E7E7]/70">
+              {label}
+            </dt>
+            <dd
+              className="mt-6 font-heading text-4xl font-semibold tracking-tight md:text-5xl"
+              style={{ color: hub.color }}
+            >
+              <AnimatedMetric value={hub.metrics[key]} />
+            </dd>
+          </div>
         ))}
-      </FadeInStagger>
-    </PublicSection>
+      </dl>
+    </EditorialBand>
   );
 }

--- a/src/components/community-hubs/HubResearch.tsx
+++ b/src/components/community-hubs/HubResearch.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import Link from "next/link";
 import { FadeIn, FadeInStagger, FadeInStaggerItem } from "@/components/animations";
+import HubEmptyState from "@/components/community-hubs/HubEmptyState";
 import {
-  PublicSection,
-  PublicSectionHeader,
-  PublicCta,
-  SurfaceCard,
-} from "@/components/shared/PublicPagePrimitives";
+  EditorialArrowLink,
+  EditorialBand,
+  EditorialEyebrow,
+  EditorialHeading,
+} from "@/components/shared/EditorialPrimitives";
 import type { ResearchItem } from "@/lib/types";
 
 type EmptyState = {
@@ -25,56 +25,55 @@ export default function HubResearch({ items = [], emptyState }: HubResearchProps
   const hasItems = items.length > 0;
 
   return (
-    <PublicSection tone="white" spacing="normal" id="hub-research">
+    <EditorialBand
+      tone="white"
+      marker="03"
+      id="hub-research"
+      aria-labelledby="hub-research-heading"
+    >
       <FadeIn>
-        <PublicSectionHeader
-          eyebrow="Research"
-          title="Evidence From the Community"
-          titleId="hub-research-heading"
-        />
+        <div className="max-w-3xl">
+          <EditorialEyebrow className="text-[#0F4C5C] dark:text-[#66C4DC]">
+            Research
+          </EditorialEyebrow>
+          <EditorialHeading id="hub-research-heading" className="mt-4">
+            Evidence From the Community
+          </EditorialHeading>
+        </div>
       </FadeIn>
 
       {hasItems ? (
-        <FadeInStagger className="mt-12 grid gap-6 md:grid-cols-2">
+        <FadeInStagger className="mt-12 grid gap-0 border-t border-[#1C1F1E]/15 md:grid-cols-2 dark:border-[#FCFAEF]/20">
           {items.map((item) => (
             <FadeInStaggerItem key={item.id} direction="up">
-              <SurfaceCard className="h-full p-6">
-                <p className="text-xs font-semibold uppercase tracking-wide text-[#0097b2] dark:text-[#66C4DC]">
+              <article className="flex h-full flex-col border-b border-[#1C1F1E]/15 px-1 py-7 md:border-r md:px-6 md:odd:border-r dark:border-[#FCFAEF]/20">
+                <p className="font-subheading text-xs font-bold uppercase tracking-[0.2em] text-[#0097b2] dark:text-[#66C4DC]">
                   {item.status}
                 </p>
-                <h3 className="mt-2 text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+                <h3 className="mt-3 font-heading text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
                   {item.title}
                 </h3>
-                <p className="mt-3 text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
+                <p className="mt-3 flex-1 text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
                   {item.description}
                 </p>
                 {item.link ? (
-                  <Link
-                    href={item.link}
-                    className="mt-4 inline-flex text-sm font-semibold text-[#0097b2] hover:text-[#eeba2b] dark:text-[#66C4DC]"
-                  >
+                  <EditorialArrowLink href={item.link} className="mt-4">
                     Explore the research
-                  </Link>
+                  </EditorialArrowLink>
                 ) : null}
-              </SurfaceCard>
+              </article>
             </FadeInStaggerItem>
           ))}
         </FadeInStagger>
       ) : (
-        <FadeIn className="mt-12">
-          <SurfaceCard className="mx-auto max-w-3xl p-8 text-center">
-            <h3 className="text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
-              {emptyState.title}
-            </h3>
-            <p className="mt-3 text-base leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
-              {emptyState.description}
-            </p>
-            <PublicCta href={emptyState.cta.href} variant="teal" className="mt-6">
-              {emptyState.cta.label}
-            </PublicCta>
-          </SurfaceCard>
+        <FadeIn className="mt-10">
+          <HubEmptyState
+            title={emptyState.title}
+            description={emptyState.description}
+            cta={emptyState.cta}
+          />
         </FadeIn>
       )}
-    </PublicSection>
+    </EditorialBand>
   );
 }

--- a/src/components/community-hubs/HubsHero.tsx
+++ b/src/components/community-hubs/HubsHero.tsx
@@ -2,51 +2,56 @@
 
 import Image from "@/components/common/Image";
 import { FadeIn } from "@/components/animations";
+import {
+  EditorialBand,
+  EditorialEyebrow,
+  EditorialHeading,
+  EditorialLead,
+} from "@/components/shared/EditorialPrimitives";
 import { communityHubsListing } from "@/data/community-hubs";
 
 export default function HubsHero() {
   return (
-    <section
-      className="relative overflow-hidden bg-gradient-to-r from-[#0097b2] to-[#0F4C5C] py-16 sm:py-20 md:py-28"
+    <EditorialBand
+      tone="teal"
       aria-labelledby="community-hubs-hero-heading"
+      className="border-b border-[#FCFAEF]/20 bg-[#0F4C5C]"
+      containerClassName="py-14 sm:py-16 md:py-20 lg:py-24"
     >
-      <div className="pointer-events-none absolute inset-0 overflow-hidden">
-        <div className="absolute -top-24 right-0 h-64 w-64 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
-        <div className="absolute bottom-0 -left-24 h-96 w-96 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
-      </div>
+      <div className="grid gap-12 lg:grid-cols-12 lg:items-end lg:gap-16">
+        <FadeIn className="lg:col-span-7 lg:pb-8">
+          <EditorialEyebrow tone="gold" className="text-[#F5C94D]">
+            Community Learning & Care
+          </EditorialEyebrow>
+          <EditorialHeading
+            as="h1"
+            id="community-hubs-hero-heading"
+            className="mt-5 max-w-4xl text-[2.35rem] text-[#FCFAEF] sm:text-[3rem] md:text-[3.7rem] lg:text-[4.35rem]"
+          >
+            {communityHubsListing.headline}
+          </EditorialHeading>
+          <EditorialLead className="mt-7 max-w-3xl text-[#FCFAEF]/88 dark:text-[#FCFAEF]/88">
+            {communityHubsListing.subheadline}
+          </EditorialLead>
+        </FadeIn>
 
-      <div className="site-container relative z-10 mx-auto px-4 sm:px-6">
-        <div className="flex flex-col gap-12 lg:flex-row lg:items-center lg:gap-16">
-          <FadeIn className="max-w-3xl flex-1">
-            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#F5C94D] sm:text-sm">
-              Community Learning & Care
-            </p>
-            <h1
-              id="community-hubs-hero-heading"
-              className="mt-4 text-3xl font-light leading-tight text-[#FCFAEF] sm:text-4xl md:text-5xl lg:text-6xl xl:text-7xl"
-            >
-              {communityHubsListing.headline}
-            </h1>
-            <p className="mt-6 max-w-2xl text-base leading-relaxed text-[#FCFAEF]/85 sm:text-lg md:text-xl">
-              {communityHubsListing.subheadline}
-            </p>
-          </FadeIn>
-
-          <FadeIn direction="left" delay={0.2} className="w-full lg:max-w-md xl:max-w-lg">
-            <div className="relative h-[280px] w-full overflow-hidden rounded-3xl border border-white/10 shadow-2xl sm:h-[360px] md:h-[420px] lg:h-[480px]">
-              <Image
-                src="/highlights/Akomapa-62.jpg"
-                alt="Akomapa community health hub volunteers serving community members"
-                fill
-                priority
-                sizes="(min-width: 1024px) 40vw, 100vw"
-                className="object-cover"
-              />
-              <div className="absolute inset-0 bg-gradient-to-t from-black/35 via-transparent to-transparent" />
-            </div>
-          </FadeIn>
-        </div>
+        <FadeIn direction="left" delay={0.15} className="relative lg:col-span-5">
+          <span
+            aria-hidden="true"
+            className="absolute -top-3 left-0 z-10 h-1 w-24 bg-[#eeba2b] md:w-36"
+          />
+          <div className="relative aspect-[4/3] overflow-hidden rounded-md border border-[#FCFAEF]/25 bg-[#0F4C5C] lg:aspect-[4/5]">
+            <Image
+              src="/highlights/Akomapa-62.jpg"
+              alt="Akomapa community health hub volunteers serving community members"
+              fill
+              priority
+              sizes="(min-width: 1024px) 38vw, 100vw"
+              className="object-cover"
+            />
+          </div>
+        </FadeIn>
       </div>
-    </section>
+    </EditorialBand>
   );
 }

--- a/src/components/community-hubs/MentorshipSection.tsx
+++ b/src/components/community-hubs/MentorshipSection.tsx
@@ -3,10 +3,11 @@
 import Image from "@/components/common/Image";
 import { FadeIn, FadeInStagger, FadeInStaggerItem } from "@/components/animations";
 import {
-  PublicSection,
-  PublicSectionHeader,
-  SurfaceCard,
-} from "@/components/shared/PublicPagePrimitives";
+  EditorialBand,
+  EditorialEyebrow,
+  EditorialHeading,
+  EditorialLead,
+} from "@/components/shared/EditorialPrimitives";
 import type { MentorshipInfo } from "@/lib/types";
 import { getTeamMemberBySlug } from "@/data/team";
 
@@ -24,22 +25,30 @@ export default function MentorshipSection({ mentorship }: MentorshipSectionProps
     .filter((member) => member !== undefined);
 
   return (
-    <PublicSection tone="cream" spacing="normal" withTexture id="faculty-mentorship">
+    <EditorialBand
+      tone="cream"
+      marker="02"
+      id="faculty-mentorship"
+      aria-labelledby="faculty-mentorship-heading"
+    >
       <FadeIn>
-        <PublicSectionHeader
-          eyebrow="Faculty Mentorship"
-          title="Expert Supervision, Ethical Practice"
-          description={mentorship.model}
-          titleId="faculty-mentorship-heading"
-        />
+        <div className="max-w-3xl">
+          <EditorialEyebrow className="text-[#0F4C5C] dark:text-[#66C4DC]">
+            Faculty Mentorship
+          </EditorialEyebrow>
+          <EditorialHeading id="faculty-mentorship-heading" className="mt-4">
+            Expert Supervision, Ethical Practice
+          </EditorialHeading>
+          <EditorialLead className="mt-5">{mentorship.model}</EditorialLead>
+        </div>
       </FadeIn>
 
       {mentors.length > 0 ? (
-        <FadeInStagger className="mt-12 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        <FadeInStagger className="mt-12 grid gap-0 border-t border-[#1C1F1E]/15 md:grid-cols-2 lg:grid-cols-3 dark:border-[#FCFAEF]/20">
           {mentors.map((mentor) => (
             <FadeInStaggerItem key={mentor.slug ?? mentor.id} direction="up">
-              <SurfaceCard className="h-full overflow-hidden">
-                <div className="relative aspect-[4/3] w-full">
+              <article className="flex h-full flex-col border-b border-[#1C1F1E]/15 dark:border-[#FCFAEF]/20 md:border-r md:last:border-r-0">
+                <div className="relative aspect-[4/3] w-full overflow-hidden bg-[#0F4C5C]/10">
                   <Image
                     src={mentor.image}
                     alt={mentor.name}
@@ -48,8 +57,8 @@ export default function MentorshipSection({ mentorship }: MentorshipSectionProps
                     className="object-cover"
                   />
                 </div>
-                <div className="p-6">
-                  <h3 className="text-lg font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+                <div className="flex flex-1 flex-col px-1 py-6 md:px-6">
+                  <h3 className="font-heading text-lg font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
                     {mentor.name}
                   </h3>
                   <p className="mt-1 text-sm font-medium text-[#0097b2] dark:text-[#66C4DC]">
@@ -59,11 +68,11 @@ export default function MentorshipSection({ mentorship }: MentorshipSectionProps
                     {mentor.bio}
                   </p>
                 </div>
-              </SurfaceCard>
+              </article>
             </FadeInStaggerItem>
           ))}
         </FadeInStagger>
       ) : null}
-    </PublicSection>
+    </EditorialBand>
   );
 }

--- a/src/components/community-hubs/StoriesSection.tsx
+++ b/src/components/community-hubs/StoriesSection.tsx
@@ -1,12 +1,11 @@
 "use client";
 
 import { FadeIn, FadeInStagger, FadeInStaggerItem } from "@/components/animations";
+import HubEmptyState from "@/components/community-hubs/HubEmptyState";
 import {
-  PublicSection,
-  PublicSectionHeader,
-  PublicCta,
-  SurfaceCard,
-} from "@/components/shared/PublicPagePrimitives";
+  EditorialBand,
+  EditorialHeading,
+} from "@/components/shared/EditorialPrimitives";
 import type { Story } from "@/lib/types";
 
 type EmptyState = {
@@ -29,49 +28,48 @@ export default function StoriesSection({
   sectionId,
 }: StoriesSectionProps) {
   const hasStories = stories.length > 0;
+  const headingId = `${sectionId}-heading`;
 
   return (
-    <PublicSection tone="white" spacing="normal" id={sectionId}>
+    <EditorialBand
+      tone="white"
+      id={sectionId}
+      aria-labelledby={headingId}
+    >
       <FadeIn>
-        <PublicSectionHeader title={title} titleId={`${sectionId}-heading`} />
+        <EditorialHeading id={headingId}>{title}</EditorialHeading>
       </FadeIn>
 
       {hasStories ? (
-        <FadeInStagger className="mt-12 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        <FadeInStagger className="mt-12 grid gap-0 border-t border-[#1C1F1E]/15 md:grid-cols-2 lg:grid-cols-3 dark:border-[#FCFAEF]/20">
           {stories.map((story) => (
             <FadeInStaggerItem key={story.id} direction="up">
-              <SurfaceCard className="h-full p-6">
-                <p className="text-xs font-semibold uppercase tracking-wide text-[#0097b2] dark:text-[#66C4DC]">
+              <article className="flex h-full flex-col border-b border-[#1C1F1E]/15 px-1 py-7 md:border-r md:px-6 md:last:border-r-0 dark:border-[#FCFAEF]/20">
+                <p className="font-subheading text-xs font-bold uppercase tracking-[0.2em] text-[#0097b2] dark:text-[#66C4DC]">
                   {story.role}
                 </p>
-                <h3 className="mt-2 text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+                <h3 className="mt-3 font-heading text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
                   {story.title}
                 </h3>
-                <p className="mt-3 text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
+                <p className="mt-3 flex-1 text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
                   {story.excerpt}
                 </p>
                 <p className="mt-4 text-sm font-medium text-[#2F3332] dark:text-[#E6E7E7]">
                   — {story.author}
                 </p>
-              </SurfaceCard>
+              </article>
             </FadeInStaggerItem>
           ))}
         </FadeInStagger>
       ) : (
-        <FadeIn className="mt-12">
-          <SurfaceCard className="mx-auto max-w-3xl p-8 text-center">
-            <h3 className="text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
-              {emptyState.title}
-            </h3>
-            <p className="mt-3 text-base leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
-              {emptyState.description}
-            </p>
-            <PublicCta href={emptyState.cta.href} variant="teal" className="mt-6">
-              {emptyState.cta.label}
-            </PublicCta>
-          </SurfaceCard>
+        <FadeIn className="mt-10">
+          <HubEmptyState
+            title={emptyState.title}
+            description={emptyState.description}
+            cta={emptyState.cta}
+          />
         </FadeIn>
       )}
-    </PublicSection>
+    </EditorialBand>
   );
 }

--- a/src/components/community-hubs/WhyHubsMatter.tsx
+++ b/src/components/community-hubs/WhyHubsMatter.tsx
@@ -1,40 +1,61 @@
 "use client";
 
-import { FadeIn, FadeInStagger, FadeInStaggerItem } from "@/components/animations";
+import { FadeIn } from "@/components/animations";
 import {
-  PublicSection,
-  PublicSectionHeader,
-  SurfaceCard,
-} from "@/components/shared/PublicPagePrimitives";
+  EditorialBand,
+  EditorialEyebrow,
+  EditorialHeading,
+  EditorialLead,
+} from "@/components/shared/EditorialPrimitives";
 import { whyHubsMatter } from "@/data/community-hubs";
 
 export default function WhyHubsMatter() {
   return (
-    <PublicSection tone="teal" spacing="normal" id="why-hubs-matter">
+    <EditorialBand
+      tone="teal"
+      marker="04"
+      id="why-hubs-matter"
+      aria-labelledby="why-hubs-matter-heading"
+    >
       <FadeIn>
-        <PublicSectionHeader
-          eyebrow="Why Our Hubs Matter"
-          title="More Than a Place to Receive Care"
-          description="Our hubs strengthen communities, develop ethical leaders, generate evidence, and pilot innovations that can scale."
-          titleId="why-hubs-matter-heading"
-          eyebrowTone="gold"
-          titleClassName="text-[#FCFAEF]"
-          descriptionClassName="text-[#FCFAEF]/85"
-        />
+        <div className="max-w-3xl">
+          <EditorialEyebrow tone="gold" className="text-[#F5C94D]">
+            Why Our Hubs Matter
+          </EditorialEyebrow>
+          <EditorialHeading
+            id="why-hubs-matter-heading"
+            className="mt-4 text-[#FCFAEF]"
+          >
+            More Than a Place to Receive Care
+          </EditorialHeading>
+          <EditorialLead className="mt-5 text-[#FCFAEF]/85 dark:text-[#FCFAEF]/85">
+            Our hubs strengthen communities, develop ethical leaders, generate
+            evidence, and pilot innovations that can scale.
+          </EditorialLead>
+        </div>
       </FadeIn>
 
-      <FadeInStagger className="mt-12 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
-        {whyHubsMatter.map((item) => (
-          <FadeInStaggerItem key={item.id} direction="up">
-            <SurfaceCard className="h-full border-[#FCFAEF]/15 bg-[#FCFAEF]/10 p-6 text-[#FCFAEF] backdrop-blur-sm">
-              <h3 className="text-lg font-semibold">{item.title}</h3>
-              <p className="mt-3 text-sm leading-relaxed text-[#FCFAEF]/85">
-                {item.description}
-              </p>
-            </SurfaceCard>
-          </FadeInStaggerItem>
+      <ol className="mt-12 grid border-t border-[#FCFAEF]/25 md:grid-cols-2 xl:grid-cols-5">
+        {whyHubsMatter.map((item, index) => (
+          <li
+            key={item.id}
+            className="border-b border-[#FCFAEF]/25 px-1 py-7 md:odd:border-r md:px-6 xl:border-r xl:px-5 xl:last:border-r-0"
+          >
+            <span
+              aria-hidden="true"
+              className="font-heading text-4xl font-semibold tracking-[-0.06em] text-[#FCFAEF]/45"
+            >
+              {String(index + 1).padStart(2, "0")}
+            </span>
+            <h3 className="mt-5 font-heading text-lg font-semibold text-[#FCFAEF]">
+              {item.title}
+            </h3>
+            <p className="mt-3 text-sm leading-relaxed text-[#FCFAEF]/85">
+              {item.description}
+            </p>
+          </li>
         ))}
-      </FadeInStagger>
-    </PublicSection>
+      </ol>
+    </EditorialBand>
   );
 }

--- a/src/components/community-hubs/__tests__/CommunityHubsEditorial.test.tsx
+++ b/src/components/community-hubs/__tests__/CommunityHubsEditorial.test.tsx
@@ -1,0 +1,199 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import CommunityHubDetailPage from "@/components/community-hubs/CommunityHubDetailPage";
+import FiveMissions from "@/components/community-hubs/FiveMissions";
+import HubActivities from "@/components/community-hubs/HubActivities";
+import HubCard from "@/components/community-hubs/HubCard";
+import HubCardGrid from "@/components/community-hubs/HubCardGrid";
+import HubMetrics from "@/components/community-hubs/HubMetrics";
+import HubsHero from "@/components/community-hubs/HubsHero";
+import WhyHubsMatter from "@/components/community-hubs/WhyHubsMatter";
+import { getHubStatusLabel } from "@/components/community-hubs/hub-status";
+import {
+  communityHubs,
+  communityHubsListing,
+  getHubHref,
+  hubActivities,
+  hubEmptyStates,
+  hubMissions,
+  whyHubsMatter,
+} from "@/data/community-hubs";
+
+describe("Community hubs listing editorial sections", () => {
+  it("renders a single flat hero heading with approved copy and image", () => {
+    render(<HubsHero />);
+
+    const heading = screen.getByRole("heading", {
+      level: 1,
+      name: communityHubsListing.headline,
+    });
+    const hero = heading.closest("section");
+
+    expect(hero).toHaveAttribute("data-editorial-tone", "teal");
+    expect(hero?.className).not.toContain("gradient");
+    expect(screen.getByText(communityHubsListing.subheadline)).toBeVisible();
+    expect(
+      screen.getByRole("img", {
+        name: /community health hub volunteers serving community members/i,
+      }),
+    ).toBeVisible();
+  });
+
+  it("presents the five missions as one ordered model without card surfaces", () => {
+    render(<FiveMissions />);
+
+    const section = screen.getByRole("region", {
+      name: "What Our Hubs Are Built to Do",
+    });
+    const list = section.querySelector("ol");
+    expect(list).not.toBeNull();
+
+    const items = within(section).getAllByRole("listitem");
+    expect(items).toHaveLength(hubMissions.length);
+    expect(items.map((item) => within(item).getByRole("heading", { level: 3 }).textContent)).toEqual(
+      hubMissions.map((mission) => mission.title),
+    );
+    expect(section.querySelector("[data-slot='card']")).toBeNull();
+  });
+
+  it("keeps hub activities scannable and correctly ordered", () => {
+    render(<HubActivities />);
+
+    const section = screen.getByRole("region", {
+      name: "Learning, Care, and Partnership in Action",
+    });
+    const items = within(section).getAllByRole("listitem");
+    expect(items).toHaveLength(hubActivities.length);
+    expect(items.map((item) => within(item).getByRole("heading", { level: 3 }).textContent)).toEqual(
+      hubActivities.map((activity) => activity.title),
+    );
+    expect(section.querySelector("[data-slot='card']")).toBeNull();
+  });
+
+  it("exposes hub location, status text, and accessible destination links", () => {
+    render(<HubCardGrid />);
+
+    const cards = screen.getAllByTestId("community-hub-card");
+    expect(cards).toHaveLength(communityHubs.length);
+
+    for (const hub of communityHubs) {
+      const card = cards.find((node) => node.getAttribute("data-hub-id") === hub.id);
+      expect(card).toBeDefined();
+      expect(card).toHaveAttribute("data-hub-status", hub.status);
+      expect(within(card!).getByText(getHubStatusLabel(hub.status))).toBeVisible();
+      expect(
+        within(card!).getByText((_, element) => {
+          return (
+            element?.tagName === "P" &&
+            (element.textContent ?? "").includes(hub.location) &&
+            (element.textContent ?? "").includes(hub.country)
+          );
+        }),
+      ).toBeVisible();
+      expect(
+        within(card!).getByRole("link", { name: new RegExp(hub.name) }),
+      ).toHaveAttribute("href", getHubHref(hub));
+    }
+  });
+
+  it("renders the value proposition as numbered editorial rows", () => {
+    render(<WhyHubsMatter />);
+
+    const section = screen.getByRole("region", {
+      name: "More Than a Place to Receive Care",
+    });
+    expect(section).toHaveAttribute("data-editorial-tone", "teal");
+    expect(within(section).getAllByRole("listitem")).toHaveLength(whyHubsMatter.length);
+    expect(section.querySelector("[data-slot='card']")).toBeNull();
+  });
+});
+
+describe("Community hub detail editorial system", () => {
+  it.each(communityHubs)(
+    "preserves approved data and semantic metrics for $name",
+    (hub) => {
+      render(<CommunityHubDetailPage hub={hub} />);
+
+      expect(
+        screen.getByRole("heading", { level: 1, name: hub.name }),
+      ).toBeVisible();
+      expect(screen.getByText(getHubStatusLabel(hub.status))).toBeVisible();
+      expect(
+        screen.getByText((_, element) => {
+          return (
+            element?.tagName === "P" &&
+            (element.textContent ?? "").includes(hub.location) &&
+            (element.textContent ?? "").includes(hub.country)
+          );
+        }),
+      ).toBeVisible();
+      expect(screen.getByText(hub.description)).toBeVisible();
+
+      const metrics = document.querySelector("[data-hub-metrics]");
+      expect(metrics?.tagName).toBe("DL");
+      expect(metrics?.querySelectorAll("dt")).toHaveLength(4);
+      expect(metrics?.querySelectorAll("dd")).toHaveLength(4);
+      expect(screen.getByText("Community members served")).toBeVisible();
+      expect(screen.getByText("Students trained")).toBeVisible();
+      expect(screen.getByText("Communities reached")).toBeVisible();
+      expect(screen.getByText("Partners engaged")).toBeVisible();
+
+      if (hub.status === "in-development") {
+        expect(
+          screen.getByText(/This hub is in development/i),
+        ).toBeVisible();
+      }
+
+      expect(screen.getByText(hub.facultyMentorship!.model)).toBeVisible();
+      expect(screen.getByText(hubEmptyStates.communityStories.title)).toBeVisible();
+      expect(screen.getByText(hubEmptyStates.studentStories.title)).toBeVisible();
+      expect(screen.getByText(hubEmptyStates.research.title)).toBeVisible();
+      expect(screen.getByText(hubEmptyStates.innovation.title)).toBeVisible();
+
+      expect(
+        screen.getByRole("link", {
+          name: hubEmptyStates.communityStories.cta.label,
+        }),
+      ).toHaveAttribute("href", hubEmptyStates.communityStories.cta.href);
+      expect(
+        screen.getByRole("link", {
+          name: hubEmptyStates.studentStories.cta.label,
+        }),
+      ).toHaveAttribute("href", hubEmptyStates.studentStories.cta.href);
+      expect(
+        screen.getByRole("link", {
+          name: hubEmptyStates.research.cta.label,
+        }),
+      ).toHaveAttribute("href", hubEmptyStates.research.cta.href);
+      expect(
+        screen.getByRole("link", {
+          name: hubEmptyStates.innovation.cta.label,
+        }),
+      ).toHaveAttribute("href", hubEmptyStates.innovation.cta.href);
+
+      expect(document.querySelectorAll("h1")).toHaveLength(1);
+      expect(document.querySelector("[data-slot='card']")).toBeNull();
+    },
+  );
+
+  it("keeps hub accent color on metric values only", () => {
+    const hub = communityHubs[0];
+    render(<HubMetrics hub={hub} />);
+
+    const values = document.querySelectorAll("[data-hub-metrics] dd");
+    expect(values).toHaveLength(4);
+    for (const value of values) {
+      expect(value).toHaveStyle({ color: hub.color });
+    }
+  });
+
+  it("renders a single hub card with navigational accessible name", () => {
+    const hub = communityHubs[0];
+    render(<HubCard hub={hub} />);
+
+    expect(
+      screen.getByRole("link", { name: new RegExp(hub.name) }),
+    ).toHaveAttribute("href", getHubHref(hub));
+    expect(screen.getByText(getHubStatusLabel(hub.status))).toBeVisible();
+  });
+});

--- a/src/components/community-hubs/hub-status.ts
+++ b/src/components/community-hubs/hub-status.ts
@@ -1,0 +1,12 @@
+import type { CommunityHub } from "@/lib/types";
+
+export const hubStatusLabels = {
+  active: "Active",
+  "in-development": "In development",
+  planned: "Planned",
+  future: "Future",
+} as const satisfies Record<CommunityHub["status"], string>;
+
+export function getHubStatusLabel(status: CommunityHub["status"]): string {
+  return hubStatusLabels[status];
+}

--- a/src/components/theme/ThemeProvider.tsx
+++ b/src/components/theme/ThemeProvider.tsx
@@ -22,6 +22,31 @@ const initialState: ThemeProviderState = {
 
 const ThemeProviderContext = createContext<ThemeProviderState>(initialState)
 
+function resolveTheme(theme: Theme): "dark" | "light" {
+  if (theme === "system") {
+    return window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light"
+  }
+  return theme
+}
+
+function applyThemeClass(theme: Theme) {
+  const root = window.document.documentElement
+  const resolved = resolveTheme(theme)
+
+  // Avoid remove-then-add flashes. Stripping `dark`/`light` even briefly
+  // retriggers global color transitions and can make contrast checks read
+  // intermediate computed colors (e.g. rgb(103, 104, 100)).
+  if (root.classList.contains(resolved)) {
+    root.classList.remove(resolved === "dark" ? "light" : "dark")
+    return
+  }
+
+  root.classList.remove("light", "dark")
+  root.classList.add(resolved)
+}
+
 export function ThemeProvider({
   children,
   defaultTheme = "system",
@@ -40,29 +65,16 @@ export function ThemeProvider({
   })
 
   useEffect(() => {
-    const root = window.document.documentElement
-    
-    // Remove the class first
-    root.classList.remove("light", "dark")
-
-    if (theme === "system") {
-      const systemTheme = window.matchMedia("(prefers-color-scheme: dark)")
-        .matches
-        ? "dark"
-        : "light"
-        
-      root.classList.add(systemTheme)
-      return
-    }
-
-    root.classList.add(theme)
+    applyThemeClass(theme)
   }, [theme])
 
   const value = {
     theme,
-    setTheme: (theme: Theme) => {
-      localStorage.setItem(storageKey, theme)
-      setTheme(theme)
+    setTheme: (nextTheme: Theme) => {
+      localStorage.setItem(storageKey, nextTheme)
+      // Apply immediately so the class is correct before paint, then sync state.
+      applyThemeClass(nextTheme)
+      setTheme(nextTheme)
     },
   }
 
@@ -75,9 +87,9 @@ export function ThemeProvider({
 
 export const useTheme = () => {
   const context = useContext(ThemeProviderContext)
-  
+
   if (context === undefined)
     throw new Error("useTheme must be used within a ThemeProvider")
-  
+
   return context
 }


### PR DESCRIPTION
## Summary
- Migrates `/community-hubs` and UCC/UG/NHP detail routes onto the shared editorial system from #179/#180 (`EditorialBand`, typography, CTAs) while preserving approved hub facts, statuses, metrics, stories, empty states, and route behavior.
- Replaces gradient heroes, glow decoration, icon-card grids, and frosted panels with flat cream/white/teal/deep-teal bands, numbered border-led lists, semantic metric definition lists, and intentional empty-state callouts.
- Keeps one data-driven `CommunityHubDetailPage` for all three hubs; hub accent colors are used sparingly (preview top rule + metric values) so each location stays place-specific without a separate design system.

Closes #181  
Related: #179

## Test plan
- [x] `nvm use 22`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (includes `CommunityHubsEditorial` coverage for all hub variants)
- [x] `npm run build`
- [x] `npx playwright test e2e/community-hubs.spec.ts e2e/community-hubs-editorial.spec.ts --project=chromium`
- [x] Responsive + typography suites for `/community-hubs`
- [x] Spot-check light/dark on listing + UCC/UG/NHP at 390 / 768 / 1280
- [x] Confirm Active / In development / Future status text remains clear without relying on color
- [x] Keyboard-tab hub Learn More links and empty-state CTAs; verify focus rings
- [x] Confirm legacy `/clinics*` redirects still land on `/community-hubs*`