### PR TITLE
Design academy programs and roadmap pages

### DIFF
--- a/e2e/academy-programs-roadmap-editorial.spec.ts
+++ b/e2e/academy-programs-roadmap-editorial.spec.ts
@@ -1,0 +1,271 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+import { announcementCampaign } from "../src/data/announcements";
+import { academyCurriculum, academyOverview } from "../src/data/academy";
+import { LEADERSHIP_APP_FORM_URL } from "../src/config/links";
+import { phases } from "../src/components/roadmap/phases";
+
+const routes = [
+  "/academy",
+  "/programs",
+  "/programs/akomapa-foods",
+  "/programs/akomapa-ghltp",
+  "/programs/akomapa-network",
+  "/programs/akomapa-young-advocates",
+  "/roadmap",
+] as const;
+
+const viewports = [
+  { name: "mobile-390", width: 390, height: 844 },
+  { name: "boundary-640", width: 640, height: 900 },
+  { name: "tablet-768", width: 768, height: 1024 },
+  { name: "boundary-900", width: 900, height: 1024 },
+  { name: "ipad-pro-1024", width: 1024, height: 1366 },
+  { name: "laptop-1280", width: 1280, height: 800 },
+  { name: "desktop-1440", width: 1440, height: 900 },
+  { name: "wide-1536", width: 1536, height: 960 },
+] as const;
+
+const themes = ["light", "dark"] as const;
+
+async function preparePage(page: Page, theme: (typeof themes)[number]) {
+  await page.addInitScript(
+    ({ version, storedTheme }) => {
+      localStorage.setItem("akomapa-announcements-dismissed", version);
+      localStorage.setItem("akomapa-theme", storedTheme);
+      document.documentElement.classList.remove("light", "dark");
+      document.documentElement.classList.add(storedTheme);
+
+      const style = document.createElement("style");
+      style.textContent =
+        "*,*::before,*::after{transition-duration:0s!important;animation-duration:0s!important}";
+      document.documentElement.append(style);
+    },
+    { version: announcementCampaign.version, storedTheme: theme },
+  );
+}
+
+async function expectNoOverflow(page: Page) {
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => document.documentElement.scrollWidth <= window.innerWidth + 1,
+      ),
+    )
+    .toBe(true);
+}
+
+async function expectElementInViewport(locator: Locator) {
+  const contained = await locator.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    return rect.left >= -1 && rect.right <= window.innerWidth + 1;
+  });
+  expect(contained).toBe(true);
+}
+
+for (const viewport of viewports) {
+  for (const theme of themes) {
+    test(`${viewport.name} · ${theme} · Academy/Programs/Roadmap editorial contracts`, async ({
+      page,
+    }) => {
+      test.setTimeout(90_000);
+      await preparePage(page, theme);
+      await page.setViewportSize(viewport);
+
+      for (const route of routes) {
+        await page.goto(route, { waitUntil: "domcontentloaded" });
+        await expect(page.locator("main h1")).toHaveCount(1);
+        await expectElementInViewport(page.locator("main h1"));
+        await expectNoOverflow(page);
+
+        const bands = page.locator("[data-editorial-band]");
+        await expect(bands.first()).toBeVisible();
+
+        const standaloneControls = page.locator(
+          "[data-editorial-band] a, [data-editorial-band] button",
+        );
+        const undersized = await standaloneControls.evaluateAll((controls) =>
+          controls
+            .filter((control) => {
+              const style = getComputedStyle(control);
+              const rect = control.getBoundingClientRect();
+              return (
+                style.display !== "none" &&
+                style.visibility !== "hidden" &&
+                (rect.width < 44 || rect.height < 44)
+              );
+            })
+            .map((control) => control.textContent?.trim() ?? control.tagName),
+        );
+        expect(undersized).toEqual([]);
+      }
+    });
+  }
+}
+
+test("academy preserves curriculum order, certification, and apply destination", async ({
+  page,
+}) => {
+  await preparePage(page, "light");
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto("/academy", { waitUntil: "domcontentloaded" });
+
+  await expect(
+    page.getByRole("heading", { level: 1, name: "Akomapa Academy" }),
+  ).toBeVisible();
+  await expect(page.getByText(academyOverview.title)).toBeVisible();
+  await expect(
+    page.getByText(academyCurriculum.totalDuration, { exact: true }),
+  ).toBeVisible();
+
+  const moduleTitles = await page
+    .locator("#curriculum ol > li h3")
+    .allTextContents();
+  expect(moduleTitles).toEqual(
+    academyCurriculum.modules.map((module) => module.title),
+  );
+
+  await expect(
+    page.getByRole("heading", {
+      name: academyCurriculum.certificationName,
+    }),
+  ).toBeVisible();
+
+  await expect(
+    page.getByRole("link", { name: /Become a Scholar/i }).first(),
+  ).toHaveAttribute("href", LEADERSHIP_APP_FORM_URL);
+});
+
+test("programs listing preserves destinations and impact labels", async ({
+  page,
+}) => {
+  await preparePage(page, "light");
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto("/programs", { waitUntil: "domcontentloaded" });
+
+  await expect(
+    page.getByRole("link", { name: /Explore Akomapa Clinics/i }),
+  ).toHaveAttribute("href", "/community-hubs");
+  await expect(
+    page.getByRole("link", { name: /Discover the Akomapa Network/i }),
+  ).toHaveAttribute("href", "/programs/akomapa-network");
+  await expect(
+    page.getByRole("link", { name: /Join the Leadership Program/i }),
+  ).toHaveAttribute("href", "/programs/akomapa-ghltp");
+  await expect(
+    page.getByRole("link", { name: /Join the Akomapa Young Advocates/i }),
+  ).toHaveAttribute("href", "/programs/akomapa-young-advocates");
+  await expect(
+    page.getByRole("link", { name: /Discover the Akomapa Foods & Stores/i }),
+  ).toHaveAttribute("href", "/programs/akomapa-foods");
+
+  await expect(
+    page.getByText("Students Trained", { exact: true }),
+  ).toBeVisible();
+  await expect(
+    page.getByText("Partner Clinics", { exact: true }),
+  ).toBeVisible();
+  await expect(page.getByText("Global Mentors", { exact: true })).toBeVisible();
+});
+
+test("GHLTP preserves mentor CTA, facts, and carousel region", async ({
+  page,
+}) => {
+  await preparePage(page, "light");
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto("/programs/akomapa-ghltp", { waitUntil: "domcontentloaded" });
+
+  await expect(
+    page.getByRole("link", { name: /Become a Mentor/i }).first(),
+  ).toHaveAttribute("href", "/contact");
+  await expect(
+    page.getByRole("link", { name: /Download Program Overview/i }),
+  ).toHaveAttribute("href", "/programs");
+  await expect(page.locator("[data-program-fact-summary]")).toHaveCount(1);
+  await expect(
+    page.getByRole("region", { name: "Participant testimonial carousel" }),
+  ).toBeVisible();
+});
+
+test("roadmap preserves phase chronology and CTA destinations", async ({
+  page,
+}) => {
+  await preparePage(page, "light");
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto("/roadmap", { waitUntil: "domcontentloaded" });
+
+  for (const phase of phases) {
+    await expect(page.getByText(phase.title).first()).toBeVisible();
+    await expect(page.getByText(phase.period).first()).toBeVisible();
+    await expect(page.locator(`#phase-${phase.id}`)).toBeVisible();
+  }
+
+  const ctaRegion = page.getByRole("region", {
+    name: "Help us bring this vision to life",
+  });
+  await expect(
+    ctaRegion.getByRole("link", { name: /Partner With Us/i }),
+  ).toHaveAttribute("href", "/partnerships");
+  await expect(
+    ctaRegion.getByRole("link", { name: /^Donate$/i }),
+  ).toHaveAttribute("href", "/partnerships");
+  await expect(
+    ctaRegion.getByRole("link", { name: /Contact Us/i }),
+  ).toHaveAttribute("href", "mailto:akomapahealth@gmail.com");
+});
+
+test("keeps akomapa-ghip redirect unchanged", async ({ page }) => {
+  const response = await page.goto("/programs/akomapa-ghip", {
+    waitUntil: "domcontentloaded",
+  });
+  expect(response?.status()).toBeLessThan(400);
+  await expect(page).toHaveURL(/\/global-health-immersion-program$/);
+});
+
+test("supports reduced motion and narrow reflow across family routes", async ({
+  browser,
+}) => {
+  const context = await browser.newContext({
+    reducedMotion: "reduce",
+    colorScheme: "light",
+    viewport: { width: 720, height: 900 },
+  });
+  const page = await context.newPage();
+  await preparePage(page, "light");
+
+  for (const width of [720, 390]) {
+    await page.setViewportSize({ width, height: 900 });
+    for (const route of routes) {
+      await page.goto(route, { waitUntil: "domcontentloaded" });
+      await expectNoOverflow(page);
+      await expect(page.locator("main h1")).toBeVisible();
+    }
+  }
+
+  await context.close();
+});
+
+test("preserves visible keyboard focus on program listing CTA", async ({
+  page,
+}) => {
+  await preparePage(page, "dark");
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto("/programs", { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle");
+
+  const cta = page
+    .getByRole("link", { name: /Explore Akomapa Clinics/i })
+    .first();
+  await cta.focus();
+  await expect(cta).toBeFocused();
+
+  const focusStyle = await cta.evaluate((element) => {
+    const style = getComputedStyle(element);
+    return {
+      boxShadow: style.boxShadow,
+      outlineStyle: style.outlineStyle,
+    };
+  });
+  expect(
+    focusStyle.boxShadow !== "none" || focusStyle.outlineStyle !== "none",
+  ).toBe(true);
+});

--- a/src/app/(main)/programs/Content.tsx
+++ b/src/app/(main)/programs/Content.tsx
@@ -1,142 +1,138 @@
-import { MotionDiv, MotionH1, MotionP } from "@/components/motion/framer";
-import { AnimatedMetric } from "@/components/motion/AnimatedMetric";
 import Image from "@/components/common/Image";
-import { ArrowRight, Globe, GraduationCap, Building, ChevronsDown, Sparkles, Sprout } from "lucide-react";
-import Link from "next/link";
+import { FadeIn, FadeInStagger, FadeInStaggerItem } from "@/components/animations";
+import { AnimatedMetric } from "@/components/motion/AnimatedMetric";
 import Breadcrumb from "@/components/layout/Breadcrumb";
-import { Button } from "@/components/ui/button";
+import {
+  EditorialBand,
+  EditorialButton,
+  EditorialEyebrow,
+  EditorialHeading,
+  EditorialLead,
+} from "@/components/shared/EditorialPrimitives";
 
-// Program Data
 interface Program {
   id: number;
   title: string;
   description: string;
   details: string[];
   href: string;
-  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
-  color: string;
-  bgGradient: string;
   image: string;
   alt: string;
   features?: string[];
+  ctaLabel: string;
 }
 
 const programs: Program[] = [
   {
     id: 1,
     title: "Akomapa Clinics",
-    description: "We establish interprofessional, expert-supervised clinics built in partnership with local health authorities, traditional leaders, and community members. These student-powered community health hubs deliver free, community-based care focused on the early detection and management of non-communicable diseases (NCDs), serving as both real-world classrooms for students and lifelines for underserved communities.",
+    description:
+      "We establish interprofessional, expert-supervised clinics built in partnership with local health authorities, traditional leaders, and community members. These student-powered community health hubs deliver free, community-based care focused on the early detection and management of non-communicable diseases (NCDs), serving as both real-world classrooms for students and lifelines for underserved communities.",
     details: [
       "Interprofessional student teams coordinate care across medical, nursing, pharmacy, nutrition, and public health disciplines",
       "Expert supervision ensures every patient encounter meets the highest clinical and ethical standards",
       "Community-rooted model transforms trusted spaces into care hubs accessible to families",
-      "Free services focus on NCD screening, counseling, and referrals with cultural sensitivity"
+      "Free services focus on NCD screening, counseling, and referrals with cultural sensitivity",
     ],
     href: "/community-hubs",
-    icon: Building,
-    color: "#0097b2",
-    bgGradient: "from-[#0097b2]/10 to-[#0097b2]/5",
     image: "/highlights/Akomapa-28.jpg",
     alt: "Akomapa clinic team providing community healthcare",
     features: [
       "Community-Based Care",
       "Student Leadership",
       "Expert Supervision",
-      "Local Partnership"
-    ]
+      "Local Partnership",
+    ],
+    ctaLabel: "Explore Akomapa Clinics",
   },
   {
     id: 2,
     title: "The Akomapa Network",
-    description: "Our global community of practice connects Akomapa chapters with partner student-powered clinics around the world—like SHAWCO, South Side SRFC, and Yale's Neighborhood Health Project—to share best practices, mentorship, and collaborative research. Together, we're turning local innovations into global impact.",
+    description:
+      "Our global community of practice connects Akomapa chapters with partner student-powered clinics around the world—like SHAWCO, South Side SRFC, and Yale's Neighborhood Health Project—to share best practices, mentorship, and collaborative research. Together, we're turning local innovations into global impact.",
     details: [
       "Connects student-powered clinics across continents to share innovations and learnings",
       "Facilitates mentorship exchanges between experienced and emerging clinic leaders",
       "Enables collaborative research that strengthens evidence for student-powered care",
-      "Builds a global movement of health professionals committed to equity and access"
+      "Builds a global movement of health professionals committed to equity and access",
     ],
     href: "/programs/akomapa-network",
-    icon: Globe,
-    color: "#eeba2b",
-    bgGradient: "from-[#eeba2b]/10 to-[#eeba2b]/5",
     image: "/highlights/Akomapa-40.jpg",
     alt: "Global network of student healthcare leaders",
     features: [
       "Global Community",
       "Knowledge Sharing",
       "Mentorship Exchange",
-      "Collaborative Research"
-    ]
+      "Collaborative Research",
+    ],
+    ctaLabel: "Discover the Akomapa Network",
   },
   {
     id: 3,
     title: "Global Health Leadership Training Program",
-    description: "We equip emerging health leaders with the skills, ethics, and cross-cultural experience needed to drive equitable change. Through expert-led courses, interactive seminars, and global mentorship, students learn to merge clinical care with leadership and systems thinking.",
+    description:
+      "We equip emerging health leaders with the skills, ethics, and cross-cultural experience needed to drive equitable change. Through expert-led courses, interactive seminars, and global mentorship, students learn to merge clinical care with leadership and systems thinking.",
     details: [
       "Intensive leadership curriculum combining classroom learning with hands-on rotations",
       "Expert-led courses on ethics, cultural humility, and systems thinking",
       "Interactive seminars with global health leaders from Yale, UCLA, and University of Cape Coast",
-      "Mentorship program connecting students with experienced practitioners worldwide"
+      "Mentorship program connecting students with experienced practitioners worldwide",
     ],
     href: "/programs/akomapa-ghltp",
-    icon: GraduationCap,
-    color: "#0097b2",
-    bgGradient: "from-[#0097b2]/10 to-[#0097b2]/5",
     image: "/highlights/Akomapa-66.jpg",
     alt: "Students participating in leadership training",
     features: [
       "Leadership Development",
       "Expert Mentorship",
       "Cross-Cultural Training",
-      "Systems Thinking"
-    ]
+      "Systems Thinking",
+    ],
+    ctaLabel: "Join the Leadership Program",
   },
   {
     id: 4,
     title: "Akomapa Young Advocates",
-    description: "The Akomapa Young Advocates Program is a youth empowerment and health education initiative that brings community health, mentorship, and leadership development directly to high schools. Led by interprofessional university health professional students trained through Akomapa clinics, the program equips young people with practical knowledge about non-communicable diseases (NCDs) such as hypertension and diabetes, mental wellness, and preventive health so they can become champions of healthy living and positive change in their schools and communities.",
+    description:
+      "The Akomapa Young Advocates Program is a youth empowerment and health education initiative that brings community health, mentorship, and leadership development directly to high schools. Led by interprofessional university health professional students trained through Akomapa clinics, the program equips young people with practical knowledge about non-communicable diseases (NCDs) such as hypertension and diabetes, mental wellness, and preventive health so they can become champions of healthy living and positive change in their schools and communities.",
     details: [
       "Interactive health education sessions delivered directly in high schools by trained student mentors",
       "Practical knowledge about non-communicable diseases (NCDs), stress management, and preventive health measures",
       "Ongoing mentorship that nurtures the next generation of ethical, community-minded leaders",
-      "Bridges education and action, empowering youth to become health champions in their communities"
+      "Bridges education and action, empowering youth to become health champions in their communities",
     ],
     href: "/programs/akomapa-young-advocates",
-    icon: Sparkles,
-    color: "#0097b2",
-    bgGradient: "from-[#0097b2]/10 to-[#0097b2]/5",
     image: "/highlights/Akomapa-40.jpg",
     alt: "Young advocates participating in health education",
     features: [
       "Youth Empowerment",
       "Health Education",
       "Mentorship",
-      "Leadership Development"
-    ]
+      "Leadership Development",
+    ],
+    ctaLabel: "Join the Akomapa Young Advocates",
   },
   {
     id: 5,
     title: "Akomapa Foods & Stores",
-    description: "The Akomapa Foods & Stores Initiative is the sustainability arm of the Akomapa Health model—connecting food security, economic empowerment, and healthcare access into one self-sustaining ecosystem. We believe that health doesn't start in hospitals; it starts in homes, kitchens, and markets. By linking agriculture and nutrition to our student-powered community health hubs, Akomapa creates a cycle where communities not only receive care but also co-own the means to sustain it.",
+    description:
+      "The Akomapa Foods & Stores Initiative is the sustainability arm of the Akomapa Health model—connecting food security, economic empowerment, and healthcare access into one self-sustaining ecosystem. We believe that health doesn't start in hospitals; it starts in homes, kitchens, and markets. By linking agriculture and nutrition to our student-powered community health hubs, Akomapa creates a cycle where communities not only receive care but also co-own the means to sustain it.",
     details: [
       "Community farms and food stores that make healthy, affordable food accessible to families",
       "Revenue from food sales directly supports clinic operations, creating a self-sustaining model",
       "Addresses food insecurity while promoting nutrition and reducing long-term health complications",
-      "Economic empowerment that strengthens local economies and builds community ownership"
+      "Economic empowerment that strengthens local economies and builds community ownership",
     ],
     href: "/programs/akomapa-foods",
-    icon: Sprout,
-    color: "#eeba2b",
-    bgGradient: "from-[#eeba2b]/10 to-[#eeba2b]/5",
     image: "/highlights/Akomapa-19.jpg",
     alt: "Community farm and food store initiative",
     features: [
       "Food Security",
       "Economic Empowerment",
       "Self-Sustaining Model",
-      "Community Ownership"
-    ]
-  }
+      "Community Ownership",
+    ],
+    ctaLabel: "Discover the Akomapa Foods & Stores",
+  },
 ];
 
 const impactMetrics = [
@@ -144,30 +140,37 @@ const impactMetrics = [
     value: 1000,
     suffix: "+",
     label: "Students Trained",
-    description: "Emerging health leaders equipped with skills to transform healthcare systems",
-    color: "#0097b2"
+    description:
+      "Emerging health leaders equipped with skills to transform healthcare systems",
   },
   {
     value: 15,
     suffix: "+",
     label: "Partner Clinics",
-    description: "Student-powered clinics connected through the Akomapa Network worldwide",
-    color: "#eeba2b"
+    description:
+      "Student-powered clinics connected through the Akomapa Network worldwide",
   },
   {
     value: 6,
     label: "Programs & Initiatives",
-    description: "Comprehensive programs working together to deliver holistic healthcare",
-    color: "#0097b2"
+    description:
+      "Comprehensive programs working together to deliver holistic healthcare",
   },
   {
     value: 50,
     suffix: "+",
     label: "Global Mentors",
-    description: "Expert practitioners guiding the next generation of health leaders",
-    color: "#eeba2b"
-  }
-];
+    description:
+      "Expert practitioners guiding the next generation of health leaders",
+  },
+] as const;
+
+const metricDividerClasses = [
+  "",
+  "border-t sm:border-l sm:border-t-0",
+  "border-t lg:border-l lg:border-t-0",
+  "border-t sm:border-l lg:border-l",
+] as const;
 
 export default function Content() {
   return (
@@ -175,286 +178,250 @@ export default function Content() {
       <div className="site-container mx-auto">
         <Breadcrumb />
       </div>
-      <div className="flex flex-col gap-y-section-mobile md:gap-y-section-tablet lg:gap-y-section-desktop">
-        {/* Hero Section */}
-        <section className="relative min-h-screen py-16 sm:py-20 md:py-28 bg-gradient-to-r from-[#0097b2] to-[#0F4C5C] overflow-hidden">
-        <div className="absolute top-0 right-0 w-64 h-64 bg-[#FCFAEF]/10 rounded-full -translate-y-1/2 translate-x-1/2 blur-3xl" />
-        <div className="absolute bottom-0 left-0 w-96 h-96 bg-[#FCFAEF]/10 rounded-full translate-y-1/2 -translate-x-1/2 blur-3xl" />
-        
-        <div className="site-container mx-auto px-4 sm:px-6 relative z-10 h-full flex flex-col gap-12 sm:gap-14">
-          <div className="max-w-5xl pt-4 sm:pt-8">
-            <MotionH1 
-              initial={{ opacity: 0, y: 40 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.8, ease: "easeOut" }}
-              className="text-3xl sm:text-4xl md:text-6xl lg:text-7xl font-light text-[#FCFAEF] mb-6 leading-tight"
+
+      <EditorialBand
+        tone="teal"
+        aria-labelledby="programs-hero-heading"
+        className="border-b border-[#FCFAEF]/20 bg-[#0F4C5C]"
+        containerClassName="py-14 sm:py-16 md:py-20 lg:py-24"
+      >
+        <div className="grid gap-12 lg:grid-cols-12 lg:items-end lg:gap-16">
+          <FadeIn className="lg:col-span-7 lg:pb-4">
+            <EditorialEyebrow tone="gold" className="text-[#F5C94D]">
+              Programs
+            </EditorialEyebrow>
+            <EditorialHeading
+              as="h1"
+              id="programs-hero-heading"
+              className="mt-5 max-w-4xl text-[2.35rem] text-[#FCFAEF] sm:text-[3rem] md:text-[3.7rem] lg:text-[4.35rem]"
             >
               Students. Communities. Partnerships. One Vision for Health.
-            </MotionH1>
-            <MotionP 
-              initial={{ opacity: 0, y: 40 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.15, duration: 0.8, ease: "easeOut" }}
-              className="text-base sm:text-lg md:text-2xl text-[#FCFAEF]/80 font-light max-w-3xl"
-            >
-              At Akomapa, we&apos;re reimagining how the next generation of health professionals learn, lead, and serve. Through our integrated programs, we build student-powered community health hubs, leadership pathways, and global partnerships that make care more accessible—while preparing students to transform the health systems of tomorrow.
-            </MotionP>
-          </div>
+            </EditorialHeading>
+            <EditorialLead className="mt-7 max-w-3xl text-[#FCFAEF]/88 dark:text-[#FCFAEF]/88">
+              At Akomapa, we&apos;re reimagining how the next generation of
+              health professionals learn, lead, and serve. Through our
+              integrated programs, we build student-powered community health
+              hubs, leadership pathways, and global partnerships that make care
+              more accessible—while preparing students to transform the health
+              systems of tomorrow.
+            </EditorialLead>
+          </FadeIn>
 
-          <MotionDiv
-            initial={{ opacity: 0, y: 40 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.3, duration: 0.8, ease: "easeOut" }}
-            className="flex-1 w-full"
-          >
-            <div className="relative w-full h-[280px] sm:h-[360px] md:h-[520px] lg:h-[640px] rounded-3xl overflow-hidden shadow-2xl border border-white/10">
+          <FadeIn direction="left" delay={0.15} className="relative lg:col-span-5">
+            <span
+              aria-hidden="true"
+              className="absolute -top-3 left-0 z-10 h-1 w-24 bg-[#eeba2b] md:w-36"
+            />
+            <div className="relative aspect-[4/3] overflow-hidden rounded-md border border-[#FCFAEF]/25 bg-[#0F4C5C] lg:aspect-[4/5]">
               <Image
                 src="/highlights/Akomapa-47.jpg"
                 alt="Akomapa programs and initiatives"
                 fill
-                sizes="(min-width: 1024px) 50vw, 100vw"
+                priority
+                sizes="(min-width: 1024px) 38vw, 100vw"
                 className="object-cover"
               />
-              <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-transparent" />
-              <div className="absolute -top-6 left-6 sm:left-8">
-                <div className="relative w-20 h-20">
-                  <div className="absolute inset-0 bg-[#0F4C5C] rounded-full" />
-                  <div className="absolute inset-2 bg-gradient-to-br from-[#66C4DC] via-[#0097b2] to-[#0F4C5C] rounded-full opacity-30" />
-                  <div className="absolute inset-0 flex items-center justify-center text-[#FCFAEF]">
-                    <ChevronsDown className="w-8 h-8" />
-                  </div>
-                  <div className="absolute -bottom-5 inset-x-6 h-7 bg-[#0F4C5C] rounded-b-full" />
-                </div>
-              </div>
             </div>
-          </MotionDiv>
+          </FadeIn>
         </div>
-        </section>
+      </EditorialBand>
 
-        {/* Programs Section */}
-        <section className="py-16 md:py-24 bg-[#FCFAEF] dark:bg-[#1C1F1E]">
-        <div className="site-container mx-auto px-4">
-          <div className="max-w-4xl mx-auto text-center mb-12 sm:mb-16">
-            <MotionDiv
-              initial={{ opacity: 0, y: 40 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.8, ease: "easeOut" }}
-              viewport={{ once: true }}
-            >
-              <h2 className="text-[#F5C94D] font-bold text-base sm:text-lg mb-2">
-                OUR PROGRAMS
-              </h2>
-              <h2 className="text-2xl sm:text-3xl md:text-4xl font-bold mb-4 sm:mb-6 text-[#1C1F1E] dark:text-[#FCFAEF]">
-                Integrated Pathways for Impact
-              </h2>
-              <p className="text-base sm:text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed max-w-3xl mx-auto px-4 sm:px-0">
-                Each program is designed to build upon the others, creating a comprehensive ecosystem that prepares students, serves communities, and transforms healthcare systems.
-              </p>
-            </MotionDiv>
+      <EditorialBand
+        tone="cream"
+        marker="01"
+        id="programs-list"
+        aria-labelledby="programs-list-heading"
+      >
+        <FadeIn>
+          <div className="max-w-3xl">
+            <EditorialEyebrow className="text-[#0F4C5C] dark:text-[#66C4DC]">
+              Our Programs
+            </EditorialEyebrow>
+            <EditorialHeading id="programs-list-heading" className="mt-4">
+              Integrated Pathways for Impact
+            </EditorialHeading>
+            <EditorialLead className="mt-5">
+              Each program is designed to build upon the others, creating a
+              comprehensive ecosystem that prepares students, serves
+              communities, and transforms healthcare systems.
+            </EditorialLead>
           </div>
+        </FadeIn>
 
-          <div className="space-y-12 sm:space-y-16 lg:space-y-24">
-            {programs.map((program, index) => (
-              <MotionDiv
-                key={program.id}
-                initial={{ opacity: 0, y: 60 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.8, delay: index * 0.1, ease: "easeOut" }}
-                viewport={{ once: true }}
-              >
-                <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-16 items-center">
-                  <div className={`${index % 2 === 0 ? "order-1" : "order-1 lg:order-2"} w-full h-full`}>
-                    <div className="relative w-full min-h-[320px] h-[320px] sm:h-[360px] md:h-[420px] lg:h-[450px] xl:h-[500px] rounded-3xl overflow-hidden shadow-xl group">
+        <ol className="mt-12 space-y-0 border-t border-[#1C1F1E]/15 dark:border-[#FCFAEF]/20">
+          {programs.map((program, index) => (
+            <li
+              key={program.id}
+              className="border-b border-[#1C1F1E]/15 py-12 dark:border-[#FCFAEF]/20 lg:py-16"
+            >
+              <FadeIn>
+                <div className="grid items-start gap-8 lg:grid-cols-12 lg:gap-12">
+                  <div
+                    className={`relative lg:col-span-5 ${
+                      index % 2 === 1 ? "lg:order-2" : "lg:order-1"
+                    }`}
+                  >
+                    <span
+                      aria-hidden="true"
+                      className="absolute -top-3 left-0 z-10 h-1 w-16 bg-[#eeba2b]"
+                    />
+                    <div className="relative aspect-[4/3] overflow-hidden rounded-md border border-[#1C1F1E]/10 bg-[#E6E7E7] dark:border-[#FCFAEF]/15 dark:bg-[#2F3332]">
                       <Image
                         src={program.image}
                         alt={program.alt}
                         fill
-                        sizes="(min-width: 1024px) 50vw, 100vw"
-                        className="object-cover group-hover:scale-110 transition-transform duration-700"
+                        sizes="(min-width: 1024px) 40vw, 100vw"
+                        className="object-cover"
                       />
-                      <div className="absolute inset-0 bg-gradient-to-t from-black/25 via-transparent to-transparent" />
-                      <div className="absolute top-4 left-4">
-                        <div 
-                          className="w-16 h-16 rounded-2xl flex items-center justify-center shadow-lg backdrop-blur-sm bg-white/90 dark:bg-[#2F3332]/90"
-                          style={{ border: `2px solid ${program.color}30` }}
-                        >
-                          <program.icon className="h-8 w-8" style={{ color: program.color }} />
-                        </div>
-                      </div>
                     </div>
                   </div>
-                  <div className={`${index % 2 === 0 ? "order-2" : "order-2 lg:order-1"} h-full flex flex-col justify-center`}>
-                    <div className="flex items-center gap-2 mb-4">
-                      <div className="h-1 w-8 rounded-full" style={{ backgroundColor: program.color }} />
-                      <div className="h-1 w-1 rounded-full" style={{ backgroundColor: program.color }} />
-                    </div>
-                    <h3 className="text-xl sm:text-2xl md:text-3xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF] mb-4">
+
+                  <div
+                    className={`lg:col-span-7 ${
+                      index % 2 === 1 ? "lg:order-1" : "lg:order-2"
+                    }`}
+                  >
+                    <span
+                      aria-hidden="true"
+                      className="font-heading text-3xl font-semibold tracking-[-0.06em] text-[#0097b2]/55 dark:text-[#66C4DC]/65"
+                    >
+                      {String(index + 1).padStart(2, "0")}
+                    </span>
+                    <h3 className="mt-3 font-heading text-2xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF] md:text-3xl">
                       {program.title}
                     </h3>
-                    <p className="text-sm sm:text-base text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed mb-6 max-w-xl">
+                    <p className="mt-4 max-w-2xl text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80 md:text-base">
                       {program.description}
                     </p>
-                    
-                    {program.features && (
-                      <div className="grid grid-cols-2 gap-2 sm:gap-3 mb-6">
-                        {program.features.map((feature, featureIndex) => (
-                          <div
-                            key={featureIndex}
-                            className={`bg-gradient-to-br ${program.bgGradient} dark:bg-[#2F3332] rounded-lg p-2 sm:p-3 border border-[#E6E7E7]/20 dark:border-[#4F5554]/20`}
+
+                    {program.features ? (
+                      <ul className="mt-5 flex flex-wrap gap-x-4 gap-y-2">
+                        {program.features.map((feature) => (
+                          <li
+                            key={feature}
+                            className="font-subheading text-xs font-bold uppercase tracking-[0.15em] text-[#0F4C5C] dark:text-[#66C4DC]"
                           >
-                            <p className="text-xs sm:text-sm font-medium text-[#1C1F1E] dark:text-[#FCFAEF]">
-                              {feature}
-                            </p>
-                          </div>
+                            {feature}
+                          </li>
                         ))}
-                      </div>
-                    )}
+                      </ul>
+                    ) : null}
 
-                    <div className="space-y-3 text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed max-w-xl mb-6">
-                      {program.details.slice(0, 2).map((detail, detailIndex) => (
-                        <p key={detailIndex} className="text-sm md:text-base">{detail}</p>
+                    <ul className="mt-6 max-w-2xl space-y-3 border-t border-[#1C1F1E]/10 pt-5 dark:border-[#FCFAEF]/15">
+                      {program.details.slice(0, 2).map((detail) => (
+                        <li
+                          key={detail}
+                          className="text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80 md:text-base"
+                        >
+                          {detail}
+                        </li>
                       ))}
-                    </div>
+                    </ul>
 
-                    <Button
-                      asChild
-                      className="w-full sm:w-auto bg-[#0097b2] hover:bg-[#0097b2]/80 text-[#FCFAEF] group"
-                    >
-                      <Link href={program.href} className="flex items-center justify-center">
-                        {program.id === 1
-                          ? "Explore Akomapa Clinics"
-                          : program.id === 2
-                            ? "Discover the Akomapa Network"
-                            : program.id === 3
-                              ? "Join the Leadership Program"
-                              : program.id === 4
-                                ? "Join the Akomapa Young Advocates"
-                                : program.id === 5
-                                  ? "Discover the Akomapa Foods & Stores"
-                                  : "Learn More"}
-                        <ArrowRight className="ml-2 h-4 w-4 group-hover:translate-x-1 transition-transform" />
-                      </Link>
-                    </Button>
+                    <div className="mt-7">
+                      <EditorialButton href={program.href} variant="solid">
+                        {program.ctaLabel}
+                      </EditorialButton>
+                    </div>
                   </div>
                 </div>
-              </MotionDiv>
-            ))}
-          </div>
-        </div>
-        </section>
+              </FadeIn>
+            </li>
+          ))}
+        </ol>
+      </EditorialBand>
 
-        {/* Impact Section */}
-        <section className="py-16 md:py-24 bg-gradient-to-r from-[#0097b2] to-[#0F4C5C] text-[#FCFAEF] relative overflow-hidden">
-        <div className="absolute inset-0 pointer-events-none">
-          <div className="absolute -top-24 -left-24 h-64 w-64 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
-          <div className="absolute bottom-0 right-0 h-80 w-80 rounded-full bg-[#F5C94D]/10 blur-3xl" />
-        </div>
-
-        <div className="relative site-container mx-auto px-4">
-          <div className="text-center max-w-3xl mx-auto mb-12 space-y-4">
-            <p className="text-sm font-semibold tracking-[0.2em] text-[#F5C94D] uppercase">
+      <EditorialBand
+        tone="teal"
+        marker="02"
+        id="programs-impact"
+        aria-labelledby="programs-impact-heading"
+        className="bg-[#0F4C5C]"
+      >
+        <FadeIn>
+          <div className="max-w-3xl">
+            <EditorialEyebrow tone="gold" className="text-[#F5C94D]">
               Our Impact
-            </p>
-            <h2 className="text-3xl md:text-4xl font-bold text-[#FCFAEF] leading-tight">
-              Building a Movement, One Program at a Time
-            </h2>
-            <p className="text-base sm:text-lg text-[#FCFAEF]/85 leading-relaxed">
-              Our programs work together to create lasting change—training leaders, connecting communities, and transforming healthcare systems worldwide.
-            </p>
-          </div>
-
-          <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-6 md:gap-8">
-            {impactMetrics.map((metric, index) => (
-              <MotionDiv
-                key={metric.label}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: index * 0.1 }}
-                viewport={{ once: true, amount: 0.4 }}
-                className="group relative rounded-2xl bg-[#FCFAEF]/95 text-[#1C1F1E] shadow-xl border border-[#E6E7E7]/40 overflow-hidden p-6 md:p-8 flex flex-col hover:scale-105 transition-transform duration-300"
-              >
-                <div className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300 bg-gradient-to-br from-[#0097b2]/10 via-transparent to-[#F5C94D]/15" />
-                <div className="relative flex flex-col h-full">
-                  <AnimatedMetric
-                  value={metric.value}
-                  suffix={metric.suffix ?? ""}
-                  className="text-4xl md:text-5xl font-semibold tracking-tight"
-                  style={{ color: metric.color }}
-                />
-                  <h3 className="mt-4 text-xl font-semibold uppercase tracking-[0.3em] text-[#1C1F1E] mb-3">
-                    {metric.label}
-                  </h3>
-                  <p className="text-sm md:text-base text-[#2F3332]/85 leading-relaxed flex-1">
-                    {metric.description}
-                  </p>
-                </div>
-              </MotionDiv>
-            ))}
-          </div>
-        </div>
-        </section>
-
-        {/* Call to Action */}
-        <section className="py-16 md:py-24 bg-gradient-to-r from-[#0097b2] via-[#0F4C5C] to-[#0B2F3A] text-[#FCFAEF] relative overflow-hidden">
-        <div className="absolute inset-0 pointer-events-none">
-          <div className="absolute -top-28 -left-32 h-72 w-72 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
-          <div className="absolute bottom-0 right-0 h-80 w-80 rounded-full bg-[#F5C94D]/10 blur-3xl" />
-        </div>
-
-        <div className="relative site-container mx-auto px-4 sm:px-6">
-          <div className="text-center max-w-4xl mx-auto">
-            <MotionDiv
-              initial={{ opacity: 0, y: 24 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6 }}
-              viewport={{ once: true, amount: 0.4 }}
-              className="space-y-6"
+            </EditorialEyebrow>
+            <EditorialHeading
+              id="programs-impact-heading"
+              className="mt-4 text-[#FCFAEF]"
             >
-              <div>
-                <p className="text-sm font-semibold tracking-[0.2em] text-[#F5C94D] uppercase mb-4">
-                  Get Involved
-                </p>
-                <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-6 text-[#FCFAEF] leading-tight">
-                  Be Part of the Movement
-                </h2>
-              </div>
-              <p className="text-base sm:text-lg md:text-xl text-[#FCFAEF]/85 leading-relaxed max-w-3xl mx-auto">
-                Your support powers every program. Whether through financial contributions, in-kind donations, or strategic partnerships—there&apos;s a place for you at Akomapa.
-              </p>
-              <MotionDiv
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: 0.2 }}
-                viewport={{ once: true }}
-                className="flex flex-col sm:flex-row items-center justify-center gap-4 sm:gap-6 pt-6"
-              >
-                <Button
-                  asChild
-                  size="lg"
-                  className="group bg-[#FCFAEF] text-[#0097b2] hover:bg-[#F5C94D] hover:text-[#1C1F1E] px-6 sm:px-8 py-6 h-auto text-base sm:text-lg font-semibold shadow-lg hover:shadow-xl transition-all duration-300 transform hover:scale-105"
-                >
-                  <Link href="/partnerships" className="flex items-center whitespace-nowrap">
-                    Partner with Us
-                    <ArrowRight className="h-5 w-5 ml-2 group-hover:translate-x-1 transition-transform" />
-                  </Link>
-                </Button>
-                <Button
-                  asChild
-                  size="lg"
-                  variant="outline"
-                  className="group border-2 border-[#FCFAEF] text-[#FCFAEF] bg-transparent hover:bg-[#FCFAEF] hover:text-[#0097b2] px-6 sm:px-8 py-6 h-auto text-base sm:text-lg font-semibold transition-all duration-300 transform hover:scale-105"
-                >
-                  <Link href="mailto:akomapahealth@gmail.com" className="flex items-center">
-                    Contact Us
-                    <ArrowRight className="h-5 w-5 ml-2 group-hover:translate-x-1 transition-transform" />
-                  </Link>
-                </Button>
-              </MotionDiv>
-            </MotionDiv>
+              Building a Movement, One Program at a Time
+            </EditorialHeading>
+            <EditorialLead className="mt-5 text-[#FCFAEF]/85 dark:text-[#FCFAEF]/85">
+              Our programs work together to create lasting change—training
+              leaders, connecting communities, and transforming healthcare
+              systems worldwide.
+            </EditorialLead>
           </div>
-        </div>
-        </section>
-      </div>
+        </FadeIn>
+
+        <FadeInStagger className="mt-12">
+          <dl className="grid border-y border-[#FCFAEF]/25 sm:grid-cols-2 lg:grid-cols-4">
+            {impactMetrics.map((metric, index) => (
+              <FadeInStaggerItem key={metric.label} direction="up">
+                <div
+                  className={`flex min-h-40 flex-col justify-between px-1 py-7 sm:px-6 ${metricDividerClasses[index]} border-[#FCFAEF]/25`}
+                >
+                  <dt className="font-subheading text-xs font-bold uppercase tracking-[0.2em] text-[#FCFAEF]/70">
+                    {metric.label}
+                  </dt>
+                  <dd className="mt-6">
+                    <AnimatedMetric
+                      value={metric.value}
+                      suffix={"suffix" in metric ? metric.suffix : ""}
+                      className="font-heading text-4xl font-semibold tracking-tight text-[#FCFAEF] md:text-5xl"
+                    />
+                    <p className="mt-3 text-sm leading-relaxed text-[#FCFAEF]/80">
+                      {metric.description}
+                    </p>
+                  </dd>
+                </div>
+              </FadeInStaggerItem>
+            ))}
+          </dl>
+        </FadeInStagger>
+      </EditorialBand>
+
+      <EditorialBand
+        tone="teal"
+        marker="03"
+        id="programs-cta"
+        aria-labelledby="programs-cta-heading"
+        className="border-t border-[#FCFAEF]/15 bg-[#0F4C5C]"
+      >
+        <FadeIn>
+          <div className="mx-auto max-w-3xl text-center">
+            <EditorialEyebrow tone="gold" className="text-[#F5C94D]">
+              Get Involved
+            </EditorialEyebrow>
+            <EditorialHeading
+              id="programs-cta-heading"
+              className="mt-4 text-[#FCFAEF]"
+            >
+              Be Part of the Movement
+            </EditorialHeading>
+            <EditorialLead className="mx-auto mt-6 max-w-2xl text-[#FCFAEF]/85 dark:text-[#FCFAEF]/85">
+              Your support powers every program. Whether through financial
+              contributions, in-kind donations, or strategic partnerships—there&apos;s
+              a place for you at Akomapa.
+            </EditorialLead>
+            <div className="mt-10 flex flex-col items-center justify-center gap-3 sm:flex-row sm:gap-4">
+              <EditorialButton href="/partnerships" variant="light">
+                Partner with Us
+              </EditorialButton>
+              <EditorialButton
+                href="mailto:akomapahealth@gmail.com"
+                variant="outline-light"
+                external
+              >
+                Contact Us
+              </EditorialButton>
+            </div>
+          </div>
+        </FadeIn>
+      </EditorialBand>
     </>
   );
 }

--- a/src/app/(main)/programs/akomapa-foods/Content.tsx
+++ b/src/app/(main)/programs/akomapa-foods/Content.tsx
@@ -1,104 +1,89 @@
-import { MotionDiv, MotionH1, MotionP } from "@/components/motion/framer";
-import Link from "next/link";
-import Breadcrumb from "@/components/layout/Breadcrumb";
 import Image from "@/components/common/Image";
-import { Button } from "@/components/ui/button";
-import { ArrowLeft } from "lucide-react";
+import { FadeIn } from "@/components/animations";
+import Breadcrumb from "@/components/layout/Breadcrumb";
+import ProgramDetailHero from "@/components/programs/ProgramDetailHero";
+import ProgramQuoteBand from "@/components/programs/ProgramQuoteBand";
+import {
+  EditorialBand,
+  EditorialButton,
+  EditorialEyebrow,
+  EditorialHeading,
+  EditorialLead,
+} from "@/components/shared/EditorialPrimitives";
 
 const whatWeDo = [
   {
     title: "Community Farms",
     description:
       "We work alongside farmers and cooperatives to grow fresh produce with regenerative practices, ensuring every harvest strengthens local soil, nutrition, and income.",
-    accentColor: "#0097b2"
   },
   {
     title: "Akomapa Stores",
     description:
       "Neighborhood stores make healthy food accessible and affordable, with every purchase reinvested into clinic operations and health education.",
-    accentColor: "#eeba2b"
   },
   {
     title: "Nutrition & Wellness Education",
     description:
       "Clinic visits include personalized counseling and cooking demonstrations so families leave with knowledge, recipes, and confidence.",
-    accentColor: "#0F4C5C"
   },
   {
     title: "Economic Empowerment",
     description:
       "Agriculture, retail, and distribution roles create dignified jobs for youth and women, expanding leadership pathways tied to community wellbeing.",
-    accentColor: "#0097b2"
   },
   {
     title: "Sustainability Cycle",
     description:
       "Every cedi earned flows back into medication, equipment, and leadership training, making care both free at the point of service and financially resilient.",
-    accentColor: "#eeba2b"
-  }
-];
+  },
+] as const;
 
 const longTermGoals = [
   {
     title: "Establish 5+ farms and stores by 2030",
     detail:
       "Each site will anchor an Akomapa clinic with reliable access to nutritious food grown and sold by community members.",
-    accentColor: "#0097b2"
   },
   {
     title: "Cover 25% of clinic costs annually",
     detail:
       "Proceeds from farms and stores will underwrite essential services, medicines, and logistics across the network.",
-    accentColor: "#eeba2b"
   },
   {
     title: "Train local youth and women",
     detail:
       "Hands-on apprenticeships in sustainable farming and agribusiness will expand economic mobility and leadership.",
-    accentColor: "#0F4C5C"
   },
   {
     title: "Integrate nutrition education everywhere",
     detail:
       "Every outreach, clinic day, and community event will include live cooking, tastings, and practical guidance for day-to-day wellness.",
-    accentColor: "#66C4DC"
-  }
-];
+  },
+] as const;
 
 const partners = [
   {
     name: "Local Farming Cooperatives",
-    logo: "/images/partners/local-coops-logo.svg"
+    logo: "/images/partners/local-coops-logo.svg",
   },
   {
     name: "Ministry of Food & Agriculture",
-    logo: "/images/partners/mofa-logo.svg"
+    logo: "/images/partners/mofa-logo.svg",
   },
   {
     name: "Ghana Health Service Nutrition Units",
-    logo: "/images/partners/ghana-health-service-logo.png"
+    logo: "/images/partners/ghana-health-service-logo.png",
   },
   {
     name: "UCC School of Agriculture",
-    logo: "/images/partners/ucc.png"
+    logo: "/images/partners/ucc.png",
   },
   {
     name: "Global Nutrition & Sustainability Alliance",
-    logo: "/images/partners/global-nutrition-logo.svg"
-  }
-];
-
-const ctaBaseClass =
-  "group inline-flex items-center justify-center gap-2 rounded-half px-8 py-6 h-auto text-base sm:text-lg font-medium transition-all duration-300 transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2";
-
-const primaryCtaClass =
-  `${ctaBaseClass} bg-[#0097b2] hover:bg-[#0097b2]/80 text-[#FCFAEF] shadow-lg hover:shadow-xl focus-visible:ring-[#8DD4E6]`;
-
-const secondaryCtaClass =
-  `${ctaBaseClass} bg-[#eeba2b] hover:bg-[#eeba2b]/80 text-[#FCFAEF] shadow-lg hover:shadow-xl focus-visible:ring-[#F5C94D]`;
-
-const outlineCtaClass =
-  `${ctaBaseClass} border-2 border-[#FCFAEF] text-[#FCFAEF] hover:bg-[#FCFAEF]/10 shadow-none focus-visible:ring-[#FCFAEF]`;
+    logo: "/images/partners/global-nutrition-logo.svg",
+  },
+] as const;
 
 export default function Content() {
   return (
@@ -107,378 +92,347 @@ export default function Content() {
         <Breadcrumb />
       </div>
 
-      <section className="relative min-h-[80vh] py-16 sm:py-20 md:py-28 bg-gradient-to-r from-[#0B2F3A] via-[#0F4C5C] to-[#0097b2] overflow-hidden">
-        <div className="absolute top-0 right-0 w-64 h-64 bg-[#FCFAEF]/10 rounded-full -translate-y-1/2 translate-x-1/2 blur-3xl" />
-        <div className="absolute bottom-0 left-0 w-96 h-96 bg-[#FCFAEF]/10 rounded-full translate-y-1/2 -translate-x-1/2 blur-3xl" />
+      <ProgramDetailHero
+        eyebrow="Akomapa Foods & Stores Initiative"
+        title="Nourishing Health. Sustaining Care. Empowering Communities."
+        lead="Health begins long before patients reach our clinics. By linking agriculture, nutrition, and economic participation, Akomapa ensures that every community can feed, heal, and sustain itself."
+        image="/highlights/Akomapa-47.jpg"
+        imageAlt="Akomapa Foods team cultivating community farms"
+        ctas={[
+          { href: "/partnerships", label: "Partner with Us", variant: "solid" },
+          {
+            href: "/get-involved",
+            label: "Support the Launch",
+            variant: "amber",
+          },
+          { href: "/donate", label: "Donate", variant: "amber" },
+        ]}
+      />
 
-        <div className="site-container mx-auto px-4 sm:px-6 relative z-10 flex flex-col gap-12 sm:gap-14">
-          <MotionDiv
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            className="pt-2"
-          >
-            <Link
-              href="/programs"
-              className="inline-flex items-center text-[#FCFAEF]/80 hover:text-[#FCFAEF] transition-colors text-sm font-medium"
-            >
-              <ArrowLeft className="mr-2 h-4 w-4" />
-              Back to Programs
-            </Link>
-          </MotionDiv>
-          <div className="flex flex-col lg:flex-row items-center gap-10 lg:gap-16">
-            <div className="w-full lg:w-1/2 max-w-3xl">
-              <MotionP
-                initial={{ opacity: 0, y: 40 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.8, ease: "easeOut" }}
-                className="uppercase tracking-[0.3em] text-xs sm:text-sm font-semibold text-[#FCFAEF]/80 mb-6"
-              >
-                Akomapa Foods & Stores Initiative
-              </MotionP>
-              <MotionH1
-                initial={{ opacity: 0, y: 40 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.1, duration: 0.8, ease: "easeOut" }}
-                className="text-3xl sm:text-4xl md:text-6xl lg:text-7xl font-light text-[#FCFAEF] mb-6 leading-tight"
-              >
-                Nourishing Health. Sustaining Care. Empowering Communities.
-              </MotionH1>
-              <MotionP
-                initial={{ opacity: 0, y: 40 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.2, duration: 0.8, ease: "easeOut" }}
-                className="text-base sm:text-lg md:text-2xl text-[#FCFAEF]/85 font-light"
-              >
-                Health begins long before patients reach our clinics. By linking agriculture, nutrition, and economic participation, Akomapa ensures that every community can feed, heal, and sustain itself.
-              </MotionP>
-              <MotionDiv
-                initial={{ opacity: 0, y: 40 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.3, duration: 0.8, ease: "easeOut" }}
-                className="mt-8 flex flex-col sm:flex-row flex-wrap gap-3 sm:gap-4"
-              >
-                <Button asChild className={primaryCtaClass}>
-                  <Link href="/partnerships">Partner with Us</Link>
-                </Button>
-                <Button asChild className={secondaryCtaClass}>
-                  <Link href="/get-involved">Support the Launch</Link>
-                </Button>
-                <Button asChild className={secondaryCtaClass}>
-                  <Link href="/donate">Donate</Link>
-                </Button>
-              </MotionDiv>
-            </div>
-            <MotionDiv
-              initial={{ opacity: 0, y: 40 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.4, duration: 0.8, ease: "easeOut" }}
-              className="w-full lg:w-1/2 relative h-[340px] sm:h-[420px] md:h-[520px] lg:h-[660px] rounded-3xl overflow-hidden shadow-2xl border border-white/10"
-            >
-              <Image
-                src="/highlights/Akomapa-47.jpg"
-                alt="Akomapa Foods team cultivating community farms"
-                fill
-                sizes="(min-width: 1024px) 50vw, 100vw"
-                className="object-cover object-center"
-              />
-              <div className="absolute inset-0 bg-gradient-to-t from-black/35 via-transparent to-transparent" />
-            </MotionDiv>
-          </div>
-        </div>
-      </section>
-
-      <section className="py-16 md:py-24 bg-[#FCFAEF] dark:bg-[#1C1F1E]">
-        <div className="site-container mx-auto px-4">
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-16 items-center">
-            <MotionDiv
-              initial={{ opacity: 0, y: 24 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.1, duration: 0.6 }}
-              viewport={{ once: true, amount: 0.3 }}
-              className="order-2 lg:order-1 relative w-full min-h-[320px] h-[320px] sm:h-[380px] md:h-[420px] lg:h-[460px] rounded-3xl overflow-hidden shadow-2xl"
-            >
+      <EditorialBand
+        tone="cream"
+        marker="01"
+        id="foods-about"
+        aria-labelledby="foods-about-heading"
+      >
+        <div className="grid items-start gap-10 lg:grid-cols-12 lg:gap-16">
+          <FadeIn direction="left" className="relative order-2 lg:order-1 lg:col-span-5">
+            <span
+              aria-hidden="true"
+              className="absolute -top-3 left-0 z-10 h-1 w-24 bg-[#eeba2b]"
+            />
+            <div className="relative aspect-[4/3] overflow-hidden rounded-md border border-[#1C1F1E]/10 bg-[#E6E7E7] dark:border-[#FCFAEF]/15 dark:bg-[#2F3332]">
               <Image
                 src="/highlights/Akomapa-61.jpg"
                 alt="Fresh produce harvested for the Akomapa Foods Initiative"
                 fill
-                sizes="(min-width: 1024px) 50vw, 100vw"
+                sizes="(min-width: 1024px) 40vw, 100vw"
                 className="object-cover object-center"
               />
-              <div className="absolute inset-0 bg-gradient-to-t from-black/25 via-transparent to-transparent" />
-            </MotionDiv>
-            <MotionDiv
-              initial={{ opacity: 0, y: 24 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6 }}
-              viewport={{ once: true, amount: 0.3 }}
-              className="order-1 lg:order-2"
-            >
-              <h2 className="text-3xl md:text-4xl font-bold mb-6 text-[#1C1F1E] dark:text-[#FCFAEF]">
-                About the Initiative
-              </h2>
-              <div className="space-y-5 text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed">
-                <p>
-                  The Akomapa Foods & Stores Initiative is the sustainability engine of our health model, connecting food security, economic empowerment, and clinic access in one ecosystem.
-                </p>
-                <p>
-                  Health starts in kitchens, markets, and farms. When communities grow and sell nutritious food, they also strengthen the very clinics that care for them.
-                </p>
-                <p>
-                  By linking agriculture and nutrition to student-powered community health hubs, Akomapa ensures communities receive care and co-own the means to sustain it for generations.
-                </p>
-              </div>
-            </MotionDiv>
-          </div>
-        </div>
-      </section>
-
-      <section className="py-16 md:py-24 bg-gradient-to-r from-[#0097b2] to-[#0F4C5C] text-[#FCFAEF] relative overflow-hidden">
-        <div className="absolute inset-0 pointer-events-none">
-          <div className="absolute -top-20 left-10 h-56 w-56 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
-          <div className="absolute bottom-0 right-0 h-72 w-72 rounded-full bg-[#F5C94D]/10 blur-3xl" />
-        </div>
-        <div className="relative site-container mx-auto px-4">
-          <MotionDiv
-            initial={{ opacity: 0, y: 24 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true, amount: 0.3 }}
-            className="max-w-4xl mx-auto text-center space-y-5"
-          >
-            <h2 className="text-3xl md:text-4xl font-bold">
-              Our Vision
-            </h2>
-            <p className="text-lg md:text-xl text-[#FCFAEF]/90 leading-relaxed">
-              We are building a network of community-run farms and food stores that make nutritious food accessible while generating revenue to fund free, student-led healthcare. Every clinic becomes part of a thriving local economy where wellness, work, and sustainability reinforce one another.
-            </p>
-          </MotionDiv>
-        </div>
-      </section>
-
-      <section className="py-16 md:py-24 bg-[#F4F1E8] dark:bg-[#1C1F1E]">
-        <div className="site-container mx-auto px-4">
-          <MotionDiv
-            initial={{ opacity: 0, y: 24 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true, amount: 0.3 }}
-            className="text-center max-w-4xl mx-auto mb-12 space-y-4"
-          >
-            <h2 className="text-3xl md:text-4xl font-bold text-[#1C1F1E] dark:text-[#FCFAEF]">
-              What We Do
-            </h2>
-            <p className="text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed">
-              A full-circle model blends agriculture, retail, education, and reinvestment so communities thrive alongside their clinics.
-            </p>
-          </MotionDiv>
-          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
-            {whatWeDo.map((item, index) => (
-              <MotionDiv
-                key={item.title}
-                initial={{ opacity: 0, y: 24 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: index * 0.05 }}
-                viewport={{ once: true, amount: 0.3 }}
-                className="rounded-3xl bg-white dark:bg-[#2F3332] p-6 lg:p-8 shadow-lg border border-[#E6E7E7]/50 dark:border-[#3A3E3D]"
-              >
-                <div
-                  className="h-1 w-16 rounded-full mb-4"
-                  style={{ backgroundColor: item.accentColor }}
-                />
-                <h3 className="text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF] mb-3">
-                  {item.title}
-                </h3>
-                <p className="text-base text-[#2F3332] dark:text-[#E6E7E7]/90 leading-relaxed">
-                  {item.description}
-                </p>
-              </MotionDiv>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      <section id="pilot" className="py-16 md:py-24 bg-[#FCFAEF] dark:bg-[#1C1F1E]">
-        <div className="site-container mx-auto px-4">
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-16 items-center">
-            <MotionDiv
-              initial={{ opacity: 0, y: 24 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6 }}
-              viewport={{ once: true, amount: 0.3 }}
-              className="order-2 lg:order-1 bg-white/95 dark:bg-[#2F3332]/95 rounded-3xl p-8 md:p-10 shadow-2xl border border-[#E6E7E7]/60 dark:border-[#3A3E3D] space-y-5"
-            >
-              <div className="inline-flex items-center text-xs font-semibold uppercase tracking-[0.3em] text-[#0097b2]">
-                Spotlight
-              </div>
-              <h2 className="text-3xl md:text-4xl font-bold text-[#1C1F1E] dark:text-[#FCFAEF]">
-                Pilot Project
-              </h2>
-              <p className="text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed">
-                Our first Akomapa Farm and Store launches near the University of Cape Coast in 2027. The site will supply fresh produce directly to local families, power free clinic days, and document a model for replication.
+            </div>
+          </FadeIn>
+          <FadeIn className="order-1 lg:order-2 lg:col-span-7">
+            <EditorialEyebrow className="text-[#0F4C5C] dark:text-[#66C4DC]">
+              About
+            </EditorialEyebrow>
+            <EditorialHeading id="foods-about-heading" className="mt-4">
+              About the Initiative
+            </EditorialHeading>
+            <div className="mt-6 space-y-5 text-base leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80 md:text-lg">
+              <p>
+                The Akomapa Foods & Stores Initiative is the sustainability
+                engine of our health model, connecting food security, economic
+                empowerment, and clinic access in one ecosystem.
               </p>
-              <div className="rounded-2xl bg-[#F4F1E8] dark:bg-[#1F2322] border border-[#E6E7E7]/70 dark:border-[#3A3E3D] p-6 space-y-3">
-                <p className="text-base text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed">
-                  Expansion plans are already aligned with future Akomapa clinics across Ghana, Africa, and the United States. Each new location adapts to local crops, culture, and community priorities while staying rooted in our shared standards.
-                </p>
-                <p className="text-sm font-semibold text-[#0097b2] dark:text-[#66C4DC]">
-                  Launch Timeline · 2027
-                </p>
-              </div>
-            </MotionDiv>
-            <MotionDiv
-              initial={{ opacity: 0, y: 24 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.1, duration: 0.6 }}
-              viewport={{ once: true, amount: 0.3 }}
-              className="order-1 lg:order-2 relative w-full h-[260px] sm:h-[320px] md:h-[420px] rounded-3xl overflow-hidden shadow-2xl"
+              <p>
+                Health starts in kitchens, markets, and farms. When communities
+                grow and sell nutritious food, they also strengthen the very
+                clinics that care for them.
+              </p>
+              <p>
+                By linking agriculture and nutrition to student-powered community
+                health hubs, Akomapa ensures communities receive care and co-own
+                the means to sustain it for generations.
+              </p>
+            </div>
+          </FadeIn>
+        </div>
+      </EditorialBand>
+
+      <EditorialBand
+        tone="teal"
+        marker="02"
+        id="foods-vision"
+        aria-labelledby="foods-vision-heading"
+        className="bg-[#0F4C5C]"
+      >
+        <FadeIn>
+          <div className="max-w-4xl">
+            <EditorialEyebrow tone="gold" className="text-[#F5C94D]">
+              Vision
+            </EditorialEyebrow>
+            <EditorialHeading
+              id="foods-vision-heading"
+              className="mt-4 text-[#FCFAEF]"
             >
+              Our Vision
+            </EditorialHeading>
+            <EditorialLead className="mt-6 text-[#FCFAEF]/90 dark:text-[#FCFAEF]/90 md:text-xl">
+              We are building a network of community-run farms and food stores
+              that make nutritious food accessible while generating revenue to
+              fund free, student-led healthcare. Every clinic becomes part of a
+              thriving local economy where wellness, work, and sustainability
+              reinforce one another.
+            </EditorialLead>
+          </div>
+        </FadeIn>
+      </EditorialBand>
+
+      <EditorialBand
+        tone="cream"
+        marker="03"
+        id="foods-what"
+        aria-labelledby="foods-what-heading"
+      >
+        <FadeIn>
+          <div className="max-w-3xl">
+            <EditorialEyebrow className="text-[#0F4C5C] dark:text-[#66C4DC]">
+              Model
+            </EditorialEyebrow>
+            <EditorialHeading id="foods-what-heading" className="mt-4">
+              What We Do
+            </EditorialHeading>
+            <EditorialLead className="mt-5">
+              A full-circle model blends agriculture, retail, education, and
+              reinvestment so communities thrive alongside their clinics.
+            </EditorialLead>
+          </div>
+        </FadeIn>
+
+        <ol className="mt-12 grid border-t border-[#1C1F1E]/15 md:grid-cols-2 xl:grid-cols-3 dark:border-[#FCFAEF]/20">
+          {whatWeDo.map((item, index) => (
+            <li
+              key={item.title}
+              className="border-b border-[#1C1F1E]/15 px-1 py-7 md:border-r md:px-6 xl:[&:nth-child(3n)]:border-r-0 dark:border-[#FCFAEF]/20"
+            >
+              <span
+                aria-hidden="true"
+                className="font-heading text-3xl font-semibold tracking-[-0.06em] text-[#0097b2]/55 dark:text-[#66C4DC]/65"
+              >
+                {String(index + 1).padStart(2, "0")}
+              </span>
+              <h3 className="mt-4 font-heading text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+                {item.title}
+              </h3>
+              <p className="mt-3 text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80 md:text-base">
+                {item.description}
+              </p>
+            </li>
+          ))}
+        </ol>
+      </EditorialBand>
+
+      <EditorialBand
+        tone="cream"
+        marker="04"
+        id="pilot"
+        aria-labelledby="foods-pilot-heading"
+      >
+        <div className="grid items-start gap-10 lg:grid-cols-12 lg:gap-16">
+          <FadeIn className="order-2 lg:order-1 lg:col-span-7">
+            <EditorialEyebrow className="text-[#0F4C5C] dark:text-[#66C4DC]">
+              Spotlight
+            </EditorialEyebrow>
+            <EditorialHeading id="foods-pilot-heading" className="mt-4">
+              Pilot Project
+            </EditorialHeading>
+            <EditorialLead className="mt-5">
+              Our first Akomapa Farm and Store launches near the University of
+              Cape Coast in 2027. The site will supply fresh produce directly to
+              local families, power free clinic days, and document a model for
+              replication.
+            </EditorialLead>
+            <dl className="mt-8 border-y border-[#1C1F1E]/15 dark:border-[#FCFAEF]/20">
+              <div className="py-6">
+                <dt className="sr-only">Expansion plans</dt>
+                <dd className="text-base leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80 md:text-lg">
+                  Expansion plans are already aligned with future Akomapa clinics
+                  across Ghana, Africa, and the United States. Each new location
+                  adapts to local crops, culture, and community priorities while
+                  staying rooted in our shared standards.
+                </dd>
+              </div>
+              <div className="border-t border-[#1C1F1E]/15 py-6 dark:border-[#FCFAEF]/20">
+                <dt className="sr-only">Launch timeline</dt>
+                <dd className="text-sm font-semibold text-[#0097b2] dark:text-[#66C4DC]">
+                  Launch Timeline · 2027
+                </dd>
+              </div>
+            </dl>
+          </FadeIn>
+          <FadeIn direction="left" delay={0.1} className="relative order-1 lg:order-2 lg:col-span-5">
+            <span
+              aria-hidden="true"
+              className="absolute -top-3 left-0 z-10 h-1 w-24 bg-[#eeba2b]"
+            />
+            <div className="relative aspect-[4/3] overflow-hidden rounded-md border border-[#1C1F1E]/10 bg-[#E6E7E7] dark:border-[#FCFAEF]/15 dark:bg-[#2F3332]">
               <Image
                 src="/highlights/Akomapa-40.jpg"
                 alt="Community members preparing the pilot farm launch"
                 fill
-                sizes="(min-width: 1024px) 45vw, 100vw"
+                sizes="(min-width: 1024px) 40vw, 100vw"
                 className="object-cover object-center"
               />
-              <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-transparent" />
-            </MotionDiv>
-          </div>
+            </div>
+          </FadeIn>
         </div>
-      </section>
+      </EditorialBand>
 
-      <section className="py-16 md:py-24 bg-gradient-to-r from-[#0F4C5C] via-[#0097b2] to-[#0B2F3A] text-[#FCFAEF]">
-        <div className="site-container mx-auto px-4">
-          <MotionDiv
-            initial={{ opacity: 0, y: 24 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true, amount: 0.3 }}
-            className="text-center max-w-4xl mx-auto mb-12 space-y-4"
-          >
-            <h2 className="text-3xl md:text-4xl font-bold">
+      <EditorialBand
+        tone="teal"
+        marker="05"
+        id="foods-goals"
+        aria-labelledby="foods-goals-heading"
+        className="bg-[#0F4C5C]"
+      >
+        <FadeIn>
+          <div className="max-w-3xl">
+            <EditorialEyebrow tone="gold" className="text-[#F5C94D]">
+              Goals
+            </EditorialEyebrow>
+            <EditorialHeading
+              id="foods-goals-heading"
+              className="mt-4 text-[#FCFAEF]"
+            >
               Long-Term Goals
-            </h2>
-            <p className="text-lg text-[#FCFAEF]/90 leading-relaxed">
-              Every goal ties nutrition to sustainable healthcare financing and community leadership.
-            </p>
-          </MotionDiv>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 lg:gap-8">
-            {longTermGoals.map((goal, index) => (
-              <MotionDiv
-                key={goal.title}
-                initial={{ opacity: 0, y: 24 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: index * 0.05 }}
-                viewport={{ once: true, amount: 0.3 }}
-                className="rounded-3xl bg-white/10 backdrop-blur-sm border border-white/15 p-6 lg:p-8 shadow-xl"
+            </EditorialHeading>
+            <EditorialLead className="mt-5 text-[#FCFAEF]/90 dark:text-[#FCFAEF]/90">
+              Every goal ties nutrition to sustainable healthcare financing and
+              community leadership.
+            </EditorialLead>
+          </div>
+        </FadeIn>
+
+        <ol className="mt-12 grid border-t border-[#FCFAEF]/25 md:grid-cols-2">
+          {longTermGoals.map((goal, index) => (
+            <li
+              key={goal.title}
+              className="border-b border-[#FCFAEF]/25 px-1 py-7 md:border-r md:px-6 md:odd:[&:nth-last-child(-n+1)]:border-r-0 md:[&:nth-child(2n)]:border-r-0"
+            >
+              <span
+                aria-hidden="true"
+                className="font-heading text-3xl font-semibold tracking-[-0.06em] text-[#FCFAEF]/45"
               >
-                <div
-                  className="h-1 w-16 rounded-full mb-4"
-                  style={{ backgroundColor: goal.accentColor }}
-                />
-                <h3 className="text-xl font-semibold text-white mb-3">
-                  {goal.title}
-                </h3>
-                <p className="text-base text-[#FCFAEF]/85 leading-relaxed">
-                  {goal.detail}
-                </p>
-              </MotionDiv>
-            ))}
-          </div>
-        </div>
-      </section>
+                {String(index + 1).padStart(2, "0")}
+              </span>
+              <h3 className="mt-4 font-heading text-lg font-semibold text-[#FCFAEF] md:text-xl">
+                {goal.title}
+              </h3>
+              <p className="mt-3 text-sm leading-relaxed text-[#FCFAEF]/85 md:text-base">
+                {goal.detail}
+              </p>
+            </li>
+          ))}
+        </ol>
+      </EditorialBand>
 
-      <section className="py-16 md:py-24 bg-[#FCFAEF] dark:bg-[#1C1F1E]">
-        <div className="site-container mx-auto px-4">
-          <MotionDiv
-            initial={{ opacity: 0, y: 24 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true, amount: 0.3 }}
-            className="text-center max-w-4xl mx-auto mb-10 space-y-4"
-          >
-            <h2 className="text-3xl md:text-4xl font-bold text-[#1C1F1E] dark:text-[#FCFAEF]">
+      <EditorialBand
+        tone="cream"
+        marker="06"
+        id="foods-partners"
+        aria-labelledby="foods-partners-heading"
+      >
+        <FadeIn>
+          <div className="max-w-3xl">
+            <EditorialEyebrow className="text-[#0F4C5C] dark:text-[#66C4DC]">
+              Partners
+            </EditorialEyebrow>
+            <EditorialHeading id="foods-partners-heading" className="mt-4">
               Partnerships Fuel Every Harvest
-            </h2>
-            <p className="text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed">
-              We collaborate with institutions that share a commitment to food security, research, and ethical healthcare delivery.
-            </p>
-          </MotionDiv>
-          <div className="w-full overflow-x-auto">
-            <div className="flex items-stretch gap-4 sm:gap-6 md:gap-8 min-w-max py-2">
-              {partners.map((partner) => (
-                <div
-                  key={partner.name}
-                  className="group relative flex h-24 sm:h-28 lg:h-32 w-44 sm:w-56 lg:w-64 flex-shrink-0 flex-col items-center justify-center rounded-3xl border border-[#E6E7E7]/60 dark:border-[#2F3332] bg-white dark:bg-[#2F3332] shadow-lg transition-all duration-300 hover:-translate-y-1 hover:shadow-2xl"
-                >
-                  <div className="relative h-10 sm:h-12 md:h-14 lg:h-16 w-28 sm:w-36 md:w-44 lg:w-48">
-                    <Image
-                      src={partner.logo}
-                      alt={`${partner.name} logo`}
-                      fill
-                      sizes="(min-width: 1024px) 12rem, 40vw"
-                      className="object-contain transition-transform duration-300 ease-out group-hover:scale-105"
-                    />
-                  </div>
-                  <p className="mt-3 text-xs font-semibold text-center text-[#1C1F1E] dark:text-[#FCFAEF] px-4">
-                    {partner.name}
-                  </p>
+            </EditorialHeading>
+            <EditorialLead className="mt-5">
+              We collaborate with institutions that share a commitment to food
+              security, research, and ethical healthcare delivery.
+            </EditorialLead>
+          </div>
+        </FadeIn>
+
+        <div
+          className="mt-10 w-full overflow-x-auto focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] focus-visible:ring-offset-2"
+          tabIndex={0}
+          role="region"
+          aria-label="Partner logos"
+        >
+          <ul className="flex min-w-max items-stretch gap-4 py-2 sm:gap-6 md:gap-8">
+            {partners.map((partner) => (
+              <li
+                key={partner.name}
+                className="flex h-24 w-44 flex-shrink-0 flex-col items-center justify-center border border-[#1C1F1E]/15 bg-[#FCFAEF] px-4 dark:border-[#FCFAEF]/20 dark:bg-[#1C1F1E] sm:h-28 sm:w-56 lg:h-32 lg:w-64"
+              >
+                <div className="relative h-10 w-28 sm:h-12 sm:w-36 md:h-14 md:w-44 lg:h-16 lg:w-48">
+                  <Image
+                    src={partner.logo}
+                    alt={`${partner.name} logo`}
+                    fill
+                    sizes="(min-width: 1024px) 12rem, 40vw"
+                    className="object-contain"
+                  />
                 </div>
-              ))}
+                <p className="mt-3 px-2 text-center text-xs font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+                  {partner.name}
+                </p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </EditorialBand>
+
+      <ProgramQuoteBand
+        tone="teal"
+        marker="07"
+        id="foods-quote"
+        className="bg-[#0F4C5C]"
+        quote="Our goal is to build communities that not only receive care but help sustain it. Akomapa Foods & Stores redefines healthcare by making every harvest an act of healing."
+        attribution="Akomapa Executive Team"
+      />
+
+      <EditorialBand
+        tone="teal"
+        marker="08"
+        id="foods-cta"
+        aria-labelledby="foods-cta-heading"
+        className="border-t border-[#FCFAEF]/15 bg-[#0F4C5C]"
+      >
+        <FadeIn>
+          <div className="mx-auto max-w-3xl text-center">
+            <EditorialEyebrow tone="gold" className="text-[#F5C94D]">
+              Get Involved
+            </EditorialEyebrow>
+            <EditorialHeading
+              id="foods-cta-heading"
+              className="mt-4 text-[#FCFAEF]"
+            >
+              Join the Movement
+            </EditorialHeading>
+            <EditorialLead className="mx-auto mt-6 max-w-2xl text-[#FCFAEF]/85 dark:text-[#FCFAEF]/85">
+              Help us make nutrition the foundation of sustainable healthcare.
+              Your partnership advances farms, stores, and clinics that belong to
+              the communities they serve.
+            </EditorialLead>
+            <div className="mt-10 flex flex-col items-center justify-center gap-3 sm:flex-row sm:flex-wrap sm:gap-4">
+              <EditorialButton href="/partnerships" variant="light">
+                Partner with Us
+              </EditorialButton>
+              <EditorialButton href="/get-involved" variant="outline-light">
+                Support the Launch
+              </EditorialButton>
+              <EditorialButton href="/donate" variant="amber">
+                Donate
+              </EditorialButton>
             </div>
           </div>
-        </div>
-      </section>
-
-      <section className="py-16 md:py-24 bg-gradient-to-r from-[#0F4C5C] to-[#0097b2] text-[#FCFAEF]">
-        <div className="site-container mx-auto px-4">
-          <MotionDiv
-            initial={{ opacity: 0, y: 24 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true, amount: 0.3 }}
-            className="max-w-3xl mx-auto text-center space-y-6"
-          >
-            <h2 className="text-3xl md:text-4xl font-bold">From the Founders</h2>
-            <p className="text-lg md:text-xl text-[#FCFAEF]/90 leading-relaxed italic">
-              &quot;Our goal is to build communities that not only receive care but help sustain it. Akomapa Foods & Stores redefines healthcare by making every harvest an act of healing.&quot;
-            </p>
-            <p className="text-base font-semibold text-[#F5C94D]">
-              — Akomapa Executive Team
-            </p>
-          </MotionDiv>
-        </div>
-      </section>
-
-      <section className="py-16 md:py-24 bg-gradient-to-r from-[#0B2F3A] via-[#0F4C5C] to-[#0097b2] text-[#FCFAEF]">
-        <div className="site-container mx-auto px-4">
-          <MotionDiv
-            initial={{ opacity: 0, y: 24 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true, amount: 0.3 }}
-            className="max-w-3xl mx-auto text-center space-y-6"
-          >
-            <h2 className="text-3xl md:text-4xl font-bold">
-              Join the Movement
-            </h2>
-            <p className="text-lg text-[#FCFAEF]/85 leading-relaxed">
-              Help us make nutrition the foundation of sustainable healthcare. Your partnership advances farms, stores, and clinics that belong to the communities they serve.
-            </p>
-            <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center">
-              <Button asChild className={primaryCtaClass}>
-                <Link href="/partnerships">Partner with Us</Link>
-              </Button>
-              <Button asChild className={outlineCtaClass}>
-                <Link href="/get-involved">Support the Launch</Link>
-              </Button>
-              <Button asChild className={secondaryCtaClass}>
-                <Link href="/donate">Donate</Link>
-              </Button>
-            </div>
-          </MotionDiv>
-        </div>
-      </section>
+        </FadeIn>
+      </EditorialBand>
     </>
   );
 }

--- a/src/app/(main)/programs/akomapa-ghltp/Content.tsx
+++ b/src/app/(main)/programs/akomapa-ghltp/Content.tsx
@@ -1,112 +1,108 @@
-import { MotionDiv, MotionH1, MotionP } from "@/components/motion/framer";
-import { AnimatedMetric } from "@/components/motion/AnimatedMetric";
-import Link from "next/link";
-import { ArrowLeft, ArrowRight } from "lucide-react";
-import Breadcrumb from "@/components/layout/Breadcrumb";
-import Image from "@/components/common/Image";
-/** `next/image` for static files under `public/` (partner logos). ImageKit paths use `Image` above. */
 import NextImage from "next/image";
-import { Button } from "@/components/ui/button";
+import Image from "@/components/common/Image";
+import { FadeIn, FadeInStagger, FadeInStaggerItem } from "@/components/animations";
+import { AnimatedMetric } from "@/components/motion/AnimatedMetric";
+import Breadcrumb from "@/components/layout/Breadcrumb";
 import GhltpTestimonialsCarousel from "@/components/programs/GhltpTestimonialsCarousel";
+import ProgramDetailHero from "@/components/programs/ProgramDetailHero";
+import ProgramFactSummary from "@/components/programs/ProgramFactSummary";
+import {
+  EditorialBand,
+  EditorialButton,
+  EditorialEyebrow,
+  EditorialHeading,
+  EditorialLead,
+} from "@/components/shared/EditorialPrimitives";
 
 const coreThemes = [
   {
     id: "theme-1",
     title: "Community Engagement",
     description: "Partnering authentically with local voices and systems.",
-    color: "#0097b2"
   },
   {
     id: "theme-2",
     title: "Cultural Humility",
     description: "Practicing reflective, inclusive leadership.",
-    color: "#eeba2b"
   },
   {
     id: "theme-3",
     title: "Ethical Leadership",
     description: "Navigating complexity with transparency and accountability.",
-    color: "#0097b2"
   },
   {
     id: "theme-4",
     title: "Interprofessional Collaboration",
     description: "Working across disciplines for integrated care.",
-    color: "#eeba2b"
   },
   {
     id: "theme-5",
     title: "Health Systems Innovation",
     description: "Designing and scaling creative, context-driven solutions.",
-    color: "#0097b2"
   },
   {
     id: "theme-6",
     title: "Sustainable Systems Building",
     description: "Ensuring impact that outlives projects and individuals.",
-    color: "#eeba2b"
-  }
-];
+  },
+] as const;
 
 const programFeatures = [
   {
     id: "feature-1",
     title: "Featured Speaker Series",
-    description: "Renowned global health leaders from WHO, Yale, UCLA, University of Ghana, and beyond share insights on leadership and equity.",
-    color: "#0097b2"
+    description:
+      "Renowned global health leaders from WHO, Yale, UCLA, University of Ghana, and beyond share insights on leadership and equity.",
   },
   {
     id: "feature-2",
     title: "Student-Led Discussions",
-    description: "Each week, students moderate conversations, lead reflections, and present on local/global case studies.",
-    color: "#eeba2b"
+    description:
+      "Each week, students moderate conversations, lead reflections, and present on local/global case studies.",
   },
   {
     id: "feature-3",
     title: "Interactive Assignments",
-    description: "Real-world challenges drawn from Akomapa's clinics and global partner sites, encouraging systems thinking and problem-solving.",
-    color: "#0097b2"
+    description:
+      "Real-world challenges drawn from Akomapa's clinics and global partner sites, encouraging systems thinking and problem-solving.",
   },
   {
     id: "feature-4",
     title: "Capstone Project",
-    description: "Each participant designs a practical, community-driven intervention plan with mentorship from Akomapa faculty and field partners.",
-    color: "#eeba2b"
-  }
-];
+    description:
+      "Each participant designs a practical, community-driven intervention plan with mentorship from Akomapa faculty and field partners.",
+  },
+] as const;
 
 const learningBenefits = [
   {
     id: "benefit-1",
     title: "Mentorship Access",
     description: "Mentorship from Akomapa's global advisory network",
-    color: "#0097b2"
   },
   {
     id: "benefit-2",
     title: "Case-Based Learning",
-    description: "Case-based learning from active student-powered community health hubs",
-    color: "#eeba2b"
+    description:
+      "Case-based learning from active student-powered community health hubs",
   },
   {
     id: "benefit-3",
     title: "Immersion Program",
     description: "Invitations to the Akomapa Global Health Immersion Program",
-    color: "#0097b2"
   },
   {
     id: "benefit-4",
     title: "Networking Sessions",
     description: "Global networking sessions and leadership roundtables",
-    color: "#eeba2b"
   },
   {
     id: "benefit-5",
     title: "Leadership Summit",
-    description: "Priority participation in the annual Akomapa Global Health Leadership Summit",
-    color: "#0097b2"
-  }
-];
+    description:
+      "Priority participation in the annual Akomapa Global Health Leadership Summit",
+  },
+] as const;
 
 const facultyInstitutions = [
   {
@@ -114,47 +110,81 @@ const facultyInstitutions = [
     name: "Yale School of Medicine",
     logo: "/images/partners/yale-sm-logo.png",
     width: 280,
-    height: 140
+    height: 140,
   },
   {
     id: "faculty-2",
     name: "University of Cape Coast",
     logo: "/images/partners/ucc.png",
     width: 280,
-    height: 140
+    height: 140,
   },
   {
     id: "faculty-3",
     name: "University of Ghana",
     logo: "/images/partners/ug-logo.png",
     width: 280,
-    height: 140
+    height: 140,
   },
   {
     id: "faculty-4",
     name: "David Geffen School of Medicine at UCLA",
     logo: "/images/partners/ucla.png",
     width: 280,
-    height: 140
+    height: 140,
   },
   {
     id: "faculty-5",
     name: "Ghana Health Service",
     logo: "/images/partners/ghana-health-service-logo.png",
     width: 280,
-    height: 140
-  }
-];
+    height: 140,
+  },
+] as const;
 
+const programFacts = [
+  { label: "Duration", value: "10–16 weeks (semester-long)" },
+  {
+    label: "Format",
+    value: "Virtual and hybrid delivery (live + asynchronous)",
+  },
+  {
+    label: "Structure",
+    value: "Weekly live sessions, peer discussions, and applied projects",
+  },
+  {
+    label: "Certification",
+    value:
+      "Akomapa Certificate in Global Health Leadership awarded upon completion",
+  },
+] as const;
 
-const ctaBaseClass =
-  "group inline-flex items-center justify-center gap-2 rounded-half px-8 py-6 h-auto text-base sm:text-lg font-medium transition-all duration-300 transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2";
+const impactGoals = [
+  {
+    value: 1000,
+    suffix: "+",
+    description:
+      "Train students and young professionals in ethical, community-driven leadership",
+  },
+  {
+    value: 5,
+    suffix: "+",
+    description:
+      "Build a sustainable pipeline of interprofessional global health leaders across countries",
+  },
+  {
+    value: 1,
+    suffix: "",
+    description:
+      "Strengthen links between academic learning and real-world systems change through the Akomapa Network",
+  },
+] as const;
 
-const primaryCtaClass =
-  `${ctaBaseClass} bg-[#0097b2] hover:bg-[#0097b2]/80 text-[#FCFAEF] shadow-lg hover:shadow-xl focus-visible:ring-[#8DD4E6]`;
-
-const secondaryCtaClass =
-  `${ctaBaseClass} bg-[#eeba2b] hover:bg-[#eeba2b]/80 text-[#FCFAEF] shadow-lg hover:shadow-xl focus-visible:ring-[#F5C94D]`;
+const metricDividerClasses = [
+  "",
+  "border-t md:border-l md:border-t-0",
+  "border-t md:border-l md:border-t-0",
+] as const;
 
 export default function Content() {
   return (
@@ -162,556 +192,390 @@ export default function Content() {
       <div className="site-container mx-auto">
         <Breadcrumb />
       </div>
-      
-      {/* Hero Section */}
-      <section className="relative min-h-[80vh] py-16 sm:py-20 md:py-28 bg-gradient-to-r from-[#0B2F3A] via-[#0F4C5C] to-[#0097b2] overflow-hidden">
-        <div className="absolute top-0 right-0 w-64 h-64 bg-[#FCFAEF]/10 rounded-full -translate-y-1/2 translate-x-1/2 blur-3xl" />
-        <div className="absolute bottom-0 left-0 w-96 h-96 bg-[#FCFAEF]/10 rounded-full translate-y-1/2 -translate-x-1/2 blur-3xl" />
 
-        <div className="site-container mx-auto px-4 sm:px-6 relative z-10 flex flex-col gap-4 sm:gap-8">
-          <MotionDiv
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            className="pt-2"
-          >
-            <Link 
-              href="/programs" 
-              className="inline-flex items-center text-[#FCFAEF]/80 hover:text-[#FCFAEF] transition-colors text-sm font-medium"
-            >
-              <ArrowLeft className="mr-2 h-4 w-4" />
-              Back to Programs
-            </Link>
-          </MotionDiv>
-          <div className="max-w-5xl">
-            <MotionP
-              initial={{ opacity: 0, y: 40 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.8, ease: "easeOut" }}
-              className="uppercase tracking-[0.3em] text-sm font-semibold text-[#FCFAEF]/80 mb-6"
-            >
-              Akomapa Global Health Leadership Training Program
-            </MotionP>
-            <MotionH1 
-              initial={{ opacity: 0, y: 40 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.1, duration: 0.8, ease: "easeOut" }}
-              className="text-3xl sm:text-4xl md:text-6xl lg:text-7xl font-light text-[#FCFAEF] mb-6 leading-tight"
-            >
-              Training the Next Generation of Ethical, Compassionate, and Impact-Driven Health Leaders
-            </MotionH1>
-            <MotionP 
-              initial={{ opacity: 0, y: 40 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.2, duration: 0.8, ease: "easeOut" }}
-              className="text-base sm:text-lg md:text-2xl text-[#FCFAEF]/85 font-light max-w-3xl"
-            >
-              A semester-long, certificate-bearing course that equips emerging health professionals with the knowledge, empathy, and vision to lead transformative change in global health.
-            </MotionP>
-            <MotionDiv
-              initial={{ opacity: 0, y: 40 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.3, duration: 0.8, ease: "easeOut" }}
-              className="mt-8 flex flex-wrap gap-4"
-            >
-              <Button asChild className={primaryCtaClass}>
-                <Link href="/get-involved">Apply Now</Link>
-              </Button>
-              <Button asChild className={secondaryCtaClass}>
-                <Link href="/contact">Become a Mentor</Link>
-              </Button>
-            </MotionDiv>
-          </div>
+      <ProgramDetailHero
+        eyebrow="Akomapa Global Health Leadership Training Program"
+        title="Training the Next Generation of Ethical, Compassionate, and Impact-Driven Health Leaders"
+        lead="A semester-long, certificate-bearing course that equips emerging health professionals with the knowledge, empathy, and vision to lead transformative change in global health."
+        image="/highlights/Akomapa-40.jpg"
+        imageAlt="Global health leadership training program"
+        ctas={[
+          { href: "/get-involved", label: "Apply Now", variant: "amber" },
+          {
+            href: "/contact",
+            label: "Become a Mentor",
+            variant: "outline-light",
+          },
+        ]}
+      />
 
-          <MotionDiv
-            initial={{ opacity: 0, y: 40 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.4, duration: 0.8, ease: "easeOut" }}
-            className="w-full"
-          >
-            <div className="relative w-full h-[280px] sm:h-[360px] md:h-[520px] lg:h-[640px] rounded-3xl overflow-hidden shadow-2xl border border-white/10">
+      <EditorialBand
+        tone="cream"
+        marker="01"
+        id="ghltp-about"
+        aria-labelledby="ghltp-about-heading"
+      >
+        <div className="grid items-start gap-10 lg:grid-cols-12 lg:gap-16">
+          <FadeIn className="lg:col-span-7">
+            <EditorialEyebrow className="text-[#0F4C5C] dark:text-[#66C4DC]">
+              About
+            </EditorialEyebrow>
+            <EditorialHeading id="ghltp-about-heading" className="mt-4">
+              About the Program
+            </EditorialHeading>
+            <div className="mt-6 space-y-5 text-base leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80 md:text-lg">
+              <p>
+                The Akomapa Global Health Leadership Training Program is a
+                semester-long, certificate-bearing course that equips emerging
+                health professionals with the knowledge, empathy, and vision to
+                lead transformative change in global health.
+              </p>
+              <p>
+                Taught by world experts from leading universities across Africa,
+                the United States, and beyond, and from top global health
+                organizations, this program unites students passionate about
+                reimagining healthcare — from classrooms to communities.
+              </p>
+              <p className="font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+                Rooted in Akomapa&apos;s philosophy of leadership through
+                service, the course blends rigorous academic instruction with
+                mentorship, live dialogue, and hands-on learning from the field.
+              </p>
+            </div>
+          </FadeIn>
+          <FadeIn direction="left" delay={0.1} className="relative lg:col-span-5">
+            <span
+              aria-hidden="true"
+              className="absolute -top-3 left-0 z-10 h-1 w-24 bg-[#eeba2b]"
+            />
+            <div className="relative aspect-[4/3] overflow-hidden rounded-md border border-[#1C1F1E]/10 bg-[#E6E7E7] dark:border-[#FCFAEF]/15 dark:bg-[#2F3332]">
               <Image
-                src="/highlights/Akomapa-40.jpg"
-                alt="Global health leadership training program"
+                src="/highlights/Akomapa-66.jpg"
+                alt="Students in global health leadership training"
                 fill
-                sizes="(min-width: 1024px) 50vw, 100vw"
+                sizes="(min-width: 1024px) 40vw, 100vw"
                 className="object-cover"
               />
-              <div className="absolute inset-0 bg-gradient-to-t from-black/35 via-transparent to-transparent" />
             </div>
-          </MotionDiv>
+          </FadeIn>
         </div>
-      </section>
+      </EditorialBand>
 
-      {/* About the Program Section */}
-      <section className="py-16 md:py-24 bg-[#FCFAEF] dark:bg-[#1C1F1E]">
-        <div className="site-container mx-auto px-4">
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-16 items-center">
-            <MotionDiv
-              initial={{ opacity: 0, y: 24 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6 }}
-              viewport={{ once: true, amount: 0.3 }}
-              className="order-1"
+      <EditorialBand
+        tone="teal"
+        marker="02"
+        id="ghltp-vision"
+        aria-labelledby="ghltp-vision-heading"
+        className="bg-[#0F4C5C]"
+      >
+        <FadeIn>
+          <div className="max-w-4xl">
+            <EditorialEyebrow tone="gold" className="text-[#F5C94D]">
+              Vision
+            </EditorialEyebrow>
+            <EditorialHeading
+              id="ghltp-vision-heading"
+              className="mt-4 text-[#FCFAEF]"
             >
-              <h2 className="text-3xl md:text-4xl font-bold text-[#1C1F1E] dark:text-[#FCFAEF] mb-6">
-                About the Program
-              </h2>
-              <div className="space-y-5 text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed">
-                <p>
-                  The Akomapa Global Health Leadership Training Program is a semester-long, certificate-bearing course that equips emerging health professionals with the knowledge, empathy, and vision to lead transformative change in global health.
-                </p>
-                <p>
-                  Taught by world experts from leading universities across Africa, the United States, and beyond, and from top global health organizations, this program unites students passionate about reimagining healthcare — from classrooms to communities.
-                </p>
-                <p className="font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
-                  Rooted in Akomapa&apos;s philosophy of leadership through service, the course blends rigorous academic instruction with mentorship, live dialogue, and hands-on learning from the field.
-                </p>
-              </div>
-            </MotionDiv>
-            <MotionDiv
-              initial={{ opacity: 0, y: 24 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.1, duration: 0.6 }}
-              viewport={{ once: true, amount: 0.3 }}
-              className="order-2"
-            >
-              <div className="relative w-full min-h-[320px] h-[320px] sm:h-[380px] md:h-[420px] lg:h-[460px] rounded-3xl overflow-hidden shadow-2xl">
-                <Image
-                  src="/highlights/Akomapa-66.jpg"
-                  alt="Students in global health leadership training"
-                  fill
-                  sizes="(min-width: 1024px) 50vw, 100vw"
-                  className="object-cover"
-                />
-                <div className="absolute inset-0 bg-gradient-to-t from-black/25 via-transparent to-transparent" />
-              </div>
-            </MotionDiv>
+              Our Vision
+            </EditorialHeading>
+            <EditorialLead className="mt-6 text-[#FCFAEF]/90 dark:text-[#FCFAEF]/90 md:text-xl">
+              To train a new generation of 1,000+ global health leaders who lead
+              with integrity, humility, and innovation — bridging the gap between
+              care and justice, and between learning and leadership.
+            </EditorialLead>
           </div>
-        </div>
-      </section>
+        </FadeIn>
+      </EditorialBand>
 
-      {/* Our Vision Section */}
-      <section className="py-16 md:py-24 bg-gradient-to-r from-[#0097b2] to-[#0F4C5C] text-[#FCFAEF] relative overflow-hidden">
-        <div className="absolute inset-0 pointer-events-none">
-          <div className="absolute -top-20 left-10 h-56 w-56 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
-          <div className="absolute bottom-0 right-0 h-72 w-72 rounded-full bg-[#F5C94D]/10 blur-3xl" />
-        </div>
-        <div className="relative site-container mx-auto px-4">
-          <div className="max-w-4xl mx-auto">
-            <MotionDiv
-              initial={{ opacity: 0, y: 24 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6 }}
-              viewport={{ once: true, amount: 0.3 }}
-              className="space-y-6"
-            >
-              <h2 className="text-3xl md:text-4xl font-bold mb-6">
-                Our Vision
-              </h2>
-              <p className="text-lg md:text-xl text-[#FCFAEF]/90 leading-relaxed">
-                To train a new generation of 1,000+ global health leaders who lead with integrity, humility, and innovation — bridging the gap between care and justice, and between learning and leadership.
-              </p>
-            </MotionDiv>
-          </div>
-        </div>
-      </section>
-
-      {/* What You'll Learn Section */}
-      <section className="py-16 md:py-24 bg-[#FCFAEF] dark:bg-[#1C1F1E]">
-        <div className="site-container mx-auto px-4">
-          <MotionDiv
-            initial={{ opacity: 0, y: 24 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true, amount: 0.3 }}
-            className="text-center max-w-4xl mx-auto mb-12 space-y-4"
-          >
-            <h2 className="text-3xl md:text-4xl font-bold text-[#1C1F1E] dark:text-[#FCFAEF]">
+      <EditorialBand
+        tone="cream"
+        marker="03"
+        id="ghltp-learn"
+        aria-labelledby="ghltp-learn-heading"
+      >
+        <FadeIn>
+          <div className="max-w-3xl">
+            <EditorialEyebrow className="text-[#0F4C5C] dark:text-[#66C4DC]">
+              Curriculum
+            </EditorialEyebrow>
+            <EditorialHeading id="ghltp-learn-heading" className="mt-4">
               What You&apos;ll Learn
-            </h2>
-            <p className="text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed">
-              Our curriculum integrates cross-disciplinary theory, ethical frameworks, and practice-based learning — all grounded in real case studies from Akomapa clinics across Ghana and the United States.
-            </p>
-          </MotionDiv>
-
-          <div className="max-w-6xl mx-auto">
-            <h3 className="text-xl md:text-2xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF] mb-8 text-center">
-              Core Themes
-            </h3>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8">
-              {coreThemes.map((theme, index) => (
-                <MotionDiv
-                  key={theme.id}
-                  initial={{ opacity: 0, y: 24 }}
-                  whileInView={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.6, delay: index * 0.1 }}
-                  viewport={{ once: true, amount: 0.3 }}
-                  className="group relative rounded-2xl bg-white dark:bg-[#2F3332] p-6 md:p-8 shadow-lg hover:shadow-xl transition-all duration-300 border border-[#E6E7E7]/20 dark:border-[#4F5554]/20 hover:-translate-y-1"
-                >
-                  <div className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300 bg-gradient-to-br from-[#0097b2]/5 via-transparent to-[#eeba2b]/5 rounded-2xl" />
-                  <div className="relative">
-                    <div 
-                      className="h-1 w-16 rounded-full mb-4"
-                      style={{ backgroundColor: theme.color }}
-                    />
-                    <h4 className="text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF] mb-3">
-                      {theme.title}
-                    </h4>
-                    <p className="text-sm md:text-base text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed">
-                      {theme.description}
-                    </p>
-                  </div>
-                </MotionDiv>
-              ))}
-            </div>
+            </EditorialHeading>
+            <EditorialLead className="mt-5">
+              Our curriculum integrates cross-disciplinary theory, ethical
+              frameworks, and practice-based learning — all grounded in real case
+              studies from Akomapa clinics across Ghana and the United States.
+            </EditorialLead>
           </div>
-        </div>
-      </section>
+        </FadeIn>
 
-      {/* How the Program Works Section */}
-      <section className="py-16 md:py-24 bg-gradient-to-r from-[#0F4C5C] via-[#0097b2] to-[#0B2F3A] text-[#FCFAEF] relative overflow-hidden">
-        <div className="absolute inset-0 pointer-events-none">
-          <div className="absolute -top-20 left-10 h-56 w-56 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
-          <div className="absolute bottom-0 right-0 h-72 w-72 rounded-full bg-[#F5C94D]/10 blur-3xl" />
-        </div>
-        <div className="relative site-container mx-auto px-4">
-          <MotionDiv
-            initial={{ opacity: 0, y: 24 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true, amount: 0.3 }}
-            className="text-center max-w-4xl mx-auto mb-12 space-y-4"
-          >
-            <h2 className="text-3xl md:text-4xl font-bold">
-              How the Program Works
-            </h2>
-          </MotionDiv>
-
-          <div className="max-w-4xl mx-auto mb-12">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
-              <div className="bg-[#FCFAEF]/10 backdrop-blur-md rounded-2xl p-6 border border-[#FCFAEF]/20">
-                <h3 className="text-lg font-semibold mb-2">Duration</h3>
-                <p className="text-[#FCFAEF]/90">10–16 weeks (semester-long)</p>
-              </div>
-              <div className="bg-[#FCFAEF]/10 backdrop-blur-md rounded-2xl p-6 border border-[#FCFAEF]/20">
-                <h3 className="text-lg font-semibold mb-2">Format</h3>
-                <p className="text-[#FCFAEF]/90">Virtual and hybrid delivery (live + asynchronous)</p>
-              </div>
-              <div className="bg-[#FCFAEF]/10 backdrop-blur-md rounded-2xl p-6 border border-[#FCFAEF]/20">
-                <h3 className="text-lg font-semibold mb-2">Structure</h3>
-                <p className="text-[#FCFAEF]/90">Weekly live sessions, peer discussions, and applied projects</p>
-              </div>
-              <div className="bg-[#FCFAEF]/10 backdrop-blur-md rounded-2xl p-6 border border-[#FCFAEF]/20">
-                <h3 className="text-lg font-semibold mb-2">Certification</h3>
-                <p className="text-[#FCFAEF]/90">Akomapa Certificate in Global Health Leadership awarded upon completion</p>
-              </div>
-            </div>
-          </div>
-
-          <div className="max-w-6xl mx-auto">
-            <h3 className="text-xl md:text-2xl font-semibold mb-8 text-center">
-              Program Features
-            </h3>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-8">
-              {programFeatures.map((feature, index) => (
-                <MotionDiv
-                  key={feature.id}
-                  initial={{ opacity: 0, y: 24 }}
-                  whileInView={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.6, delay: index * 0.1 }}
-                  viewport={{ once: true, amount: 0.3 }}
-                  className="relative rounded-2xl bg-[#FCFAEF]/95 text-[#1C1F1E] p-6 md:p-8 shadow-xl border border-[#E6E7E7]/40"
-                >
-                  <div 
-                    className="h-1 w-16 rounded-full mb-4"
-                    style={{ backgroundColor: feature.color }}
-                  />
-                  <h4 className="text-lg md:text-xl font-semibold mb-3 text-[#1C1F1E]">
-                    {feature.title}
-                  </h4>
-                  <p className="text-sm md:text-base text-[#2F3332]/85 leading-relaxed">
-                    {feature.description}
-                  </p>
-                </MotionDiv>
-              ))}
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Faculty & Contributors Section */}
-      <section className="py-16 md:py-24 bg-[#FCFAEF] dark:bg-[#1C1F1E]">
-        <div className="site-container mx-auto px-4">
-          <MotionDiv
-            initial={{ opacity: 0, y: 24 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true, amount: 0.3 }}
-            className="max-w-7xl mx-auto space-y-8"
-          >
-            <div className="text-center space-y-4">
-              <h2 className="text-3xl md:text-4xl font-bold text-[#1C1F1E] dark:text-[#FCFAEF]">
-                Faculty & Contributors
-              </h2>
-              <p className="text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed max-w-3xl mx-auto">
-                Taught and mentored by faculty and practitioners from leading institutions and organizations worldwide.
+        <h3 className="mt-12 font-heading text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF] md:text-2xl">
+          Core Themes
+        </h3>
+        <ol className="mt-6 grid border-t border-[#1C1F1E]/15 md:grid-cols-2 xl:grid-cols-3 dark:border-[#FCFAEF]/20">
+          {coreThemes.map((theme, index) => (
+            <li
+              key={theme.id}
+              className="border-b border-[#1C1F1E]/15 px-1 py-7 md:border-r md:px-6 xl:[&:nth-child(3n)]:border-r-0 dark:border-[#FCFAEF]/20 md:odd:[&:nth-last-child(-n+1)]:border-r-0"
+            >
+              <span
+                aria-hidden="true"
+                className="font-heading text-3xl font-semibold tracking-[-0.06em] text-[#0097b2]/55 dark:text-[#66C4DC]/65"
+              >
+                {String(index + 1).padStart(2, "0")}
+              </span>
+              <h4 className="mt-4 font-heading text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+                {theme.title}
+              </h4>
+              <p className="mt-3 text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
+                {theme.description}
               </p>
-            </div>
+            </li>
+          ))}
+        </ol>
+      </EditorialBand>
 
-            <div className="flex flex-wrap items-center justify-center gap-4 sm:gap-6 md:gap-8 lg:gap-10">
-              {facultyInstitutions.map((institution, index) => (
-                <MotionDiv
-                  key={institution.id}
-                  initial={{ opacity: 0, y: 20 }}
-                  whileInView={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.5, delay: index * 0.1 }}
-                  viewport={{ once: true, amount: 0.3 }}
-                  className="group flex-shrink-0"
-                >
-                  <div className="relative flex items-center justify-center h-[55px] sm:h-[75px] md:h-[95px] lg:h-[115px] w-auto px-4 sm:px-6 opacity-75 hover:opacity-100 transition-opacity duration-300">
-                    <NextImage
-                      src={institution.logo}
-                      alt={`${institution.name} logo`}
-                      width={institution.width}
-                      height={institution.height}
-                      className="object-contain h-full w-auto transition-transform duration-300 group-hover:scale-110"
-                    />
-                  </div>
-                </MotionDiv>
-              ))}
-            </div>
-          </MotionDiv>
-        </div>
-      </section>
+      <EditorialBand
+        tone="teal"
+        marker="04"
+        id="ghltp-how"
+        aria-labelledby="ghltp-how-heading"
+        className="bg-[#0F4C5C]"
+      >
+        <FadeIn>
+          <div className="max-w-3xl">
+            <EditorialEyebrow tone="gold" className="text-[#F5C94D]">
+              Structure
+            </EditorialEyebrow>
+            <EditorialHeading
+              id="ghltp-how-heading"
+              className="mt-4 text-[#FCFAEF]"
+            >
+              How the Program Works
+            </EditorialHeading>
+          </div>
+        </FadeIn>
 
-      {/* Learning Beyond the Classroom Section */}
-      <section className="py-16 md:py-24 bg-gradient-to-r from-[#0097b2] to-[#0F4C5C] text-[#FCFAEF] relative overflow-hidden">
-        <div className="absolute inset-0 pointer-events-none">
-          <div className="absolute -top-20 left-10 h-56 w-56 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
-          <div className="absolute bottom-0 right-0 h-72 w-72 rounded-full bg-[#F5C94D]/10 blur-3xl" />
+        <div className="mt-10">
+          <ProgramFactSummary facts={[...programFacts]} tone="dark" />
         </div>
-        <div className="relative site-container mx-auto px-4">
-          <MotionDiv
-            initial={{ opacity: 0, y: 24 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true, amount: 0.3 }}
-            className="text-center max-w-4xl mx-auto mb-12 space-y-4"
-          >
-            <h2 className="text-3xl md:text-4xl font-bold">
+
+        <h3 className="mt-14 font-heading text-xl font-semibold text-[#FCFAEF] md:text-2xl">
+          Program Features
+        </h3>
+        <ol className="mt-6 grid border-t border-[#FCFAEF]/25 md:grid-cols-2">
+          {programFeatures.map((feature, index) => (
+            <li
+              key={feature.id}
+              className="border-b border-[#FCFAEF]/25 px-1 py-7 md:px-6 md:odd:border-r"
+            >
+              <span
+                aria-hidden="true"
+                className="font-heading text-3xl font-semibold tracking-[-0.06em] text-[#FCFAEF]/45"
+              >
+                {String(index + 1).padStart(2, "0")}
+              </span>
+              <h4 className="mt-4 font-heading text-lg font-semibold text-[#FCFAEF] md:text-xl">
+                {feature.title}
+              </h4>
+              <p className="mt-3 text-sm leading-relaxed text-[#FCFAEF]/85 md:text-base">
+                {feature.description}
+              </p>
+            </li>
+          ))}
+        </ol>
+      </EditorialBand>
+
+      <EditorialBand
+        tone="cream"
+        marker="05"
+        id="ghltp-faculty"
+        aria-labelledby="ghltp-faculty-heading"
+      >
+        <FadeIn>
+          <div className="max-w-3xl">
+            <EditorialEyebrow className="text-[#0F4C5C] dark:text-[#66C4DC]">
+              Partners
+            </EditorialEyebrow>
+            <EditorialHeading id="ghltp-faculty-heading" className="mt-4">
+              Faculty & Contributors
+            </EditorialHeading>
+            <EditorialLead className="mt-5">
+              Taught and mentored by faculty and practitioners from leading
+              institutions and organizations worldwide.
+            </EditorialLead>
+          </div>
+        </FadeIn>
+
+        <ul className="mt-12 flex flex-wrap items-center justify-center gap-6 sm:gap-8 md:gap-10">
+          {facultyInstitutions.map((institution) => (
+            <li key={institution.id} className="flex-shrink-0">
+              <div className="relative flex h-14 w-auto items-center justify-center px-2 sm:h-16 md:h-20">
+                <NextImage
+                  src={institution.logo}
+                  alt={`${institution.name} logo`}
+                  width={institution.width}
+                  height={institution.height}
+                  className="h-full w-auto object-contain opacity-80"
+                />
+              </div>
+            </li>
+          ))}
+        </ul>
+      </EditorialBand>
+
+      <EditorialBand
+        tone="teal"
+        marker="06"
+        id="ghltp-benefits"
+        aria-labelledby="ghltp-benefits-heading"
+        className="bg-[#0F4C5C]"
+      >
+        <FadeIn>
+          <div className="max-w-3xl">
+            <EditorialEyebrow tone="gold" className="text-[#F5C94D]">
+              Beyond the Classroom
+            </EditorialEyebrow>
+            <EditorialHeading
+              id="ghltp-benefits-heading"
+              className="mt-4 text-[#FCFAEF]"
+            >
               Learning Beyond the Classroom
-            </h2>
-            <p className="text-lg text-[#FCFAEF]/90 leading-relaxed">
+            </EditorialHeading>
+            <EditorialLead className="mt-5 text-[#FCFAEF]/90 dark:text-[#FCFAEF]/90">
               Students gain exclusive access to:
-            </p>
-          </MotionDiv>
-
-          <div className="max-w-6xl mx-auto">
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8">
-              {learningBenefits.map((benefit, index) => (
-                <MotionDiv
-                  key={benefit.id}
-                  initial={{ opacity: 0, y: 24 }}
-                  whileInView={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.6, delay: index * 0.1 }}
-                  viewport={{ once: true, amount: 0.3 }}
-                  className="relative rounded-2xl bg-[#FCFAEF]/95 text-[#1C1F1E] p-6 md:p-8 shadow-xl border border-[#E6E7E7]/40"
-                >
-                  <div 
-                    className="h-1 w-16 rounded-full mb-4"
-                    style={{ backgroundColor: benefit.color }}
-                  />
-                  <h4 className="text-lg font-semibold mb-3 text-[#1C1F1E]">
-                    {benefit.title}
-                  </h4>
-                  <p className="text-sm md:text-base text-[#2F3332]/85 leading-relaxed">
-                    {benefit.description}
-                  </p>
-                </MotionDiv>
-              ))}
-            </div>
+            </EditorialLead>
           </div>
-        </div>
-      </section>
+        </FadeIn>
 
-      {/* Impact Goal Section */}
-      <section className="py-16 md:py-24 bg-[#FCFAEF] dark:bg-[#1C1F1E]">
-        <div className="site-container mx-auto px-4">
-          <MotionDiv
-            initial={{ opacity: 0, y: 24 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true, amount: 0.3 }}
-            className="text-center max-w-4xl mx-auto mb-12 space-y-4"
-          >
-            <h2 className="text-3xl md:text-4xl font-bold text-[#1C1F1E] dark:text-[#FCFAEF]">
+        <ol className="mt-10 grid border-t border-[#FCFAEF]/25 md:grid-cols-2 lg:grid-cols-3">
+          {learningBenefits.map((benefit, index) => (
+            <li
+              key={benefit.id}
+              className="border-b border-[#FCFAEF]/25 px-1 py-7 md:px-6 lg:border-r lg:[&:nth-child(3n)]:border-r-0"
+            >
+              <span
+                aria-hidden="true"
+                className="font-heading text-3xl font-semibold tracking-[-0.06em] text-[#FCFAEF]/45"
+              >
+                {String(index + 1).padStart(2, "0")}
+              </span>
+              <h3 className="mt-4 font-heading text-lg font-semibold text-[#FCFAEF]">
+                {benefit.title}
+              </h3>
+              <p className="mt-3 text-sm leading-relaxed text-[#FCFAEF]/85">
+                {benefit.description}
+              </p>
+            </li>
+          ))}
+        </ol>
+      </EditorialBand>
+
+      <EditorialBand
+        tone="cream"
+        marker="07"
+        id="ghltp-impact"
+        aria-labelledby="ghltp-impact-heading"
+      >
+        <FadeIn>
+          <div className="max-w-3xl">
+            <EditorialEyebrow className="text-[#0F4C5C] dark:text-[#66C4DC]">
+              Goals
+            </EditorialEyebrow>
+            <EditorialHeading id="ghltp-impact-heading" className="mt-4">
               Impact Goal
-            </h2>
-            <p className="text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed">
-              By 2027, we aim to:
-            </p>
-          </MotionDiv>
-
-          <div className="max-w-5xl mx-auto">
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-6 md:gap-8">
-              <MotionDiv
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: 0.1 }}
-                viewport={{ once: true }}
-                className="relative rounded-2xl bg-white dark:bg-[#2F3332] text-[#1C1F1E] dark:text-[#FCFAEF] p-6 md:p-8 shadow-xl border border-[#E6E7E7]/40 dark:border-[#4F5554]/40 flex flex-col"
-              >
-                <div 
-                  className="h-1 w-16 rounded-full mb-6"
-                  style={{ backgroundColor: "#0097b2" }}
-                />
-                <div className="mb-4">
-                  <AnimatedMetric
-                    value={1000}
-                    suffix="+"
-                    className="text-4xl md:text-5xl lg:text-6xl font-semibold tracking-tight"
-                    style={{ color: "#0097b2" }}
-                  />
-                </div>
-                <p className="text-base md:text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed flex-1">
-                  Train students and young professionals in ethical, community-driven leadership
-                </p>
-              </MotionDiv>
-              <MotionDiv
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: 0.2 }}
-                viewport={{ once: true }}
-                className="relative rounded-2xl bg-white dark:bg-[#2F3332] text-[#1C1F1E] dark:text-[#FCFAEF] p-6 md:p-8 shadow-xl border border-[#E6E7E7]/40 dark:border-[#4F5554]/40 flex flex-col"
-              >
-                <div 
-                  className="h-1 w-16 rounded-full mb-6"
-                  style={{ backgroundColor: "#eeba2b" }}
-                />
-                <div className="mb-4">
-                  <AnimatedMetric
-                    value={5}
-                    suffix="+"
-                    className="text-4xl md:text-5xl lg:text-6xl font-semibold tracking-tight"
-                    style={{ color: "#eeba2b" }}
-                  />
-                </div>
-                <p className="text-base md:text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed flex-1">
-                  Build a sustainable pipeline of interprofessional global health leaders across countries
-                </p>
-              </MotionDiv>
-              <MotionDiv
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: 0.3 }}
-                viewport={{ once: true }}
-                className="relative rounded-2xl bg-white dark:bg-[#2F3332] text-[#1C1F1E] dark:text-[#FCFAEF] p-6 md:p-8 shadow-xl border border-[#E6E7E7]/40 dark:border-[#4F5554]/40 flex flex-col"
-              >
-                <div 
-                  className="h-1 w-16 rounded-full mb-6"
-                  style={{ backgroundColor: "#0097b2" }}
-                />
-                <div className="mb-4">
-                  <AnimatedMetric
-                    value={1}
-                    className="text-4xl md:text-5xl lg:text-6xl font-semibold tracking-tight"
-                    style={{ color: "#0097b2" }}
-                  />
-                </div>
-                <p className="text-base md:text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed flex-1">
-                  Strengthen links between academic learning and real-world systems change through the Akomapa Network
-                </p>
-              </MotionDiv>
-            </div>
+            </EditorialHeading>
+            <EditorialLead className="mt-5">By 2027, we aim to:</EditorialLead>
           </div>
-        </div>
-      </section>
+        </FadeIn>
 
-      {/* Voices from Participants Section */}
-      <section className="py-16 md:py-24 bg-gradient-to-r from-[#0097b2] to-[#0F4C5C] text-[#FCFAEF]">
-        <div className="site-container mx-auto px-4">
-          <div className="text-center max-w-3xl mx-auto mb-12">
-            <h2 className="text-3xl md:text-4xl font-bold mb-6">
+        <FadeInStagger className="mt-12">
+          <dl className="grid border-y border-[#1C1F1E]/15 md:grid-cols-3 dark:border-[#FCFAEF]/20">
+            {impactGoals.map((goal, index) => (
+              <FadeInStaggerItem key={goal.description} direction="up">
+                <div
+                  className={`flex min-h-40 flex-col justify-between px-1 py-7 sm:px-6 ${metricDividerClasses[index]} border-[#1C1F1E]/15 dark:border-[#FCFAEF]/20`}
+                >
+                  <dt className="sr-only">{goal.description}</dt>
+                  <dd>
+                    <AnimatedMetric
+                      value={goal.value}
+                      suffix={goal.suffix}
+                      className="font-heading text-4xl font-semibold tracking-tight text-[#0097b2] md:text-5xl dark:text-[#66C4DC]"
+                    />
+                    <p className="mt-4 text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80 md:text-base">
+                      {goal.description}
+                    </p>
+                  </dd>
+                </div>
+              </FadeInStaggerItem>
+            ))}
+          </dl>
+        </FadeInStagger>
+      </EditorialBand>
+
+      <EditorialBand
+        tone="teal"
+        marker="08"
+        id="ghltp-voices"
+        aria-labelledby="ghltp-voices-heading"
+        className="bg-[#0F4C5C]"
+      >
+        <FadeIn>
+          <div className="mx-auto max-w-3xl text-center">
+            <EditorialEyebrow tone="gold" className="text-[#F5C94D]">
+              Testimonials
+            </EditorialEyebrow>
+            <EditorialHeading
+              id="ghltp-voices-heading"
+              className="mt-4 text-[#FCFAEF]"
+            >
               Voices from Participants
-            </h2>
+            </EditorialHeading>
           </div>
-          
+        </FadeIn>
+        <div className="mt-12">
           <GhltpTestimonialsCarousel />
         </div>
-      </section>
+      </EditorialBand>
 
-      {/* Join the Next Cohort CTA Section */}
-      <section className="py-16 md:py-24 bg-gradient-to-r from-[#0F4C5C] via-[#0097b2] to-[#0B2F3A] text-[#FCFAEF] relative overflow-hidden">
-        <div className="absolute inset-0 pointer-events-none">
-          <div className="absolute -top-28 -left-32 h-72 w-72 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
-          <div className="absolute bottom-0 right-0 h-80 w-80 rounded-full bg-[#F5C94D]/10 blur-3xl" />
-        </div>
-
-        <div className="relative site-container mx-auto px-4 sm:px-6">
-          <div className="text-center max-w-4xl mx-auto">
-            <MotionDiv
-              initial={{ opacity: 0, y: 24 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6 }}
-              viewport={{ once: true, amount: 0.4 }}
-              className="space-y-6"
+      <EditorialBand
+        tone="teal"
+        marker="09"
+        id="ghltp-cta"
+        aria-labelledby="ghltp-cta-heading"
+        className="border-t border-[#FCFAEF]/15 bg-[#0F4C5C]"
+      >
+        <FadeIn>
+          <div className="mx-auto max-w-3xl text-center">
+            <EditorialEyebrow tone="gold" className="text-[#F5C94D]">
+              Join the Next Cohort
+            </EditorialEyebrow>
+            <EditorialHeading
+              id="ghltp-cta-heading"
+              className="mt-4 text-[#FCFAEF]"
             >
-              <div>
-                <p className="text-sm font-semibold tracking-[0.2em] text-[#F5C94D] uppercase mb-4">
-                  Join the Next Cohort
-                </p>
-                <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-6 text-[#FCFAEF] leading-tight">
-                  Become Part of a Global Movement
-                </h2>
-              </div>
-              <p className="text-base sm:text-lg md:text-xl text-[#FCFAEF]/85 leading-relaxed max-w-3xl mx-auto">
-                Shape the future of compassionate, ethical healthcare through our Global Health Leadership Training Program.
-              </p>
-              <MotionDiv
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: 0.2 }}
-                viewport={{ once: true }}
-                className="flex flex-col sm:flex-row items-center justify-center gap-4 sm:gap-6 pt-6"
-              >
-                <Button
-                  asChild
-                  size="lg"
-                  className="group bg-[#FCFAEF] text-[#0097b2] hover:bg-[#F5C94D] hover:text-[#1C1F1E] px-6 sm:px-8 py-6 h-auto text-base sm:text-lg font-semibold shadow-lg hover:shadow-xl transition-all duration-300 transform hover:scale-105"
-                >
-                  <Link href="/get-involved" className="flex items-center whitespace-nowrap">
-                    Apply Now
-                    <ArrowRight className="h-5 w-5 ml-2 group-hover:translate-x-1 transition-transform" />
-                  </Link>
-                </Button>
-                <Button
-                  asChild
-                  size="lg"
-                  variant="outline"
-                  className="group border-2 border-[#FCFAEF] text-[#FCFAEF] bg-transparent hover:bg-[#FCFAEF] hover:text-[#0097b2] px-6 sm:px-8 py-6 h-auto text-base sm:text-lg font-semibold transition-all duration-300 transform hover:scale-105"
-                >
-                  <Link href="/programs" className="flex items-center">
-                    Download Program Overview
-                    <ArrowRight className="h-5 w-5 ml-2 group-hover:translate-x-1 transition-transform" />
-                  </Link>
-                </Button>
-                <Button
-                  asChild
-                  size="lg"
-                  variant="outline"
-                  className="group border-2 border-[#F5C94D] text-[#F5C94D] bg-transparent hover:bg-[#F5C94D] hover:text-[#1C1F1E] px-6 sm:px-8 py-6 h-auto text-base sm:text-lg font-semibold transition-all duration-300 transform hover:scale-105"
-                >
-                  <Link href="/partnerships" className="flex items-center whitespace-nowrap">
-                    Partner to Teach
-                    <ArrowRight className="h-5 w-5 ml-2 group-hover:translate-x-1 transition-transform" />
-                  </Link>
-                </Button>
-              </MotionDiv>
-            </MotionDiv>
+              Become Part of a Global Movement
+            </EditorialHeading>
+            <EditorialLead className="mx-auto mt-6 max-w-2xl text-[#FCFAEF]/85 dark:text-[#FCFAEF]/85">
+              Shape the future of compassionate, ethical healthcare through our
+              Global Health Leadership Training Program.
+            </EditorialLead>
+            <div className="mt-10 flex flex-col items-center justify-center gap-3 sm:flex-row sm:flex-wrap sm:gap-4">
+              <EditorialButton href="/get-involved" variant="light">
+                Apply Now
+              </EditorialButton>
+              <EditorialButton href="/programs" variant="outline-light">
+                Download Program Overview
+              </EditorialButton>
+              <EditorialButton href="/partnerships" variant="amber">
+                Partner to Teach
+              </EditorialButton>
+            </div>
           </div>
-        </div>
-      </section>
+        </FadeIn>
+      </EditorialBand>
     </>
   );
 }

--- a/src/app/(main)/programs/akomapa-network/Content.tsx
+++ b/src/app/(main)/programs/akomapa-network/Content.tsx
@@ -1,135 +1,134 @@
-import { MotionDiv, MotionH1, MotionP } from "@/components/motion/framer";
-import { AnimatedMetric } from "@/components/motion/AnimatedMetric";
-import Link from "next/link";
-import { ArrowLeft, ArrowRight, Quote } from "lucide-react";
-import Breadcrumb from "@/components/layout/Breadcrumb";
 import Image from "@/components/common/Image";
-import { Button } from "@/components/ui/button";
+import { FadeIn, FadeInStagger, FadeInStaggerItem } from "@/components/animations";
+import { AnimatedMetric } from "@/components/motion/AnimatedMetric";
+import Breadcrumb from "@/components/layout/Breadcrumb";
+import ProgramDetailHero from "@/components/programs/ProgramDetailHero";
+import ProgramQuoteBand from "@/components/programs/ProgramQuoteBand";
+import {
+  EditorialArrow,
+  EditorialArrowLink,
+  EditorialBand,
+  EditorialButton,
+  EditorialEyebrow,
+  EditorialHeading,
+  EditorialLead,
+} from "@/components/shared/EditorialPrimitives";
 
 const networkFeatures = [
   {
     id: "feature-1",
     title: "Peer-to-Peer Mentorship",
-    description: "Experienced student teams coach new chapters on operations, patient care, and sustainability.",
-    color: "#0097b2"
+    description:
+      "Experienced student teams coach new chapters on operations, patient care, and sustainability.",
   },
   {
     id: "feature-2",
     title: "Case-Based Learning",
-    description: "Real cases from Akomapa clinics are used for shared discussions across sites, building critical reasoning and global clinical competence.",
-    color: "#eeba2b"
+    description:
+      "Real cases from Akomapa clinics are used for shared discussions across sites, building critical reasoning and global clinical competence.",
   },
   {
     id: "feature-3",
     title: "Leadership & Training Access",
-    description: "All Network members have access to the Akomapa Global Health Leadership Training Program — a certificate-bearing course led by faculty from Yale, UCLA, UCC, and UG.",
-    color: "#0097b2"
+    description:
+      "All Network members have access to the Akomapa Global Health Leadership Training Program — a certificate-bearing course led by faculty from Yale, UCLA, UCC, and UG.",
   },
   {
     id: "feature-4",
     title: "Collaborative Research",
-    description: "Network partners co-design and publish studies that evaluate student-led interventions, community outcomes, and leadership development.",
-    color: "#eeba2b"
+    description:
+      "Network partners co-design and publish studies that evaluate student-led interventions, community outcomes, and leadership development.",
   },
   {
     id: "feature-5",
     title: "Immersion Opportunities",
-    description: "Clinics across the Network host visiting students and fellows through the Akomapa Global Health Immersion Program, promoting cross-site collaboration and cultural exchange.",
-    color: "#0097b2"
+    description:
+      "Clinics across the Network host visiting students and fellows through the Akomapa Global Health Immersion Program, promoting cross-site collaboration and cultural exchange.",
   },
   {
     id: "feature-6",
     title: "Knowledge Exchange",
-    description: "Members share best practices on community partnership, data collection, and patient-centered education through regular summits and online forums.",
-    color: "#eeba2b"
-  }
-];
+    description:
+      "Members share best practices on community partnership, data collection, and patient-centered education through regular summits and online forums.",
+  },
+] as const;
 
 const goals = [
   {
     id: "goal-1",
     title: "Strengthen Community-Based Care",
-    description: "Through sustainable, student-powered models that make preventative care accessible everywhere.",
-    color: "#0097b2",
-    value: null,
-    suffix: null,
-    label: null
+    description:
+      "Through sustainable, student-powered models that make preventative care accessible everywhere.",
+    value: null as number | null,
+    suffix: null as string | null,
+    label: null as string | null,
   },
   {
     id: "goal-2",
     title: "Train Global Leaders",
-    description: "Student leaders globally by 2027 in interprofessional collaboration and ethical leadership.",
-    color: "#eeba2b",
+    description:
+      "Student leaders globally by 2027 in interprofessional collaboration and ethical leadership.",
     value: 1000,
     suffix: "+",
-    label: "Student Leaders by 2027"
+    label: "Student Leaders by 2027",
   },
   {
     id: "goal-3",
     title: "Establish Global Presence",
     description: "Community clinics across Africa, North America, and beyond.",
-    color: "#0097b2",
     value: 10,
     suffix: "+",
-    label: "Community Clinics"
+    label: "Community Clinics",
   },
   {
     id: "goal-4",
     title: "Facilitate Joint Learning",
-    description: "Research that informs health policy and curriculum development.",
-    color: "#eeba2b",
-    value: null,
-    suffix: null,
-    label: null
+    description:
+      "Research that informs health policy and curriculum development.",
+    value: null as number | null,
+    suffix: null as string | null,
+    label: null as string | null,
   },
   {
     id: "goal-5",
     title: "Build Global Platform",
-    description: "Mentorship and exchange platform connecting students, faculty, and communities.",
-    color: "#0097b2",
+    description:
+      "Mentorship and exchange platform connecting students, faculty, and communities.",
     value: 5,
     suffix: "+",
-    label: "Countries Connected"
-  }
-];
+    label: "Countries Connected",
+  },
+] as const;
 
 const partnerClinics = [
   {
     name: "Akomapa UCC Clinic",
     location: "University of Cape Coast, Ghana",
-    description: "Our first clinic and proof of concept—serving over 1,000 patients while training 75+ students.",
+    description:
+      "Our first clinic and proof of concept—serving over 1,000 patients while training 75+ students.",
     href: "/community-hubs/ucc",
     logo: "/images/partners/akomapa-logo.png",
-    accentColor: "#0097b2"
+    external: false,
   },
   {
     name: "Neighborhood Health Project",
     location: "New Haven, USA",
-    description: "A longstanding student-powered organization advancing community health equity in Connecticut.",
+    description:
+      "A longstanding student-powered organization advancing community health equity in Connecticut.",
     href: "https://nhp.sites.yale.edu/",
     logo: "/images/partners/nhp-logo.png",
-    accentColor: "#eeba2b",
-    external: true
+    external: true,
   },
   {
     name: "South Side Student-Run Free Clinic",
     location: "University of Chicago, USA",
-    description: "A model clinic empowering students to lead in primary care and chronic disease management.",
+    description:
+      "A model clinic empowering students to lead in primary care and chronic disease management.",
     href: "#",
     logo: "/images/partners/uchicago.png",
-    accentColor: "#0097b2"
-  }
-];
-
-const ctaBaseClass =
-  "group inline-flex items-center justify-center gap-2 rounded-half px-8 py-6 h-auto text-base sm:text-lg font-medium transition-all duration-300 transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2";
-
-
-const primaryCtaClass =
-  `${ctaBaseClass} bg-[#0097b2] hover:bg-[#0097b2]/80 text-[#FCFAEF] shadow-lg hover:shadow-xl focus-visible:ring-[#8DD4E6]`;
-
-const secondaryCtaClass =
-  `${ctaBaseClass} bg-[#eeba2b] hover:bg-[#eeba2b]/80 text-[#FCFAEF] shadow-lg hover:shadow-xl focus-visible:ring-[#F5C94D]`;
+    external: false,
+  },
+] as const;
 
 export default function Content() {
   return (
@@ -137,493 +136,358 @@ export default function Content() {
       <div className="site-container mx-auto">
         <Breadcrumb />
       </div>
-      
-      {/* Hero Section */}
-      <section className="relative min-h-[80vh] py-16 sm:py-20 md:py-28 bg-gradient-to-r from-[#0B2F3A] via-[#0F4C5C] to-[#0097b2] overflow-hidden">
-        <div className="absolute top-0 right-0 w-64 h-64 bg-[#FCFAEF]/10 rounded-full -translate-y-1/2 translate-x-1/2 blur-3xl" />
-        <div className="absolute bottom-0 left-0 w-96 h-96 bg-[#FCFAEF]/10 rounded-full translate-y-1/2 -translate-x-1/2 blur-3xl" />
 
-        <div className="site-container mx-auto px-4 sm:px-6 relative z-10 flex flex-col gap-4 sm:gap-8">
-          <MotionDiv
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            className="pt-2"
-          >
-            <Link 
-              href="/programs" 
-              className="inline-flex items-center text-[#FCFAEF]/80 hover:text-[#FCFAEF] transition-colors text-sm font-medium"
-            >
-              <ArrowLeft className="mr-2 h-4 w-4" />
-              Back to Programs
-            </Link>
-          </MotionDiv>
-          <div className="max-w-5xl">
-            <MotionP
-              initial={{ opacity: 0, y: 40 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.8, ease: "easeOut" }}
-              className="uppercase tracking-[0.3em] text-sm font-semibold text-[#FCFAEF]/80 mb-6"
-            >
-              The Akomapa Network
-            </MotionP>
-            <MotionH1 
-              initial={{ opacity: 0, y: 40 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.1, duration: 0.8, ease: "easeOut" }}
-              className="text-3xl sm:text-4xl md:text-6xl lg:text-7xl font-light text-[#FCFAEF] mb-6 leading-tight"
-            >
-              Connecting Clinics. Sharing Knowledge. Building the Future of Global Health.
-            </MotionH1>
-            <MotionP 
-              initial={{ opacity: 0, y: 40 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.2, duration: 0.8, ease: "easeOut" }}
-              className="text-base sm:text-lg md:text-2xl text-[#FCFAEF]/85 font-light max-w-3xl"
-            >
-              A global community of student-powered clinics, universities, and mentors working together to reimagine how healthcare is delivered and taught.
-            </MotionP>
-            <MotionDiv
-            initial={{ opacity: 0, y: 40 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.3, duration: 0.8, ease: "easeOut" }}
-            className="mt-8 flex flex-wrap gap-4"
-            >
-              <Button asChild className={primaryCtaClass}>
-                <Link href="/get-involved">Join the Network</Link>
-              </Button>
-              <Button asChild className={secondaryCtaClass}>
-                <Link href="/partnerships">Partner with Us</Link>
-              </Button>
-            </MotionDiv>
-          </div>
+      <ProgramDetailHero
+        eyebrow="The Akomapa Network"
+        title="Connecting Clinics. Sharing Knowledge. Building the Future of Global Health."
+        lead="A global community of student-powered clinics, universities, and mentors working together to reimagine how healthcare is delivered and taught."
+        image="/highlights/Akomapa-40.jpg"
+        imageAlt="Global network of student healthcare leaders"
+        ctas={[
+          { href: "/get-involved", label: "Join the Network", variant: "solid" },
+          { href: "/partnerships", label: "Partner with Us", variant: "amber" },
+        ]}
+      />
 
-          <MotionDiv
-            initial={{ opacity: 0, y: 40 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.4, duration: 0.8, ease: "easeOut" }}
-            className="w-full"
-          >
-            <div className="relative w-full h-[280px] sm:h-[360px] md:h-[520px] lg:h-[640px] rounded-3xl overflow-hidden shadow-2xl border border-white/10">
+      <EditorialBand
+        tone="cream"
+        marker="01"
+        id="network-about"
+        aria-labelledby="network-about-heading"
+      >
+        <div className="grid items-start gap-10 lg:grid-cols-12 lg:gap-16">
+          <FadeIn className="lg:col-span-7">
+            <EditorialEyebrow className="text-[#0F4C5C] dark:text-[#66C4DC]">
+              About
+            </EditorialEyebrow>
+            <EditorialHeading id="network-about-heading" className="mt-4">
+              About the Network
+            </EditorialHeading>
+            <div className="mt-6 space-y-5 text-base leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80 md:text-lg">
+              <p>
+                The Akomapa Network is a global community of student-powered
+                clinics, universities, and mentors working together to reimagine
+                how healthcare is delivered and taught.
+              </p>
+              <p>
+                We connect student-powered, expert-supervised clinics from across
+                Africa and the United States — uniting them through shared
+                learning, leadership training, and collaborative innovation.
+              </p>
+              <p className="font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+                Our goal is simple but bold: to make community-based,
+                preventative care accessible everywhere while training the next
+                generation of global health leaders.
+              </p>
+            </div>
+          </FadeIn>
+          <FadeIn direction="left" delay={0.1} className="relative lg:col-span-5">
+            <span
+              aria-hidden="true"
+              className="absolute -top-3 left-0 z-10 h-1 w-24 bg-[#eeba2b]"
+            />
+            <div className="relative aspect-[4/3] overflow-hidden rounded-md border border-[#1C1F1E]/10 bg-[#E6E7E7] dark:border-[#FCFAEF]/15 dark:bg-[#2F3332]">
               <Image
-                src="/highlights/Akomapa-40.jpg"
-                alt="Global network of student healthcare leaders"
+                src="/highlights/Akomapa-66.jpg"
+                alt="Students collaborating across the network"
                 fill
-                sizes="(min-width: 1024px) 50vw, 100vw"
+                sizes="(min-width: 1024px) 40vw, 100vw"
                 className="object-cover"
               />
-              <div className="absolute inset-0 bg-gradient-to-t from-black/35 via-transparent to-transparent" />
             </div>
-          </MotionDiv>
+          </FadeIn>
         </div>
-      </section>
+      </EditorialBand>
 
-      {/* About the Network Section */}
-      <section className="py-16 md:py-24 bg-[#FCFAEF] dark:bg-[#1C1F1E]">
-        <div className="site-container mx-auto px-4">
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-16 items-center">
-            <MotionDiv
-              initial={{ opacity: 0, y: 24 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6 }}
-              viewport={{ once: true, amount: 0.3 }}
-              className="order-1"
+      <EditorialBand
+        tone="teal"
+        marker="02"
+        id="network-vision"
+        aria-labelledby="network-vision-heading"
+        className="bg-[#0F4C5C]"
+      >
+        <FadeIn>
+          <div className="max-w-4xl">
+            <EditorialEyebrow tone="gold" className="text-[#F5C94D]">
+              Vision
+            </EditorialEyebrow>
+            <EditorialHeading
+              id="network-vision-heading"
+              className="mt-4 text-[#FCFAEF]"
             >
-              <h2 className="text-3xl md:text-4xl font-bold mb-6 text-[#1C1F1E] dark:text-[#FCFAEF]">
-                About the Network
-              </h2>
-              <div className="space-y-5 text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed">
-                <p>
-                  The Akomapa Network is a global community of student-powered clinics, universities, and mentors working together to reimagine how healthcare is delivered and taught.
-                </p>
-                <p>
-                  We connect student-powered, expert-supervised clinics from across Africa and the United States — uniting them through shared learning, leadership training, and collaborative innovation.
-                </p>
-                <p className="font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
-                  Our goal is simple but bold: to make community-based, preventative care accessible everywhere while training the next generation of global health leaders.
-                </p>
-              </div>
-            </MotionDiv>
-            <MotionDiv
-              initial={{ opacity: 0, y: 24 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.1, duration: 0.6 }}
-              viewport={{ once: true, amount: 0.3 }}
-              className="order-2"
-            >
-              <div className="relative w-full min-h-[320px] h-[320px] sm:h-[380px] md:h-[420px] lg:h-[460px] rounded-3xl overflow-hidden shadow-2xl">
-                <Image
-                  src="/highlights/Akomapa-66.jpg"
-                  alt="Students collaborating across the network"
-                  fill
-                  sizes="(min-width: 1024px) 50vw, 100vw"
-                  className="object-cover"
-                />
-                <div className="absolute inset-0 bg-gradient-to-t from-black/25 via-transparent to-transparent" />
-              </div>
-            </MotionDiv>
+              Our Vision
+            </EditorialHeading>
+            <EditorialLead className="mt-6 text-[#FCFAEF]/90 dark:text-[#FCFAEF]/90 md:text-xl">
+              To build a global learning ecosystem where student-powered clinics
+              don&apos;t work in isolation but as part of a connected movement —
+              sharing data, stories, and strategies that strengthen both care
+              delivery and education.
+            </EditorialLead>
+            <EditorialLead className="mt-5 text-[#FCFAEF]/85 dark:text-[#FCFAEF]/85">
+              We envision a world where a student team in Ghana can learn from
+              one in Chicago, where a New Haven community project can inspire a
+              rural screening model, and where young leaders everywhere are
+              equipped to bridge the gap between knowledge and action.
+            </EditorialLead>
           </div>
-        </div>
-      </section>
+        </FadeIn>
+      </EditorialBand>
 
-      {/* Vision Section */}
-      <section className="py-16 md:py-24 bg-gradient-to-r from-[#0097b2] via-[#0F4C5C] to-[#0B2F3A] text-[#FCFAEF] relative overflow-hidden">
-        <div className="absolute inset-0 pointer-events-none">
-          <div className="absolute -top-24 -left-24 h-64 w-64 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
-          <div className="absolute bottom-0 right-0 h-80 w-80 rounded-full bg-[#F5C94D]/10 blur-3xl" />
-        </div>
-        <div className="relative site-container mx-auto px-4">
-          <div className="max-w-4xl mx-auto">
-            <MotionDiv
-              initial={{ opacity: 0, y: 24 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6 }}
-              viewport={{ once: true, amount: 0.3 }}
-              className="text-center mb-12 space-y-6"
-            >
-              <h2 className="text-3xl md:text-4xl font-bold leading-tight">
-                Our Vision
-              </h2>
-              <p className="text-lg md:text-xl text-[#FCFAEF]/90 leading-relaxed">
-                To build a global learning ecosystem where student-powered clinics don&apos;t work in isolation but as part of a connected movement — sharing data, stories, and strategies that strengthen both care delivery and education.
-              </p>
-              <p className="text-base md:text-lg text-[#FCFAEF]/85 leading-relaxed">
-                We envision a world where a student team in Ghana can learn from one in Chicago, where a New Haven community project can inspire a rural screening model, and where young leaders everywhere are equipped to bridge the gap between knowledge and action.
-              </p>
-            </MotionDiv>
-          </div>
-        </div>
-      </section>
-
-      {/* What the Network Does Section */}
-      <section className="py-16 md:py-24 bg-[#FCFAEF] dark:bg-[#1C1F1E]">
-        <div className="site-container mx-auto px-4">
-          <MotionDiv
-            initial={{ opacity: 0, y: 24 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true, amount: 0.3 }}
-            className="text-center max-w-4xl mx-auto mb-12 space-y-4"
-          >
-            <h2 className="text-3xl md:text-4xl font-bold text-[#1C1F1E] dark:text-[#FCFAEF]">
+      <EditorialBand
+        tone="cream"
+        marker="03"
+        id="network-does"
+        aria-labelledby="network-does-heading"
+      >
+        <FadeIn>
+          <div className="max-w-3xl">
+            <EditorialEyebrow className="text-[#0F4C5C] dark:text-[#66C4DC]">
+              Functions
+            </EditorialEyebrow>
+            <EditorialHeading id="network-does-heading" className="mt-4">
               What the Network Does
-            </h2>
-            <p className="text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed">
-              Six core functions that connect, empower, and amplify student-powered care across the globe.
-            </p>
-          </MotionDiv>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8">
-            {networkFeatures.map((feature, index) => (
-              <MotionDiv
-                key={feature.id}
-                initial={{ opacity: 0, y: 24 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: index * 0.1 }}
-                viewport={{ once: true, amount: 0.3 }}
-                className="group relative rounded-2xl bg-white dark:bg-[#2F3332] p-6 md:p-8 shadow-lg hover:shadow-xl transition-all duration-300 border border-[#E6E7E7]/20 dark:border-[#4F5554]/20 hover:-translate-y-1"
-              >
-                <div className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300 bg-gradient-to-br from-[#0097b2]/5 via-transparent to-[#eeba2b]/5 rounded-2xl" />
-                <div className="relative">
-                  <div 
-                    className="h-1 w-16 rounded-full mb-4"
-                    style={{ backgroundColor: feature.color }}
-                  />
-                  <h3 className="text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF] mb-3">
-                    {feature.title}
-                  </h3>
-                  <p className="text-sm md:text-base text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed">
-                    {feature.description}
-                  </p>
-                </div>
-              </MotionDiv>
-            ))}
+            </EditorialHeading>
+            <EditorialLead className="mt-5">
+              Six core functions that connect, empower, and amplify
+              student-powered care across the globe.
+            </EditorialLead>
           </div>
-        </div>
-      </section>
+        </FadeIn>
 
-      {/* Goals Section */}
-      <section className="py-16 md:py-24 bg-gradient-to-r from-[#0097b2] to-[#0F4C5C] text-[#FCFAEF] relative overflow-hidden">
-        <div className="absolute inset-0 pointer-events-none">
-          <div className="absolute -top-20 left-10 h-56 w-56 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
-          <div className="absolute bottom-0 right-0 h-72 w-72 rounded-full bg-[#F5C94D]/10 blur-3xl" />
-        </div>
-        <div className="relative site-container mx-auto px-4">
-          <MotionDiv
-            initial={{ opacity: 0, y: 24 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true, amount: 0.3 }}
-            className="text-center max-w-4xl mx-auto mb-12 space-y-4"
-          >
-            <h2 className="text-3xl md:text-4xl font-bold leading-tight">
+        <ol className="mt-12 grid border-t border-[#1C1F1E]/15 md:grid-cols-2 xl:grid-cols-3 dark:border-[#FCFAEF]/20">
+          {networkFeatures.map((feature, index) => (
+            <li
+              key={feature.id}
+              className="border-b border-[#1C1F1E]/15 px-1 py-7 md:border-r md:px-6 xl:[&:nth-child(3n)]:border-r-0 dark:border-[#FCFAEF]/20"
+            >
+              <span
+                aria-hidden="true"
+                className="font-heading text-3xl font-semibold tracking-[-0.06em] text-[#0097b2]/55 dark:text-[#66C4DC]/65"
+              >
+                {String(index + 1).padStart(2, "0")}
+              </span>
+              <h3 className="mt-4 font-heading text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+                {feature.title}
+              </h3>
+              <p className="mt-3 text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
+                {feature.description}
+              </p>
+            </li>
+          ))}
+        </ol>
+      </EditorialBand>
+
+      <EditorialBand
+        tone="teal"
+        marker="04"
+        id="network-goals"
+        aria-labelledby="network-goals-heading"
+        className="bg-[#0F4C5C]"
+      >
+        <FadeIn>
+          <div className="max-w-3xl">
+            <EditorialEyebrow tone="gold" className="text-[#F5C94D]">
+              Goals
+            </EditorialEyebrow>
+            <EditorialHeading
+              id="network-goals-heading"
+              className="mt-4 text-[#FCFAEF]"
+            >
               What We Hope to Accomplish
-            </h2>
-            <p className="text-lg text-[#FCFAEF]/85 leading-relaxed">
+            </EditorialHeading>
+            <EditorialLead className="mt-5 text-[#FCFAEF]/85 dark:text-[#FCFAEF]/85">
               Bold goals that drive our collective mission forward.
-            </p>
-          </MotionDiv>
+            </EditorialLead>
+          </div>
+        </FadeIn>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8 max-w-6xl mx-auto">
+        <FadeInStagger className="mt-12">
+          <ol className="grid border-t border-[#FCFAEF]/25 md:grid-cols-2 lg:grid-cols-3">
             {goals.map((goal, index) => (
-              <MotionDiv
-                key={goal.id}
-                initial={{ opacity: 0, y: 24 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: index * 0.1 }}
-                viewport={{ once: true, amount: 0.3 }}
-                className="relative rounded-2xl bg-[#FCFAEF]/95 text-[#1C1F1E] p-6 md:p-8 shadow-xl border border-[#E6E7E7]/40 hover:scale-105 transition-transform duration-300 flex flex-col"
-              >
-                <div 
-                  className="h-1 w-16 rounded-full mb-4"
-                  style={{ backgroundColor: goal.color }}
-                />
-                {goal.value !== null && (
-                  <div className="mb-4">
-                    <AnimatedMetric
-                      value={goal.value}
-                      suffix={goal.suffix ?? ""}
-                      className="text-4xl md:text-5xl lg:text-6xl font-semibold tracking-tight"
-                      style={{ color: goal.color }}
-                    />
-                    {goal.label && (
-                      <p className="mt-2 text-sm font-semibold uppercase tracking-[0.2em] text-[#1C1F1E]/70">
-                        {goal.label}
-                      </p>
-                    )}
-                  </div>
-                )}
-                <h3 className="text-lg md:text-xl font-semibold mb-3 text-[#1C1F1E]">
-                  {goal.title}
-                </h3>
-                <p className="text-sm md:text-base text-[#2F3332]/85 leading-relaxed flex-1">
-                  {goal.description}
-                </p>
-              </MotionDiv>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Partner Clinics Section */}
-      <section className="py-16 md:py-24 bg-[#FCFAEF] dark:bg-[#1C1F1E]">
-        <div className="site-container mx-auto px-4">
-          <MotionDiv
-            initial={{ opacity: 0, y: 24 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true, amount: 0.3 }}
-            className="text-center max-w-4xl mx-auto mb-12 space-y-4"
-          >
-            <h2 className="text-3xl md:text-4xl font-bold text-[#1C1F1E] dark:text-[#FCFAEF]">
-              Founding & Partner Clinics
-            </h2>
-            <p className="text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed">
-              Student-powered clinics leading the way in community-based care and global collaboration.
-            </p>
-          </MotionDiv>
-
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-6xl mx-auto">
-            {partnerClinics.map((clinic, index) => (
-              <MotionDiv
-                key={clinic.name}
-                initial={{ opacity: 0, y: 24 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: index * 0.1 }}
-                viewport={{ once: true, amount: 0.3 }}
-                className="group relative bg-white dark:bg-[#2F3332] rounded-2xl overflow-hidden shadow-lg hover:shadow-xl transition-all duration-300 border border-[#E6E7E7]/20 dark:border-[#4F5554]/20 hover:-translate-y-1"
-              >
-                <div className="p-6 md:p-8">
-                  <div className="flex items-center justify-center h-28 md:h-32 mb-6">
-                    <div className="relative h-full w-full">
-                      <Image
-                        src={clinic.logo}
-                        alt={`${clinic.name} logo`}
-                        fill
-                        sizes="(min-width: 1024px) 28vw, 90vw"
-                        className="object-contain"
+              <FadeInStaggerItem key={goal.id} direction="up">
+                <li className="flex h-full flex-col border-b border-[#FCFAEF]/25 px-1 py-7 md:px-6 lg:border-r lg:[&:nth-child(3n)]:border-r-0">
+                  <span
+                    aria-hidden="true"
+                    className="font-heading text-3xl font-semibold tracking-[-0.06em] text-[#FCFAEF]/45"
+                  >
+                    {String(index + 1).padStart(2, "0")}
+                  </span>
+                  {goal.value !== null ? (
+                    <div className="mt-4">
+                      <AnimatedMetric
+                        value={goal.value}
+                        suffix={goal.suffix ?? ""}
+                        className="font-heading text-4xl font-semibold tracking-tight text-[#eeba2b] md:text-5xl"
                       />
+                      {goal.label ? (
+                        <p className="mt-2 font-subheading text-xs font-semibold uppercase tracking-[0.2em] text-[#FCFAEF]/65">
+                          {goal.label}
+                        </p>
+                      ) : null}
                     </div>
-                  </div>
-                  <h3 className="text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF] mb-2">
-                    {clinic.name}
+                  ) : null}
+                  <h3 className="mt-4 font-heading text-lg font-semibold text-[#FCFAEF] md:text-xl">
+                    {goal.title}
                   </h3>
-                  <p className="text-sm text-[#0097b2] dark:text-[#66C4DC] mb-4 font-medium">
-                    {clinic.location}
+                  <p className="mt-3 text-sm leading-relaxed text-[#FCFAEF]/85 md:text-base">
+                    {goal.description}
                   </p>
-                  <p className="text-sm md:text-base text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed mb-6">
-                    {clinic.description}
-                  </p>
-                  {clinic.external ? (
-                    <a
-                      href={clinic.href}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center text-sm font-semibold"
-                      style={{ color: clinic.accentColor }}
-                    >
-                      Visit Page
-                      <ArrowRight className="ml-2 h-4 w-4 group-hover:translate-x-1 transition-transform" />
-                    </a>
-                  ) : (
-                    <Link
-                      href={clinic.href}
-                      className="inline-flex items-center text-sm font-semibold"
-                      style={{ color: clinic.accentColor }}
-                    >
-                      Visit Page
-                      <ArrowRight className="ml-2 h-4 w-4 group-hover:translate-x-1 transition-transform" />
-                    </Link>
-                  )}
-                </div>
-                <div 
-                  className="absolute bottom-0 left-0 right-0 h-1 opacity-0 group-hover:opacity-100 transition-opacity"
-                  style={{ backgroundColor: clinic.accentColor }}
-                />
-              </MotionDiv>
+                </li>
+              </FadeInStaggerItem>
             ))}
-          </div>
-        </div>
-      </section>
+          </ol>
+        </FadeInStagger>
+      </EditorialBand>
 
-      {/* Why It Matters Section */}
-      <section className="py-16 md:py-24 bg-gradient-to-r from-[#0B2F3A] via-[#0F4C5C] to-[#0097b2] text-[#FCFAEF] relative overflow-hidden">
-        <div className="absolute inset-0 pointer-events-none">
-          <div className="absolute -top-28 -left-32 h-72 w-72 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
-          <div className="absolute bottom-0 right-0 h-80 w-80 rounded-full bg-[#F5C94D]/10 blur-3xl" />
-        </div>
-        <div className="relative site-container mx-auto px-4">
-          <div className="max-w-4xl mx-auto">
-            <MotionDiv
-              initial={{ opacity: 0, y: 24 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6 }}
-              viewport={{ once: true, amount: 0.3 }}
-              className="text-center mb-8"
+      <EditorialBand
+        tone="cream"
+        marker="05"
+        id="network-partners"
+        aria-labelledby="network-partners-heading"
+      >
+        <FadeIn>
+          <div className="max-w-3xl">
+            <EditorialEyebrow className="text-[#0F4C5C] dark:text-[#66C4DC]">
+              Partners
+            </EditorialEyebrow>
+            <EditorialHeading id="network-partners-heading" className="mt-4">
+              Founding & Partner Clinics
+            </EditorialHeading>
+            <EditorialLead className="mt-5">
+              Student-powered clinics leading the way in community-based care
+              and global collaboration.
+            </EditorialLead>
+          </div>
+        </FadeIn>
+
+        <ul className="mt-12 grid border-t border-[#1C1F1E]/15 md:grid-cols-3 dark:border-[#FCFAEF]/20">
+          {partnerClinics.map((clinic) => (
+            <li
+              key={clinic.name}
+              className="border-b border-[#1C1F1E]/15 px-1 py-8 md:border-r md:px-6 md:[&:nth-child(3n)]:border-r-0 dark:border-[#FCFAEF]/20"
             >
-              <h2 className="text-3xl md:text-4xl font-bold mb-6 leading-tight">
-                Why It Matters
-              </h2>
-            </MotionDiv>
-            <MotionDiv
-              initial={{ opacity: 0, y: 24 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6, delay: 0.1 }}
-              viewport={{ once: true, amount: 0.3 }}
-              className="space-y-6 text-lg md:text-xl text-[#FCFAEF]/90 leading-relaxed"
+              <div className="relative mb-6 flex h-20 items-center justify-center sm:h-24">
+                <div className="relative h-full w-full max-w-[12rem]">
+                  <Image
+                    src={clinic.logo}
+                    alt={`${clinic.name} logo`}
+                    fill
+                    sizes="(min-width: 1024px) 20vw, 60vw"
+                    className="object-contain"
+                  />
+                </div>
+              </div>
+              <h3 className="font-heading text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+                {clinic.name}
+              </h3>
+              <p className="mt-2 text-sm font-medium text-[#0097b2] dark:text-[#66C4DC]">
+                {clinic.location}
+              </p>
+              <p className="mt-4 text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80 md:text-base">
+                {clinic.description}
+              </p>
+              {clinic.external ? (
+                <a
+                  href={clinic.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="group mt-6 inline-flex min-h-11 w-fit items-center gap-2 text-sm font-semibold text-[#0097b2] transition-colors hover:text-[#0F4C5C] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] focus-visible:ring-offset-2 dark:text-[#66C4DC] dark:hover:text-[#F5C94D]"
+                >
+                  Visit Page
+                  <EditorialArrow className="transition-transform group-hover:translate-x-0.5" />
+                </a>
+              ) : (
+                <EditorialArrowLink href={clinic.href} className="mt-6">
+                  Visit Page
+                </EditorialArrowLink>
+              )}
+            </li>
+          ))}
+        </ul>
+      </EditorialBand>
+
+      <EditorialBand
+        tone="teal"
+        marker="06"
+        id="network-matters"
+        aria-labelledby="network-matters-heading"
+        className="bg-[#0F4C5C]"
+      >
+        <FadeIn>
+          <div className="max-w-4xl">
+            <EditorialEyebrow tone="gold" className="text-[#F5C94D]">
+              Purpose
+            </EditorialEyebrow>
+            <EditorialHeading
+              id="network-matters-heading"
+              className="mt-4 text-[#FCFAEF]"
             >
+              Why It Matters
+            </EditorialHeading>
+            <div className="mt-6 space-y-5 text-base leading-relaxed text-[#FCFAEF]/90 md:text-lg">
               <p>
-                The Akomapa Network is more than a collaboration — it&apos;s a global classroom without walls.
+                The Akomapa Network is more than a collaboration — it&apos;s a
+                global classroom without walls.
               </p>
               <p>
-                Every clinic becomes both a site of care and a site of learning, where students grow as clinicians, leaders, and changemakers while improving the health of their communities.
+                Every clinic becomes both a site of care and a site of learning,
+                where students grow as clinicians, leaders, and changemakers
+                while improving the health of their communities.
               </p>
               <p className="font-semibold text-[#FCFAEF]">
-                By linking student-powered clinics into one connected system, we&apos;re making community care smarter, stronger, and sustainable — driven by evidence, compassion, and shared purpose.
+                By linking student-powered clinics into one connected system,
+                we&apos;re making community care smarter, stronger, and
+                sustainable — driven by evidence, compassion, and shared purpose.
               </p>
-            </MotionDiv>
+            </div>
           </div>
-        </div>
-      </section>
+        </FadeIn>
+      </EditorialBand>
 
-      {/* Join the Movement CTA */}
-      <section className="py-16 md:py-24 bg-[#FCFAEF] dark:bg-[#1C1F1E]">
-        <div className="site-container mx-auto px-4">
-          <MotionDiv
-            initial={{ opacity: 0, y: 24 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true, amount: 0.3 }}
-            className="max-w-3xl mx-auto text-center space-y-6"
-          >
-            <h2 className="text-3xl md:text-4xl font-bold text-[#1C1F1E] dark:text-[#FCFAEF]">
+      <EditorialBand
+        tone="cream"
+        marker="07"
+        id="network-cta"
+        aria-labelledby="network-cta-heading"
+      >
+        <FadeIn>
+          <div className="mx-auto max-w-3xl text-center">
+            <EditorialEyebrow className="text-[#0F4C5C] dark:text-[#66C4DC]">
+              Get Involved
+            </EditorialEyebrow>
+            <EditorialHeading id="network-cta-heading" className="mt-4">
               Join the Movement
-            </h2>
-            <p className="text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed">
-              We invite universities, clinics, and community organizations to join a network redefining what it means to learn, lead, and serve.
-            </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center pt-4">
-              <Button
-                asChild
-                className="bg-[#0097b2] hover:bg-[#0097b2]/80 text-[#FCFAEF] font-semibold px-8 py-6 h-auto"
-              >
-                <Link href="/partnerships" className="flex items-center whitespace-nowrap">
-                  Join the Network
-                  <ArrowRight className="ml-2 h-4 w-4" />
-                </Link>
-              </Button>
-              <Button
-                asChild
-                variant="outline"
-                className="border-2 border-[#0097b2] text-[#0097b2] hover:bg-[#0097b2] hover:text-[#FCFAEF] font-semibold px-8 py-6 h-auto"
-              >
-                <Link href="/partnerships" className="flex items-center whitespace-nowrap">
-                  Propose a Partnership
-                  <ArrowRight className="ml-2 h-4 w-4" />
-                </Link>
-              </Button>
-              <Button
-                asChild
-                variant="outline"
-                className="border-2 border-[#eeba2b] text-[#eeba2b] hover:bg-[#eeba2b] hover:text-[#1C1F1E] font-semibold px-8 py-6 h-auto"
-              >
-                <Link href="/programs" className="flex items-center whitespace-nowrap">
-                  Learn More
-                  <ArrowRight className="ml-2 h-4 w-4" />
-                </Link>
-              </Button>
+            </EditorialHeading>
+            <EditorialLead className="mx-auto mt-5 max-w-2xl">
+              We invite universities, clinics, and community organizations to
+              join a network redefining what it means to learn, lead, and serve.
+            </EditorialLead>
+            <div className="mt-10 flex flex-col items-center justify-center gap-3 sm:flex-row sm:flex-wrap sm:gap-4">
+              <EditorialButton href="/partnerships" variant="solid">
+                Join the Network
+              </EditorialButton>
+              <EditorialButton href="/partnerships" variant="outline">
+                Propose a Partnership
+              </EditorialButton>
+              <EditorialButton href="/programs" variant="amber">
+                Learn More
+              </EditorialButton>
             </div>
-          </MotionDiv>
-        </div>
-      </section>
+          </div>
+        </FadeIn>
+      </EditorialBand>
 
-      {/* From the Founders Section */}
-      <section className="py-16 md:py-24 bg-gradient-to-r from-[#0F4C5C] via-[#0097b2] to-[#0B2F3A] text-[#FCFAEF] relative overflow-hidden">
-        <div className="absolute inset-0 pointer-events-none">
-          <div className="absolute -top-20 left-10 h-56 w-56 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
-          <div className="absolute bottom-0 right-0 h-72 w-72 rounded-full bg-[#F5C94D]/10 blur-3xl" />
-        </div>
-        <div className="relative site-container mx-auto px-4">
-          <MotionDiv
-            initial={{ opacity: 0, y: 24 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true, amount: 0.3 }}
-            className="max-w-3xl mx-auto space-y-8"
-          >
-            <h2 className="text-3xl md:text-4xl font-bold text-center">From the Founders</h2>
-            
-            <div className="relative bg-[#FCFAEF]/10 backdrop-blur-md rounded-2xl p-8 md:p-10 shadow-xl border border-[#FCFAEF]/20">
-              <div className="absolute top-6 left-6 text-[#FCFAEF]/20">
-                <Quote size={48} />
-              </div>
-              <blockquote className="relative z-10 text-lg md:text-xl text-[#FCFAEF]/90 leading-relaxed italic pl-8">
-                &quot;The Akomapa Network is building a future where a clinic is not just a place of care but a platform for transformation. Together, we&apos;re proving that student leadership can move systems, and that collaboration across borders can save lives.&quot;
-              </blockquote>
-            </div>
-
-            <div className="flex items-center gap-4">
-              <div className="relative h-16 w-16 rounded-full overflow-hidden border-2 border-[#F5C94D]/40 shadow-lg flex-shrink-0">
-                <Image
-                  src="/team/sedem-dankwa.jpg"
-                  alt="Sedem Dankwa"
-                  fill
-                  className="object-cover object-center"
-                  sizes="64px"
-                />
-              </div>
-              <div className="flex flex-col items-start">
-                <p className="text-base font-semibold text-[#F5C94D]">
-                  Sedem Dankwa
-                </p>
-                <p className="text-sm text-[#FCFAEF]/80">
-                  Global Partnerships Team Lead
-                </p>
-              </div>
-            </div>
-          </MotionDiv>
-        </div>
-      </section>
+      <ProgramQuoteBand
+        tone="teal"
+        marker="08"
+        id="network-quote"
+        className="bg-[#0F4C5C]"
+        quote="The Akomapa Network is building a future where a clinic is not just a place of care but a platform for transformation. Together, we're proving that student leadership can move systems, and that collaboration across borders can save lives."
+        attribution="Sedem Dankwa"
+        role="Global Partnerships Team Lead"
+        image="/team/sedem-dankwa.jpg"
+        imageAlt="Sedem Dankwa"
+      />
     </>
   );
 }

--- a/src/app/(main)/programs/akomapa-young-advocates/Content.tsx
+++ b/src/app/(main)/programs/akomapa-young-advocates/Content.tsx
@@ -1,10 +1,16 @@
-import { MotionDiv, MotionH1, MotionP } from "@/components/motion/framer";
-import { AnimatedMetric } from "@/components/motion/AnimatedMetric";
-import Link from "next/link";
-import { ArrowLeft, ArrowRight } from "lucide-react";
-import Breadcrumb from "@/components/layout/Breadcrumb";
 import Image from "@/components/common/Image";
-import { Button } from "@/components/ui/button";
+import { FadeIn, FadeInStagger, FadeInStaggerItem } from "@/components/animations";
+import { AnimatedMetric } from "@/components/motion/AnimatedMetric";
+import Breadcrumb from "@/components/layout/Breadcrumb";
+import ProgramDetailHero from "@/components/programs/ProgramDetailHero";
+import ProgramQuoteBand from "@/components/programs/ProgramQuoteBand";
+import {
+  EditorialBand,
+  EditorialButton,
+  EditorialEyebrow,
+  EditorialHeading,
+  EditorialLead,
+} from "@/components/shared/EditorialPrimitives";
 
 const whatWeDo = [
   {
@@ -12,64 +18,55 @@ const whatWeDo = [
     title: "Educate on NCDs",
     description:
       "We translate complex topics—hypertension, diabetes, mental health, and nutrition—into relatable lessons, helping students see how these non-communicable concerns connect to stress, emotional well-being, and long-term health.",
-    color: "#0097b2"
   },
   {
     id: "screenings",
     title: "Provide Health Screenings",
     description:
       "Students receive free blood pressure and glucose checks with pathways to local Akomapa clinics for follow-up care when needed.",
-    color: "#eeba2b"
   },
   {
     id: "healthy-lifestyles",
     title: "Promote Healthy Lifestyles",
     description:
       "Interactive demonstrations share practical strategies for preventing hypertension, diabetes, and mental health challenges through balanced nutrition, movement, stress management, and emotional well-being.",
-    color: "#0F4C5C"
   },
   {
     id: "advocate-training",
     title: "Train Young Advocates",
     description:
       "We mentor student leaders to run awareness campaigns on hypertension, diabetes, and mental health—leading peer education and championing wellness initiatives on their campuses.",
-    color: "#0097b2"
   },
   {
     id: "career-mentorship",
     title: "Offer Career Mentorship",
     description:
       "Storytelling circles expose students to careers in medicine, nursing, pharmacy, public health, and leadership while demystifying the journey ahead.",
-    color: "#eeba2b"
-  }
-];
+  },
+] as const;
 
 const mentorshipBenefits = [
   {
     title: "Leadership Coaching",
     description:
       "Continued mentorship in health leadership, communication, and advocacy keeps every Young Advocate supported.",
-    color: "#0097b2"
   },
   {
     title: "Training Studios",
     description:
       "Periodic workshops dive into community engagement and prevention of hypertension, diabetes, and mental health challenges using real cases from Akomapa clinics.",
-    color: "#eeba2b"
   },
   {
     title: "Student Projects",
     description:
       "Advocates design and lead school-based health campaigns, service projects, and storytelling activations.",
-    color: "#0F4C5C"
   },
   {
     title: "Youth Forums",
     description:
       "Invitations to leadership forums and community health days connect students to regional clinic partners.",
-    color: "#8DD4E6"
-  }
-];
+  },
+] as const;
 
 const mentorshipHighlights = [
   {
@@ -77,50 +74,47 @@ const mentorshipHighlights = [
     title: "Guided by University Mentors",
     description:
       "Each advocate is paired with an interprofessional mentor who blends compassion, accountability, and lived experience.",
-    accent: "#F5C94D"
   },
   {
     label: "Leadership in Action",
     title: "Projects that Matter",
     description:
       "Students launch wellness clubs, awareness drives, and research projects that keep momentum alive between visits.",
-    accent: "#66C4DC"
   },
   {
     label: "Community Connection",
     title: "Clinic-Linked Support",
     description:
       "Mentorship stays tethered to Akomapa clinics so referrals, data, and storytelling always feed back into care.",
-    accent: "#E6E7E7"
-  }
-];
+  },
+] as const;
 
 const howItWorks = [
   {
     eyebrow: "Step 01",
     title: "Clinic Partnerships",
     description:
-      "Local Akomapa clinics collaborate with nearby high schools to co-design immersive health education experiences."
+      "Local Akomapa clinics collaborate with nearby high schools to co-design immersive health education experiences.",
   },
   {
     eyebrow: "Step 02",
     title: "Student Facilitation",
     description:
-      "Interprofessional university teams deliver interactive sessions that blend storytelling, demonstrations, and screenings for hypertension, diabetes, and mental wellness."
+      "Interprofessional university teams deliver interactive sessions that blend storytelling, demonstrations, and screenings for hypertension, diabetes, and mental wellness.",
   },
   {
     eyebrow: "Step 03",
     title: "Young Advocate Pathway",
     description:
-      "Students who show passion join the Young Advocates track for deeper mentorship and leadership development."
+      "Students who show passion join the Young Advocates track for deeper mentorship and leadership development.",
   },
   {
     eyebrow: "Step 04",
     title: "Sustained Engagement",
     description:
-      "Regional clinic teams host mentorship circles, community projects, and annual leadership events to keep momentum strong."
-  }
-];
+      "Regional clinic teams host mentorship circles, community projects, and annual leadership events to keep momentum strong.",
+  },
+] as const;
 
 const impactMetrics = [
   {
@@ -129,8 +123,8 @@ const impactMetrics = [
     value: 9000,
     suffix: "+",
     label: "Students Reached",
-    description: "Educating high school students on preventing hypertension, diabetes, and mental health challenges—building lifelong health literacy.",
-    color: "#0097b2"
+    description:
+      "Educating high school students on preventing hypertension, diabetes, and mental health challenges—building lifelong health literacy.",
   },
   {
     id: "advocates",
@@ -138,8 +132,8 @@ const impactMetrics = [
     value: 300,
     suffix: "+",
     label: "Youth Advocates",
-    description: "Training peer leaders to champion healthy habits and support students around hypertension, diabetes, mental health, and stress on their campuses.",
-    color: "#eeba2b"
+    description:
+      "Training peer leaders to champion healthy habits and support students around hypertension, diabetes, mental health, and stress on their campuses.",
   },
   {
     id: "partnerships",
@@ -147,8 +141,8 @@ const impactMetrics = [
     value: 6,
     suffix: "+",
     label: "Clinic Regions",
-    description: "Linking schools to clinic teams that reinforce prevention and referrals for hypertension, diabetes, mental health, and whole-person care across regions.",
-    color: "#0F4C5C"
+    description:
+      "Linking schools to clinic teams that reinforce prevention and referrals for hypertension, diabetes, mental health, and whole-person care across regions.",
   },
   {
     id: "pipeline",
@@ -156,547 +150,429 @@ const impactMetrics = [
     value: 1,
     suffix: "",
     label: "Leadership Pipeline",
-    description: "Building an early pathway into compassionate health leadership grounded in care for body and mind.",
-    color: "#0097b2"
-  }
-];
-
-const ctaBaseClass =
-  "group inline-flex items-center justify-center gap-2 rounded-half px-8 py-6 h-auto text-base sm:text-lg font-medium transition-all duration-300 transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2";
-
-const primaryCtaClass =
-  `${ctaBaseClass} bg-[#0097b2] hover:bg-[#0097b2]/80 text-[#FCFAEF] shadow-lg hover:shadow-xl focus-visible:ring-[#8DD4E6]`;
-
-const secondaryCtaClass =
-  `${ctaBaseClass} bg-[#eeba2b] hover:bg-[#eeba2b]/80 text-[#FCFAEF] shadow-lg hover:shadow-xl focus-visible:ring-[#F5C94D]`;
+    description:
+      "Building an early pathway into compassionate health leadership grounded in care for body and mind.",
+  },
+] as const;
 
 export default function Content() {
   return (
-    <div className="overflow-x-hidden">
+    <>
       <div className="site-container mx-auto">
         <Breadcrumb />
       </div>
 
-      <section className="relative min-h-[80vh] py-16 sm:py-20 md:py-28 bg-gradient-to-r from-[#0B2F3A] via-[#0F4C5C] to-[#0097b2] overflow-hidden">
-        <div className="absolute top-6 right-6 w-64 h-64 bg-[#FCFAEF]/10 rounded-full blur-3xl" />
-        <div className="absolute bottom-6 left-6 w-96 h-96 bg-[#FCFAEF]/10 rounded-full blur-3xl" />
+      <ProgramDetailHero
+        eyebrow="Akomapa Young Advocates Program"
+        title="Educating. Empowering. Inspiring the Next Generation of Health Leaders."
+        lead="Led by university students trained through Akomapa clinics, the Young Advocates Program brings education on hypertension, diabetes, mental health, and whole-person wellness—alongside mentorship and leadership development—directly to high schools."
+        image="/gallery/gallery-pic-2.jpg"
+        imageAlt="Young advocates participating in a health education session"
+        ctas={[
+          { href: "/partnerships", label: "Partner with Us", variant: "solid" },
+          {
+            href: "/get-involved",
+            label: "Volunteer as a University Student",
+            variant: "amber",
+          },
+        ]}
+      />
 
-        <div className="site-container mx-auto px-4 sm:px-6 relative z-10 flex flex-col gap-12 sm:gap-14">
-          <MotionDiv
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            className="pt-2"
-          >
-            <Link
-              href="/programs"
-              className="inline-flex items-center text-[#FCFAEF]/80 hover:text-[#FCFAEF] transition-colors text-sm font-medium"
-            >
-              <ArrowLeft className="mr-2 h-4 w-4" />
-              Back to Programs
-            </Link>
-          </MotionDiv>
-          <div className="max-w-5xl">
-            <MotionP
-              initial={{ opacity: 0, y: 40 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.8, ease: "easeOut" }}
-              className="uppercase tracking-[0.3em] text-sm font-semibold text-[#FCFAEF]/80 mb-6"
-            >
-              Akomapa Young Advocates Program
-            </MotionP>
-            <MotionH1
-              initial={{ opacity: 0, y: 40 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.1, duration: 0.8, ease: "easeOut" }}
-              className="text-3xl sm:text-4xl md:text-6xl lg:text-7xl font-light text-[#FCFAEF] mb-6 leading-tight"
-            >
-              Educating. Empowering. Inspiring the Next Generation of Health Leaders.
-            </MotionH1>
-            <MotionP
-              initial={{ opacity: 0, y: 40 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.2, duration: 0.8, ease: "easeOut" }}
-              className="text-base sm:text-lg md:text-2xl text-[#FCFAEF]/85 font-light max-w-3xl"
-            >
-              Led by university students trained through Akomapa clinics, the Young Advocates Program brings education on hypertension, diabetes, mental health, and whole-person wellness—alongside mentorship and leadership development—directly to high schools.
-            </MotionP>
-            <MotionDiv
-              initial={{ opacity: 0, y: 40 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.3, duration: 0.8, ease: "easeOut" }}
-              className="mt-8 flex flex-wrap gap-4"
-            >
-              <Button asChild className={primaryCtaClass}>
-                <Link href="/partnerships">Partner with Us</Link>
-              </Button>
-              <Button asChild className={secondaryCtaClass}>
-                <Link href="/get-involved">Volunteer as a University Student</Link>
-              </Button>
-            </MotionDiv>
-          </div>
-
-          <MotionDiv
-            initial={{ opacity: 0, y: 40 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.4, duration: 0.8, ease: "easeOut" }}
-            className="w-full"
-          >
-            <div className="relative w-full h-[280px] sm:h-[360px] md:h-[520px] lg:h-[640px] rounded-3xl overflow-hidden shadow-2xl border border-white/10">
+      <EditorialBand
+        tone="cream"
+        marker="01"
+        id="ya-about"
+        aria-labelledby="ya-about-heading"
+      >
+        <div className="grid items-start gap-10 lg:grid-cols-12 lg:gap-16">
+          <FadeIn className="lg:col-span-7">
+            <EditorialEyebrow className="text-[#0F4C5C] dark:text-[#66C4DC]">
+              About
+            </EditorialEyebrow>
+            <EditorialHeading id="ya-about-heading" className="mt-4">
+              About the Program
+            </EditorialHeading>
+            <div className="mt-6 space-y-5 text-base leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80 md:text-lg">
+              <p>
+                The Young Advocates Program brings community health, mentorship,
+                and leadership development directly to high schools. University
+                student teams trained through Akomapa clinics facilitate
+                learning, screenings, and storytelling that meet teens where they
+                are.
+              </p>
+              <p>
+                Education on hypertension, diabetes, and mental health—as key
+                non-communicable concerns—helps students understand how
+                lifestyle, stress, and emotional well-being shape long-term
+                health outcomes.
+              </p>
+              <p className="font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+                Every session bridges education and community care—nurturing
+                ethical, community-minded leaders who champion physical and
+                mental well-being in their schools and neighborhoods.
+              </p>
+            </div>
+          </FadeIn>
+          <FadeIn direction="left" delay={0.1} className="relative lg:col-span-5">
+            <span
+              aria-hidden="true"
+              className="absolute -top-3 left-0 z-10 h-1 w-24 bg-[#eeba2b]"
+            />
+            <div className="relative aspect-[4/3] overflow-hidden rounded-md border border-[#1C1F1E]/10 bg-[#E6E7E7] dark:border-[#FCFAEF]/15 dark:bg-[#2F3332]">
               <Image
-                src="/gallery/gallery-pic-2.jpg"
-                alt="Young advocates participating in a health education session"
+                src="/highlights/Akomapa-66.jpg"
+                alt="University mentors guiding high school students"
                 fill
-                sizes="(min-width: 1024px) 50vw, 100vw"
+                sizes="(min-width: 1024px) 40vw, 100vw"
                 className="object-cover object-center"
               />
-              <div className="absolute inset-0 bg-gradient-to-t from-black/35 via-transparent to-transparent" />
             </div>
-          </MotionDiv>
+          </FadeIn>
         </div>
-      </section>
+      </EditorialBand>
 
-      <section className="py-16 md:py-24 bg-[#FCFAEF] dark:bg-[#1C1F1E]">
-        <div className="site-container mx-auto px-4">
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-16 items-center">
-            <MotionDiv
-              initial={{ opacity: 0, y: 24 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6 }}
-              viewport={{ once: true, amount: 0.3 }}
-              className="order-1"
+      <EditorialBand
+        tone="teal"
+        marker="02"
+        id="ya-mission"
+        aria-labelledby="ya-mission-heading"
+        className="bg-[#0F4C5C]"
+      >
+        <FadeIn>
+          <div className="max-w-3xl">
+            <EditorialEyebrow tone="gold" className="text-[#F5C94D]">
+              Mission
+            </EditorialEyebrow>
+            <EditorialHeading
+              id="ya-mission-heading"
+              className="mt-4 text-[#FCFAEF]"
             >
-              <h2 className="text-3xl md:text-4xl font-bold mb-6 text-[#1C1F1E] dark:text-[#FCFAEF]">
-                About the Program
-              </h2>
-              <div className="space-y-5 text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed">
-                <p>
-                  The Young Advocates Program brings community health, mentorship, and leadership development directly to high schools. University student teams trained through Akomapa clinics facilitate learning, screenings, and storytelling that meet teens where they are.
-                </p>
-                <p>
-                  Education on hypertension, diabetes, and mental health—as key non-communicable concerns—helps students understand how lifestyle, stress, and emotional well-being shape long-term health outcomes.
-                </p>
-                <p className="font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
-                  Every session bridges education and community care—nurturing ethical, community-minded leaders who champion physical and mental well-being in their schools and neighborhoods.
-                </p>
-              </div>
-            </MotionDiv>
-            <MotionDiv
-              initial={{ opacity: 0, y: 24 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.1, duration: 0.6 }}
-              viewport={{ once: true, amount: 0.3 }}
-              className="order-2"
-            >
-              <div className="relative w-full min-h-[320px] h-[320px] sm:h-[380px] md:h-[420px] lg:h-[460px] rounded-3xl overflow-hidden shadow-2xl">
-                <Image
-                  src="/highlights/Akomapa-66.jpg"
-                  alt="University mentors guiding high school students"
-                  fill
-                  sizes="(min-width: 1024px) 50vw, 100vw"
-                  className="object-cover object-center"
-                />
-                <div className="absolute inset-0 bg-gradient-to-t from-black/25 via-transparent to-transparent" />
-              </div>
-            </MotionDiv>
+              Our Mission
+            </EditorialHeading>
+            <EditorialLead className="mt-6 text-[#FCFAEF]/90 dark:text-[#FCFAEF]/90 md:text-xl">
+              To cultivate youth leaders who understand their power to improve
+              community health, advocate for well-being, and serve as role models
+              of compassion and integrity.
+            </EditorialLead>
           </div>
-        </div>
-      </section>
+        </FadeIn>
+      </EditorialBand>
 
-      <section className="py-16 md:py-24 bg-gradient-to-r from-[#0097b2] to-[#0F4C5C] text-[#FCFAEF] relative overflow-hidden">
-        <div className="absolute inset-0 pointer-events-none">
-          <div className="absolute -top-20 left-10 h-56 w-56 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
-          <div className="absolute bottom-0 right-0 h-72 w-72 rounded-full bg-[#F5C94D]/10 blur-3xl" />
-        </div>
-        <div className="relative site-container mx-auto px-4">
-          <MotionDiv
-            initial={{ opacity: 0, y: 24 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true, amount: 0.3 }}
-            className="text-center max-w-3xl mx-auto space-y-4"
-          >
-            <h2 className="text-3xl md:text-4xl font-bold">Our Mission</h2>
-            <p className="text-lg text-[#FCFAEF]/90 leading-relaxed">
-              To cultivate youth leaders who understand their power to improve community health, advocate for well-being, and serve as role models of compassion and integrity.
-            </p>
-          </MotionDiv>
-        </div>
-      </section>
+      <EditorialBand
+        tone="cream"
+        marker="03"
+        id="ya-what"
+        aria-labelledby="ya-what-heading"
+      >
+        <FadeIn>
+          <div className="max-w-3xl">
+            <EditorialEyebrow className="text-[#0F4C5C] dark:text-[#66C4DC]">
+              Approach
+            </EditorialEyebrow>
+            <EditorialHeading id="ya-what-heading" className="mt-4">
+              What We Do
+            </EditorialHeading>
+            <EditorialLead className="mt-5">
+              University student teams lead immersive sessions that turn
+              classrooms into hubs of curiosity and leadership—where students
+              learn to prevent hypertension, diabetes, and mental health
+              challenges through health literacy and peer support.
+            </EditorialLead>
+          </div>
+        </FadeIn>
 
-      <section className="py-16 md:py-24 bg-[#FCFAEF] dark:bg-[#1C1F1E]">
-        <div className="site-container mx-auto px-4">
-          <MotionDiv
-            initial={{ opacity: 0, y: 24 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true, amount: 0.3 }}
-            className="text-center max-w-4xl mx-auto mb-12 space-y-4"
-          >
-            <h2 className="text-3xl md:text-4xl font-bold text-[#1C1F1E] dark:text-[#FCFAEF]">What We Do</h2>
-            <p className="text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed">
-              University student teams lead immersive sessions that turn classrooms into hubs of curiosity and leadership—where students learn to prevent hypertension, diabetes, and mental health challenges through health literacy and peer support.
-            </p>
-          </MotionDiv>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8">
-            {whatWeDo.map((item, index) => (
-              <MotionDiv
-                key={item.id}
-                initial={{ opacity: 0, y: 24 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: index * 0.1 }}
-                viewport={{ once: true, amount: 0.3 }}
-                className="relative rounded-2xl bg-white dark:bg-[#2F3332] p-6 md:p-8 shadow-lg hover:shadow-xl transition-all duration-300 border border-[#E6E7E7]/30 dark:border-[#4F5554]/30 hover:-translate-y-1"
+        <ol className="mt-12 grid border-t border-[#1C1F1E]/15 md:grid-cols-2 lg:grid-cols-3 dark:border-[#FCFAEF]/20">
+          {whatWeDo.map((item, index) => (
+            <li
+              key={item.id}
+              className="border-b border-[#1C1F1E]/15 px-1 py-7 md:border-r md:px-6 lg:[&:nth-child(3n)]:border-r-0 dark:border-[#FCFAEF]/20"
+            >
+              <span
+                aria-hidden="true"
+                className="font-heading text-3xl font-semibold tracking-[-0.06em] text-[#0097b2]/55 dark:text-[#66C4DC]/65"
               >
-                <div
-                  className="h-1 w-16 rounded-full mb-4"
-                  style={{ backgroundColor: item.color }}
-                />
-                <h3 className="text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF] mb-3">
-                  {item.title}
-                </h3>
-                <p className="text-sm md:text-base text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed">
-                  {item.description}
-                </p>
-              </MotionDiv>
-            ))}
-          </div>
-        </div>
-      </section>
+                {String(index + 1).padStart(2, "0")}
+              </span>
+              <h3 className="mt-4 font-heading text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+                {item.title}
+              </h3>
+              <p className="mt-3 text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
+                {item.description}
+              </p>
+            </li>
+          ))}
+        </ol>
+      </EditorialBand>
 
-      <section className="py-16 md:py-24 bg-gradient-to-r from-[#0F4C5C] via-[#0097b2] to-[#0B2F3A] text-[#FCFAEF] relative overflow-hidden">
-        <div className="absolute inset-0 pointer-events-none">
-          <div className="absolute top-6 left-6 h-64 w-64 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
-          <div className="absolute bottom-0 right-0 h-80 w-80 rounded-full bg-[#F5C94D]/10 blur-3xl" />
-        </div>
-        <div className="relative site-container mx-auto px-4">
-          <div className="grid grid-cols-1 lg:grid-cols-[1.1fr,0.9fr] gap-12 lg:gap-16 items-stretch">
-            <MotionDiv
-              initial={{ opacity: 0, y: 24 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6 }}
-              viewport={{ once: true, amount: 0.3 }}
-              className="space-y-8"
+      <EditorialBand
+        tone="teal"
+        marker="04"
+        id="ya-mentorship"
+        aria-labelledby="ya-mentorship-heading"
+        className="bg-[#0F4C5C]"
+      >
+        <div className="grid items-start gap-12 lg:grid-cols-12 lg:gap-16">
+          <FadeIn className="lg:col-span-6">
+            <EditorialEyebrow tone="gold" className="text-[#F5C94D]">
+              Beyond a single visit
+            </EditorialEyebrow>
+            <EditorialHeading
+              id="ya-mentorship-heading"
+              className="mt-4 text-[#FCFAEF]"
             >
-              <div className="space-y-3">
-                <p className="text-xs font-semibold tracking-[0.35em] uppercase text-[#F5C94D]/80">
-                  Beyond a single visit
-                </p>
-                <h2 className="text-3xl md:text-4xl font-bold">Ongoing Mentorship</h2>
-                <p className="text-lg text-[#FCFAEF]/85 leading-relaxed">
-                  Students who show enthusiasm join a long-term mentorship journey guided by university mentors from local Akomapa clinics—turning curiosity into consistent leadership, resilience, and peer support.
-                </p>
-              </div>
+              Ongoing Mentorship
+            </EditorialHeading>
+            <EditorialLead className="mt-5 text-[#FCFAEF]/85 dark:text-[#FCFAEF]/85">
+              Students who show enthusiasm join a long-term mentorship journey
+              guided by university mentors from local Akomapa clinics—turning
+              curiosity into consistent leadership, resilience, and peer support.
+            </EditorialLead>
 
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                {mentorshipHighlights.map((highlight, index) => (
-                  <MotionDiv
-                    key={highlight.title}
-                    initial={{ opacity: 0, y: 20 }}
-                    whileInView={{ opacity: 1, y: 0 }}
-                    transition={{ duration: 0.5, delay: index * 0.1 }}
-                    viewport={{ once: true }}
-                    className="rounded-2xl border border-white/15 bg-white/5 p-5 shadow-lg backdrop-blur-[2px]"
-                  >
-                    <p
-                      className="text-xs font-semibold tracking-[0.3em] uppercase"
-                      style={{ color: highlight.accent }}
-                    >
-                      {highlight.label}
-                    </p>
-                    <h3 className="text-lg font-semibold text-white mt-2">{highlight.title}</h3>
-                    <p className="text-sm text-[#FCFAEF]/80 leading-relaxed mt-1">
+            <dl className="mt-10 border-t border-[#FCFAEF]/25">
+              {mentorshipHighlights.map((highlight) => (
+                <div
+                  key={highlight.title}
+                  className="border-b border-[#FCFAEF]/25 py-6"
+                >
+                  <dt className="font-subheading text-xs font-bold uppercase tracking-[0.2em] text-[#F5C94D]">
+                    {highlight.label}
+                  </dt>
+                  <dd className="mt-2">
+                    <h3 className="font-heading text-lg font-semibold text-[#FCFAEF]">
+                      {highlight.title}
+                    </h3>
+                    <p className="mt-2 text-sm leading-relaxed text-[#FCFAEF]/80">
                       {highlight.description}
                     </p>
-                  </MotionDiv>
-                ))}
-              </div>
-            </MotionDiv>
-
-            <MotionDiv
-              initial={{ opacity: 0, y: 24 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.1, duration: 0.6 }}
-              viewport={{ once: true, amount: 0.3 }}
-              className="relative"
-            >
-              <div className="absolute top-4 right-4 h-24 w-24 bg-[#FCFAEF]/10 rounded-full blur-3xl" />
-              <div className="relative">
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
-                  {mentorshipBenefits.map((benefit, index) => (
-                    <MotionDiv
-                      key={benefit.title}
-                      initial={{ opacity: 0, y: 15 }}
-                      whileInView={{ opacity: 1, y: 0 }}
-                      transition={{ duration: 0.5, delay: index * 0.1 }}
-                      viewport={{ once: true }}
-                      className="relative overflow-hidden rounded-3xl border border-[#E6E7E7]/40 bg-[#FCFAEF] p-5 sm:p-6 shadow-2xl"
-                    >
-                      <div className="pointer-events-none absolute inset-0 opacity-40">
-                        <div className="absolute inset-0 bg-gradient-to-br from-white via-transparent to-white/60" />
-                        <div className="absolute inset-0 mix-blend-multiply">
-                          <div className="h-full w-full bg-[radial-gradient(circle_at_top,_rgba(250,244,228,0.8),_transparent_60%)]" />
-                        </div>
-                      </div>
-                      <div className="relative space-y-3">
-                        <div className="flex items-center gap-3">
-                          <div
-                            className="h-10 w-10 rounded-2xl flex items-center justify-center text-sm font-semibold border border-[#E6E7E7]"
-                            style={{
-                              backgroundColor: `${benefit.color}22`,
-                              color: benefit.color
-                            }}
-                          >
-                            {String(index + 1).padStart(2, "0")}
-                          </div>
-                          <h3 className="text-lg font-semibold text-[#1C1F1E]">{benefit.title}</h3>
-                        </div>
-                        <p className="text-sm md:text-base text-[#2F3332] leading-relaxed">
-                          {benefit.description}
-                        </p>
-                      </div>
-                    </MotionDiv>
-                  ))}
+                  </dd>
                 </div>
-              </div>
-            </MotionDiv>
-          </div>
+              ))}
+            </dl>
+          </FadeIn>
+
+          <FadeIn delay={0.1} className="lg:col-span-6">
+            <ol className="grid border-t border-[#FCFAEF]/25 sm:grid-cols-2">
+              {mentorshipBenefits.map((benefit, index) => (
+                <li
+                  key={benefit.title}
+                  className="border-b border-[#FCFAEF]/25 px-1 py-7 sm:border-r sm:px-6 sm:odd:[&:nth-last-child(-n+1)]:border-r-0 sm:[&:nth-child(2n)]:border-r-0"
+                >
+                  <span
+                    aria-hidden="true"
+                    className="font-heading text-3xl font-semibold tracking-[-0.06em] text-[#FCFAEF]/45"
+                  >
+                    {String(index + 1).padStart(2, "0")}
+                  </span>
+                  <h3 className="mt-4 font-heading text-lg font-semibold text-[#FCFAEF]">
+                    {benefit.title}
+                  </h3>
+                  <p className="mt-3 text-sm leading-relaxed text-[#FCFAEF]/85">
+                    {benefit.description}
+                  </p>
+                </li>
+              ))}
+            </ol>
+          </FadeIn>
         </div>
-      </section>
+      </EditorialBand>
 
-      <section className="py-16 md:py-24 bg-[#FCFAEF] dark:bg-[#1C1F1E]">
-        <div className="site-container mx-auto px-4">
-          <MotionDiv
-            initial={{ opacity: 0, y: 24 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true, amount: 0.3 }}
-            className="text-center max-w-4xl mx-auto mb-12 space-y-4"
-          >
-            <h2 className="text-3xl md:text-4xl font-bold text-[#1C1F1E] dark:text-[#FCFAEF]">How It Works</h2>
-            <p className="text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed">
-              A simple, repeatable model ensures every region delivers quality mentorship anchored in community care.
-            </p>
-          </MotionDiv>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-8 max-w-5xl mx-auto">
-            {howItWorks.map((step, index) => (
-              <MotionDiv
-                key={step.title}
-                initial={{ opacity: 0, y: 24 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: index * 0.1 }}
-                viewport={{ once: true, amount: 0.3 }}
-                className="rounded-3xl bg-white dark:bg-[#2F3332] p-6 md:p-8 shadow-xl border border-[#E6E7E7]/40 dark:border-[#4F5554]/40"
-              >
-                <p className="text-xs font-semibold tracking-[0.3em] uppercase text-[#0097b2] dark:text-[#66C4DC] mb-3">
-                  {step.eyebrow}
-                </p>
-                <h3 className="text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF] mb-3">
-                  {step.title}
-                </h3>
-                <p className="text-sm md:text-base text-[#2F3332] dark:text-[#E6E7E7]/90 leading-relaxed">
-                  {step.description}
-                </p>
-              </MotionDiv>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      <section
-        data-testid="young-advocates-impact-section"
-        className="py-16 md:py-24 bg-gradient-to-r from-[#0097b2] to-[#0F4C5C] text-[#FCFAEF] relative overflow-hidden"
+      <EditorialBand
+        tone="cream"
+        marker="05"
+        id="ya-how"
+        aria-labelledby="ya-how-heading"
       >
-        <div className="absolute inset-0 pointer-events-none">
-          <div className="absolute -top-20 left-10 h-56 w-56 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
-          <div className="absolute bottom-0 right-0 h-72 w-72 rounded-full bg-[#F5C94D]/10 blur-3xl" />
-        </div>
-        <div className="relative site-container mx-auto px-4">
-          <MotionDiv
-            initial={{ opacity: 0, y: 24 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true, amount: 0.3 }}
-            className="text-center max-w-4xl mx-auto mb-12 space-y-4"
-          >
-            <h2 className="text-3xl md:text-4xl font-bold">Our Impact</h2>
-            <p className="text-lg text-[#FCFAEF]/85 leading-relaxed">
-              Every classroom conversation is part of a larger movement to build a healthier, more compassionate generation.
-            </p>
-          </MotionDiv>
+        <FadeIn>
+          <div className="max-w-3xl">
+            <EditorialEyebrow className="text-[#0F4C5C] dark:text-[#66C4DC]">
+              Process
+            </EditorialEyebrow>
+            <EditorialHeading id="ya-how-heading" className="mt-4">
+              How It Works
+            </EditorialHeading>
+            <EditorialLead className="mt-5">
+              A simple, repeatable model ensures every region delivers quality
+              mentorship anchored in community care.
+            </EditorialLead>
+          </div>
+        </FadeIn>
 
+        <ol className="mt-12 grid border-t border-[#1C1F1E]/15 md:grid-cols-2 dark:border-[#FCFAEF]/20">
+          {howItWorks.map((step, index) => (
+            <li
+              key={step.title}
+              className="border-b border-[#1C1F1E]/15 px-1 py-7 md:border-r md:px-6 md:odd:[&:nth-last-child(-n+1)]:border-r-0 md:[&:nth-child(2n)]:border-r-0 dark:border-[#FCFAEF]/20"
+            >
+              <p className="font-subheading text-xs font-bold uppercase tracking-[0.2em] text-[#0097b2] dark:text-[#66C4DC]">
+                {step.eyebrow}
+              </p>
+              <span className="sr-only">
+                Step {String(index + 1).padStart(2, "0")}
+              </span>
+              <h3 className="mt-4 font-heading text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+                {step.title}
+              </h3>
+              <p className="mt-3 text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80 md:text-base">
+                {step.description}
+              </p>
+            </li>
+          ))}
+        </ol>
+      </EditorialBand>
+
+      <EditorialBand
+        tone="teal"
+        marker="06"
+        id="ya-impact"
+        data-testid="young-advocates-impact-section"
+        aria-labelledby="ya-impact-heading"
+        className="bg-[#0F4C5C]"
+      >
+        <FadeIn>
+          <div className="max-w-3xl">
+            <EditorialEyebrow tone="gold" className="text-[#F5C94D]">
+              Results
+            </EditorialEyebrow>
+            <EditorialHeading
+              id="ya-impact-heading"
+              className="mt-4 text-[#FCFAEF]"
+            >
+              Our Impact
+            </EditorialHeading>
+            <EditorialLead className="mt-5 text-[#FCFAEF]/85 dark:text-[#FCFAEF]/85">
+              Every classroom conversation is part of a larger movement to build
+              a healthier, more compassionate generation.
+            </EditorialLead>
+          </div>
+        </FadeIn>
+
+        <FadeInStagger className="mt-12">
           <div
             data-testid="young-advocates-impact-grid"
-            className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6 md:gap-8 xl:gap-10 items-stretch w-full max-w-[90rem] mx-auto"
+            className="grid w-full max-w-[90rem] grid-cols-1 items-stretch gap-6 md:grid-cols-2 md:gap-8 xl:grid-cols-4 xl:gap-10"
           >
-            {impactMetrics.map((metric, index) => (
-              <MotionDiv
-                key={metric.id}
-                data-testid="young-advocates-impact-card"
-                initial={{ opacity: 0, y: 24 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: index * 0.1 }}
-                viewport={{ once: true, amount: 0.3 }}
-                className="group relative h-full min-w-0 rounded-[28px] border border-white/35 bg-[#FCFAEF]/95 p-7 sm:p-8 md:p-9 xl:p-10 text-[#1C1F1E] shadow-xl backdrop-blur-[2px] transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_10px_20px_rgba(0,0,0,0.08)]"
-              >
-                <div
-                  className="absolute inset-x-0 top-0 h-1.5"
-                  style={{ backgroundColor: metric.color }}
-                />
-                <div className="relative flex h-full flex-col gap-5 md:gap-6 pt-2 md:pt-3">
-                  <p
-                    className="text-xs font-semibold uppercase tracking-[0.28em]"
-                    style={{ color: metric.color }}
-                  >
+            {impactMetrics.map((metric) => (
+              <FadeInStaggerItem key={metric.id} direction="up" className="h-full min-w-0">
+                <article
+                  data-testid="young-advocates-impact-card"
+                  className="flex h-full min-w-0 flex-col border border-[#FCFAEF]/25 bg-[#FCFAEF] px-6 py-7 text-[#1C1F1E] sm:px-7 sm:py-8"
+                >
+                  <p className="font-subheading text-xs font-bold uppercase tracking-[0.2em] text-[#0097b2]">
                     {metric.eyebrow}
                   </p>
-                  <div className="space-y-3">
+                  <div className="mt-4 space-y-3">
                     <AnimatedMetric
                       value={metric.value}
                       suffix={metric.suffix ?? ""}
-                      className="text-5xl md:text-6xl lg:text-7xl font-semibold tracking-tight leading-none"
-                      style={{ color: metric.color }}
+                      className="font-heading text-5xl font-semibold leading-none tracking-tight text-[#0097b2] md:text-6xl"
                     />
-                    <h3 className="text-2xl md:text-[1.75rem] font-semibold leading-tight text-[#1C1F1E]">
+                    <h3 className="font-heading text-2xl font-semibold leading-tight text-[#1C1F1E] md:text-[1.75rem]">
                       {metric.label}
                     </h3>
                   </div>
-                  <p className="text-base text-[#2F3332]/85 leading-relaxed flex-1">
+                  <p className="mt-4 flex-1 text-base leading-relaxed text-[#2F3332]/85">
                     {metric.description}
                   </p>
-                </div>
-              </MotionDiv>
+                </article>
+              </FadeInStaggerItem>
             ))}
           </div>
-        </div>
-      </section>
+        </FadeInStagger>
+      </EditorialBand>
 
-      <section className="py-16 md:py-24 bg-[#F4F1E8] dark:bg-[#1C1F1E]">
-        <div className="site-container mx-auto px-4">
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-16 items-center">
-            <MotionDiv
-              initial={{ opacity: 0, y: 24 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6 }}
-              viewport={{ once: true, amount: 0.3 }}
-              className="order-2 lg:order-1 space-y-5 text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed"
-            >
-              <h2 className="text-3xl md:text-4xl font-bold mb-4 text-[#1C1F1E] dark:text-[#FCFAEF]">
-                Powered by Akomapa Clinics
-              </h2>
-              <p>
-                Each local Akomapa clinic leads the Young Advocates Program in its region. The Akomapa UCC Clinic runs the initiative across high schools in Cape Coast and surrounding towns, mentoring students to become youth health ambassadors connected to real community care.
-              </p>
-              <p>
-                Partnerships between clinics, faculty mentors, and education authorities ensure students receive accurate information and compassionate guidance on hypertension, diabetes, and mental health—with real pathways to care that support whole-person well-being.
-              </p>
-            </MotionDiv>
-
-            <MotionDiv
-              initial={{ opacity: 0, y: 24 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.1, duration: 0.6 }}
-              viewport={{ once: true, amount: 0.3 }}
-              className="order-1 lg:order-2 relative w-full min-h-[320px] h-[320px] sm:h-[380px] md:h-[420px] lg:h-[460px] rounded-3xl overflow-hidden shadow-2xl"
-            >
+      <EditorialBand
+        tone="cream"
+        marker="07"
+        id="ya-clinics"
+        aria-labelledby="ya-clinics-heading"
+      >
+        <div className="grid items-start gap-10 lg:grid-cols-12 lg:gap-16">
+          <FadeIn direction="left" className="relative order-1 lg:order-2 lg:col-span-5">
+            <span
+              aria-hidden="true"
+              className="absolute -top-3 left-0 z-10 h-1 w-24 bg-[#eeba2b]"
+            />
+            <div className="relative aspect-[4/3] overflow-hidden rounded-md border border-[#1C1F1E]/10 bg-[#E6E7E7] dark:border-[#FCFAEF]/15 dark:bg-[#2F3332]">
               <Image
                 src="/highlights/Akomapa-19.jpg"
                 alt="Akomapa clinic mentors supporting youth"
                 fill
-                sizes="(min-width: 1024px) 50vw, 100vw"
+                sizes="(min-width: 1024px) 40vw, 100vw"
                 className="object-cover object-center"
               />
-              <div className="absolute inset-0 bg-gradient-to-t from-black/25 via-transparent to-transparent" />
-            </MotionDiv>
-          </div>
-        </div>
-      </section>
-
-      <section className="py-16 md:py-24 bg-gradient-to-r from-[#0F4C5C] via-[#0097b2] to-[#0B2F3A] text-[#FCFAEF] relative overflow-hidden">
-        <div className="absolute inset-0 pointer-events-none">
-          <div className="absolute -top-20 left-10 h-56 w-56 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
-          <div className="absolute bottom-0 right-0 h-72 w-72 rounded-full bg-[#F5C94D]/10 blur-3xl" />
-        </div>
-        <div className="relative site-container mx-auto px-4">
-          <MotionDiv
-            initial={{ opacity: 0, y: 24 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true, amount: 0.3 }}
-            className="max-w-3xl mx-auto space-y-8"
-          >
-            <h2 className="text-3xl md:text-4xl font-bold text-center">From the Founders</h2>
-            <div className="relative bg-[#FCFAEF]/10 backdrop-blur-md rounded-2xl p-8 md:p-10 shadow-xl border border-[#FCFAEF]/20">
-              <blockquote className="relative z-10 text-lg md:text-xl text-[#FCFAEF]/90 leading-relaxed italic">
-                “The Akomapa Young Advocates Program believes that leadership begins with empathy. By empowering young people to care for their health and their communities, we are building a generation of changemakers with good hearts.”
-              </blockquote>
             </div>
-            <div className="flex items-center gap-4">
-              <div className="relative h-16 w-16 rounded-full overflow-hidden border-2 border-[#F5C94D]/40 shadow-lg flex-shrink-0 bg-white/90">
-                <Image
-                  src="/images/team/brian-fleischer.jpeg"
-                  alt="Akomapa Health"
-                  fill
-                  sizes="64px"
-                  className="object-contain p-2"
-                />
-              </div>
-              <div className="flex flex-col items-start">
-                <p className="text-base font-semibold text-[#F5C94D]">
-                  Akomapa Executive Team
-                </p>
-                <p className="text-sm text-[#FCFAEF]/80">
-                  Founders of the Young Advocates Program
-                </p>
-              </div>
+          </FadeIn>
+          <FadeIn className="order-2 lg:order-1 lg:col-span-7">
+            <EditorialEyebrow className="text-[#0F4C5C] dark:text-[#66C4DC]">
+              Clinics
+            </EditorialEyebrow>
+            <EditorialHeading id="ya-clinics-heading" className="mt-4">
+              Powered by Akomapa Clinics
+            </EditorialHeading>
+            <div className="mt-6 space-y-5 text-base leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80 md:text-lg">
+              <p>
+                Each local Akomapa clinic leads the Young Advocates Program in
+                its region. The Akomapa UCC Clinic runs the initiative across
+                high schools in Cape Coast and surrounding towns, mentoring
+                students to become youth health ambassadors connected to real
+                community care.
+              </p>
+              <p>
+                Partnerships between clinics, faculty mentors, and education
+                authorities ensure students receive accurate information and
+                compassionate guidance on hypertension, diabetes, and mental
+                health—with real pathways to care that support whole-person
+                well-being.
+              </p>
             </div>
-          </MotionDiv>
+          </FadeIn>
         </div>
-      </section>
+      </EditorialBand>
 
-      <section className="py-16 md:py-24 bg-[#FCFAEF] dark:bg-[#1C1F1E]">
-        <div className="site-container mx-auto px-4">
-          <MotionDiv
-            initial={{ opacity: 0, y: 24 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true, amount: 0.3 }}
-            className="max-w-3xl mx-auto text-center space-y-6"
-          >
-            <h2 className="text-3xl md:text-4xl font-bold text-[#1C1F1E] dark:text-[#FCFAEF]">
+      <ProgramQuoteBand
+        tone="teal"
+        marker="08"
+        id="ya-quote"
+        className="bg-[#0F4C5C]"
+        quote="The Akomapa Young Advocates Program believes that leadership begins with empathy. By empowering young people to care for their health and their communities, we are building a generation of changemakers with good hearts."
+        attribution="Akomapa Executive Team"
+        role="Founders of the Young Advocates Program"
+        image="/images/team/brian-fleischer.jpeg"
+        imageAlt="Akomapa Health"
+      />
+
+      <EditorialBand
+        tone="cream"
+        marker="09"
+        id="ya-cta"
+        aria-labelledby="ya-cta-heading"
+      >
+        <FadeIn>
+          <div className="mx-auto max-w-3xl text-center">
+            <EditorialEyebrow className="text-[#0F4C5C] dark:text-[#66C4DC]">
+              Get Involved
+            </EditorialEyebrow>
+            <EditorialHeading id="ya-cta-heading" className="mt-4">
               Partner or Get Involved
-            </h2>
-            <p className="text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed">
-              We welcome partnerships with schools, education authorities, and organizations dedicated to youth development and community health.
-            </p>
-            <div className="flex flex-col sm:flex-row sm:flex-wrap gap-4 justify-center">
-              <Button asChild className={primaryCtaClass}>
-                <Link href="/partnerships" className="flex items-center">
-                  Partner with Us
-                  <ArrowRight className="ml-2 h-5 w-5" />
-                </Link>
-              </Button>
-              <Button asChild className={secondaryCtaClass}>
-                <Link href="/get-involved" className="flex items-center">
-                  Volunteer as a Student
-                  <ArrowRight className="ml-2 h-5 w-5" />
-                </Link>
-              </Button>
-              <Button
-                asChild
-                className={`${ctaBaseClass} border-2 border-[#0097b2] text-[#0097b2] bg-transparent hover:bg-[#0097b2]/10 hover:text-[#1C1F1E] shadow-none focus-visible:ring-[#8DD4E6]`}
-              >
-                <Link href="/donate" className="flex items-center">
-                  Support the Program
-                  <ArrowRight className="ml-2 h-5 w-5" />
-                </Link>
-              </Button>
+            </EditorialHeading>
+            <EditorialLead className="mx-auto mt-5 max-w-2xl">
+              We welcome partnerships with schools, education authorities, and
+              organizations dedicated to youth development and community health.
+            </EditorialLead>
+            <div className="mt-10 flex flex-col items-center justify-center gap-3 sm:flex-row sm:flex-wrap sm:gap-4">
+              <EditorialButton href="/partnerships" variant="solid">
+                Partner with Us
+              </EditorialButton>
+              <EditorialButton href="/get-involved" variant="amber">
+                Volunteer as a Student
+              </EditorialButton>
+              <EditorialButton href="/donate" variant="outline">
+                Support the Program
+              </EditorialButton>
             </div>
-          </MotionDiv>
-        </div>
-      </section>
-    </div>
+          </div>
+        </FadeIn>
+      </EditorialBand>
+    </>
   );
 }

--- a/src/app/(main)/roadmap/Content.tsx
+++ b/src/app/(main)/roadmap/Content.tsx
@@ -1,19 +1,15 @@
-import { ArrowRight, Heart, ChevronRight } from "lucide-react";
-import Link from "next/link";
 import Image from "@/components/common/Image";
+import { FadeIn } from "@/components/animations";
 import Breadcrumb from "@/components/layout/Breadcrumb";
-import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { MotionDiv, MotionH1, MotionH2, MotionP } from "@/components/motion/framer";
 import RoadmapPhases from "@/components/roadmap/RoadmapPhases";
 import { phases } from "@/components/roadmap/phases";
+import {
+  EditorialBand,
+  EditorialButton,
+  EditorialEyebrow,
+  EditorialHeading,
+  EditorialLead,
+} from "@/components/shared/EditorialPrimitives";
 
 export default function Content() {
   return (
@@ -21,171 +17,130 @@ export default function Content() {
       <div className="site-container mx-auto">
         <Breadcrumb />
       </div>
-      <div className="flex flex-col gap-y-section-mobile md:gap-y-section-tablet lg:gap-y-section-desktop">
-        {/* Hero Section */}
-        <section className="relative py-16 md:py-24 overflow-hidden">
-          {/* Roadmap hero background — decorative — intentional empty alt */}
-          <div className="absolute inset-0 z-0 opacity-10" aria-hidden>
-            <Image
-              src="/highlights/Akomapa-28.jpg"
-              alt=""
-              fill
-              sizes="100vw"
-              className="object-cover"
-            />
+
+      <EditorialBand
+        tone="cream"
+        aria-labelledby="roadmap-hero-heading"
+        className="relative overflow-hidden border-b border-[#1C1F1E]/10 dark:border-[#FCFAEF]/15"
+        containerClassName="py-14 sm:py-16 md:py-20 lg:py-24"
+      >
+        <div className="pointer-events-none absolute inset-0 opacity-[0.08]" aria-hidden>
+          <Image
+            src="/highlights/Akomapa-28.jpg"
+            alt=""
+            fill
+            sizes="100vw"
+            className="object-cover"
+            priority
+          />
+        </div>
+
+        <FadeIn className="relative z-10 mx-auto max-w-4xl text-center">
+          <EditorialEyebrow className="text-[#0F4C5C] dark:text-[#66C4DC]">
+            Akomapa&apos;s 3-Year Roadmap
+          </EditorialEyebrow>
+          <EditorialHeading
+            as="h1"
+            id="roadmap-hero-heading"
+            className="mt-5 text-[2.35rem] sm:text-[3rem] md:text-[3.5rem]"
+          >
+            Building sustainable care, one step at a time.
+          </EditorialHeading>
+          <EditorialLead className="mx-auto mt-6 max-w-3xl">
+            Our comprehensive 3-year roadmap (2025–2028) outlines our journey
+            from launching essential healthcare services to building
+            sustainable, replicable care models across Ghana and beyond.
+          </EditorialLead>
+        </FadeIn>
+      </EditorialBand>
+
+      <RoadmapPhases />
+
+      <EditorialBand
+        tone="white"
+        marker="02"
+        id="roadmap-timeline"
+        aria-labelledby="roadmap-timeline-heading"
+      >
+        <FadeIn>
+          <div className="max-w-3xl">
+            <EditorialEyebrow className="text-[#0F4C5C] dark:text-[#66C4DC]">
+              Chronology
+            </EditorialEyebrow>
+            <EditorialHeading id="roadmap-timeline-heading" className="mt-4">
+              Our Journey Timeline
+            </EditorialHeading>
           </div>
+        </FadeIn>
 
-          <div className="site-container mx-auto px-4 relative z-10">
-            <div className="max-w-4xl mx-auto text-center">
-              <MotionDiv
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                className="mb-6"
-              >
-                <Badge className="bg-[#0097b2] text-[#FCFAEF] mb-4">
-                  🧭 Akomapa&apos;s 3-Year Roadmap
-                </Badge>
-              </MotionDiv>
-
-              <MotionH1
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.1 }}
-                className="text-4xl md:text-5xl font-bold text-[#1C1F1E] dark:text-[#FCFAEF] mb-6"
-              >
-                Building sustainable care, one step at a time.
-              </MotionH1>
-
-              <MotionP
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.2 }}
-                className="text-xl text-[#2F3332] dark:text-[#E6E7E7] mb-8 max-w-3xl mx-auto"
-              >
-                Our comprehensive 3-year roadmap (2025–2028) outlines our journey
-                from launching essential healthcare services to building
-                sustainable, replicable care models across Ghana and beyond.
-              </MotionP>
-            </div>
-          </div>
-        </section>
-
-        <RoadmapPhases />
-
-        {/* Progress Timeline */}
-        <section className="py-16 bg-[#FCFAEF] dark:bg-[#1C1F1E]">
-          <div className="site-container mx-auto px-4">
-            <div className="max-w-4xl mx-auto">
-              <MotionH2
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6 }}
-                viewport={{ once: true }}
-                className="text-3xl font-bold text-center text-[#1C1F1E] dark:text-[#FCFAEF] mb-12"
-              >
-                Our Journey Timeline
-              </MotionH2>
-
-              <div className="relative">
-                {/* Timeline Line */}
-                <div className="absolute left-1/2 transform -translate-x-1/2 w-1 bg-[#0097b2] dark:bg-[#66C4DC] h-full"></div>
-
-                {phases.map((phase, index) => (
-                  <MotionDiv
-                    key={phase.id}
-                    initial={{ opacity: 0, y: 20 }}
-                    whileInView={{ opacity: 1, y: 0 }}
-                    transition={{ duration: 0.6, delay: index * 0.2 }}
-                    viewport={{ once: true }}
-                    className={`relative mb-12 ${
-                      index % 2 === 0 ? "md:flex-row" : "md:flex-row-reverse"
-                    } flex flex-col md:flex-row items-center`}
-                  >
-                    {/* Timeline Dot */}
-                    <div
-                      className={`absolute left-1/2 transform -translate-x-1/2 w-6 h-6 rounded-full ${phase.color} border-4 border-white dark:border-[#2F3332] z-10`}
-                    ></div>
-
-                    {/* Content */}
-                    <div
-                      className={`w-full md:w-1/2 ${index % 2 === 0 ? "md:pr-8" : "md:pl-8"} text-center md:text-left`}
-                    >
-                      <Card className="bg-white dark:bg-[#2F3332] shadow-lg border-0">
-                        <CardHeader>
-                          <CardTitle className="text-[#1C1F1E] dark:text-[#FCFAEF]">
-                            {phase.title}
-                          </CardTitle>
-                          <CardDescription className="text-[#0097b2] dark:text-[#66C4DC] font-medium">
-                            {phase.period}
-                          </CardDescription>
-                        </CardHeader>
-                        <CardContent>
-                          <p className="text-[#2F3332] dark:text-[#E6E7E7]">
-                            {phase.focus}
-                          </p>
-                        </CardContent>
-                      </Card>
-                    </div>
-                  </MotionDiv>
-                ))}
-              </div>
-            </div>
-          </div>
-        </section>
-
-        {/* Call to Action */}
-        <section className="py-16 bg-gradient-to-r from-[#0097b2] to-[#eeba2b]">
-          <div className="site-container mx-auto px-4 text-center">
-            <MotionDiv
-              initial={{ opacity: 0, y: 20 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6 }}
-              viewport={{ once: true }}
+        <ol className="mt-12 border-t border-[#1C1F1E]/15 dark:border-[#FCFAEF]/20">
+          {phases.map((phase, index) => (
+            <li
+              key={phase.id}
+              className="grid gap-3 border-b border-[#1C1F1E]/15 py-7 sm:grid-cols-[auto_1fr] sm:gap-8 dark:border-[#FCFAEF]/20"
             >
-              <h2 className="text-3xl md:text-4xl font-bold mb-6 text-[#FCFAEF]">
-                📣 Help us bring this vision to life
-              </h2>
-              <p className="text-xl text-[#FCFAEF]/90 mb-8 max-w-2xl mx-auto">
-                Whether you&apos;re a donor, global health ally, or community
-                partner — we invite you to walk this road with us.
-              </p>
-              <div className="flex flex-col sm:flex-row gap-4 justify-center">
-                <Button
-                  asChild
-                  size="lg"
-                  className="bg-[#FCFAEF] text-[#0097b2] hover:bg-[#FCFAEF]/90 font-semibold"
-                >
-                  <Link href="/partnerships" className="flex items-center">
-                    Partner With Us <ArrowRight size={20} className="ml-2" />
-                  </Link>
-                </Button>
-                <Button
-                  asChild
-                  size="lg"
-                  className="bg-[#eeba2b] text-[#FCFAEF] hover:bg-[#F5C94D] font-semibold"
-                >
-                  <Link href="/partnerships" className="flex items-center">
-                    Donate <Heart size={20} className="ml-2" />
-                  </Link>
-                </Button>
-                <Button
-                  asChild
-                  size="lg"
-                  variant="outline"
-                  className="border-[#FCFAEF] text-[#FCFAEF] bg-transparent hover:bg-[#FCFAEF] hover:text-[#0097b2] font-semibold"
-                >
-                  <a
-                    href="mailto:akomapahealth@gmail.com"
-                    className="flex items-center"
-                  >
-                    Contact Us <ChevronRight size={20} className="ml-2" />
-                  </a>
-                </Button>
+              <span
+                aria-hidden="true"
+                className="font-heading text-3xl font-semibold tracking-[-0.06em] text-[#0097b2]/55 dark:text-[#66C4DC]/65"
+              >
+                {String(index + 1).padStart(2, "0")}
+              </span>
+              <div>
+                <h3 className="font-heading text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+                  {phase.title}
+                </h3>
+                <p className="mt-2 font-subheading text-xs font-bold uppercase tracking-[0.2em] text-[#0097b2] dark:text-[#66C4DC]">
+                  {phase.period}
+                </p>
+                <p className="mt-3 text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80 md:text-base">
+                  {phase.focus}
+                </p>
               </div>
-            </MotionDiv>
+            </li>
+          ))}
+        </ol>
+      </EditorialBand>
+
+      <EditorialBand
+        tone="teal"
+        marker="03"
+        id="roadmap-cta"
+        aria-labelledby="roadmap-cta-heading"
+        className="bg-[#0F4C5C]"
+      >
+        <FadeIn>
+          <div className="mx-auto max-w-3xl text-center">
+            <EditorialEyebrow tone="gold" className="text-[#F5C94D]">
+              Get Involved
+            </EditorialEyebrow>
+            <EditorialHeading
+              id="roadmap-cta-heading"
+              className="mt-4 text-[#FCFAEF]"
+            >
+              Help us bring this vision to life
+            </EditorialHeading>
+            <EditorialLead className="mx-auto mt-6 max-w-2xl text-[#FCFAEF]/85 dark:text-[#FCFAEF]/85">
+              Whether you&apos;re a donor, global health ally, or community
+              partner — we invite you to walk this road with us.
+            </EditorialLead>
+            <div className="mt-10 flex flex-col items-center justify-center gap-3 sm:flex-row sm:gap-4">
+              <EditorialButton href="/partnerships" variant="light">
+                Partner With Us
+              </EditorialButton>
+              <EditorialButton href="/partnerships" variant="amber">
+                Donate
+              </EditorialButton>
+              <EditorialButton
+                href="mailto:akomapahealth@gmail.com"
+                variant="outline-light"
+                external
+              >
+                Contact Us
+              </EditorialButton>
+            </div>
           </div>
-        </section>
-      </div>
+        </FadeIn>
+      </EditorialBand>
     </>
   );
 }

--- a/src/components/academy/AcademyHero.tsx
+++ b/src/components/academy/AcademyHero.tsx
@@ -1,12 +1,17 @@
 import Image from "@/components/common/Image";
-import { Button } from "@/components/ui/button";
-import Link from "next/link";
+import { FadeIn, FadeInStagger, FadeInStaggerItem } from "@/components/animations";
 import {
-  FadeIn,
-  FadeInStagger,
-  FadeInStaggerItem,
-} from "@/components/animations";
-import { academyOverview, academyCurriculum, academyFaculty } from "@/data/academy";
+  EditorialBand,
+  EditorialButton,
+  EditorialEyebrow,
+  EditorialHeading,
+  EditorialLead,
+} from "@/components/shared/EditorialPrimitives";
+import {
+  academyOverview,
+  academyCurriculum,
+  academyFaculty,
+} from "@/data/academy";
 import { LEADERSHIP_APP_FORM_URL } from "@/config/links";
 
 const heroStats = [
@@ -24,97 +29,89 @@ const heroStats = [
   },
 ] as const;
 
-const ctaBaseClass =
-  "group inline-flex items-center justify-center gap-2 rounded-half px-8 py-6 h-auto text-base sm:text-lg font-medium transition-all duration-300 transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2";
+const metricDividerClasses = [
+  "",
+  "border-t sm:border-l sm:border-t-0",
+  "border-t sm:border-l sm:border-t-0",
+] as const;
 
 export default function AcademyHero() {
   return (
-    <section
-      className="relative overflow-hidden bg-gradient-to-r from-[#0097b2] to-[#0F4C5C] py-16 sm:py-20 md:py-28"
+    <EditorialBand
+      tone="teal"
       aria-labelledby="academy-hero-heading"
+      className="border-b border-[#FCFAEF]/20 bg-[#0F4C5C]"
+      containerClassName="py-14 sm:py-16 md:py-20 lg:py-24"
     >
-      <div className="pointer-events-none absolute inset-0 overflow-hidden">
-        <div className="absolute -top-24 right-0 h-64 w-64 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
-        <div className="absolute bottom-0 -left-24 h-96 w-96 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
-        <div className="absolute bottom-0 right-0 h-80 w-80 rounded-full bg-[#F5C94D]/10 blur-3xl" />
-      </div>
+      <div className="grid gap-12 lg:grid-cols-12 lg:items-end lg:gap-16">
+        <FadeIn className="lg:col-span-7 lg:pb-4">
+          <EditorialEyebrow tone="gold" className="text-[#F5C94D]">
+            Leadership Development
+          </EditorialEyebrow>
+          <EditorialHeading
+            as="h1"
+            id="academy-hero-heading"
+            className="mt-5 max-w-4xl text-[2.35rem] text-[#FCFAEF] sm:text-[3rem] md:text-[3.7rem] lg:text-[4.35rem]"
+          >
+            Akomapa Academy
+          </EditorialHeading>
+          <p className="mt-4 max-w-2xl font-heading text-lg font-semibold text-[#F5C94D] md:text-xl">
+            {academyOverview.title}
+          </p>
+          <EditorialLead className="mt-5 max-w-3xl text-[#FCFAEF]/88 dark:text-[#FCFAEF]/88">
+            {academyOverview.description}
+          </EditorialLead>
 
-      <div className="site-container relative z-10 mx-auto px-4 sm:px-6">
-        <div className="flex flex-col gap-12 lg:flex-row lg:items-center lg:gap-16">
-          <FadeIn className="max-w-3xl flex-1">
-            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#FCFAEF]/80 sm:text-sm">
-              Leadership Development
-            </p>
-            <h1
-              id="academy-hero-heading"
-              className="mt-4 text-3xl font-light leading-tight text-[#FCFAEF] sm:text-4xl md:text-5xl lg:text-6xl xl:text-7xl"
-            >
-              Akomapa Academy
-            </h1>
-            <p className="mt-4 text-lg font-semibold text-[#F5C94D] md:text-xl lg:text-2xl">
-              {academyOverview.title}
-            </p>
-            <p className="mt-4 max-w-2xl text-base leading-relaxed text-[#FCFAEF]/85 sm:text-lg">
-              {academyOverview.description}
-            </p>
-
-            <FadeInStagger
-              className="mt-8 grid grid-cols-1 gap-3 sm:grid-cols-3 sm:gap-4"
-              staggerDelay={0.1}
-            >
-              {heroStats.map((stat) => (
+          <FadeInStagger className="mt-10" staggerDelay={0.08}>
+            <dl className="grid border-y border-[#FCFAEF]/25 sm:grid-cols-3">
+              {heroStats.map((stat, index) => (
                 <FadeInStaggerItem key={stat.label} direction="up">
-                  <div className="rounded-xl border border-white/10 bg-white/5 p-3 sm:rounded-2xl sm:p-4">
-                    <p className="text-2xl font-semibold text-white sm:text-3xl">
-                      {stat.value}
-                    </p>
-                    <p className="mt-1 text-xs uppercase tracking-[0.2em] text-white/70 sm:tracking-[0.3em]">
+                  <div
+                    className={`flex min-h-28 flex-col justify-between px-1 py-6 sm:px-5 ${metricDividerClasses[index]} border-[#FCFAEF]/25`}
+                  >
+                    <dt className="font-subheading text-xs font-bold uppercase tracking-[0.2em] text-[#FCFAEF]/70">
                       {stat.label}
-                    </p>
+                    </dt>
+                    <dd className="mt-4 font-heading text-2xl font-semibold tracking-tight text-[#FCFAEF] sm:text-3xl">
+                      {stat.value}
+                    </dd>
                   </div>
                 </FadeInStaggerItem>
               ))}
-            </FadeInStagger>
+            </dl>
+          </FadeInStagger>
 
-            <FadeIn direction="up" delay={0.3}>
-              <div className="mt-8 flex flex-wrap gap-3 sm:gap-4">
-                <Button
-                  asChild
-                  className={`${ctaBaseClass} bg-[#eeba2b] text-[#FCFAEF] shadow-lg hover:bg-[#eeba2b]/80 hover:shadow-xl focus-visible:ring-[#F5C94D]`}
-                >
-                  <a
-                    href={LEADERSHIP_APP_FORM_URL}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Become a Scholar
-                  </a>
-                </Button>
-                <Button
-                  asChild
-                  className={`${ctaBaseClass} bg-[#0097b2] text-[#FCFAEF] shadow-lg hover:bg-[#0097b2]/80 hover:shadow-xl focus-visible:ring-[#8DD4E6]`}
-                >
-                  <Link href="#curriculum">Explore Curriculum</Link>
-                </Button>
-              </div>
-            </FadeIn>
-          </FadeIn>
+          <div className="mt-8 flex flex-wrap gap-3 sm:gap-4">
+            <EditorialButton
+              href={LEADERSHIP_APP_FORM_URL}
+              variant="amber"
+              external
+            >
+              Become a Scholar
+            </EditorialButton>
+            <EditorialButton href="#curriculum" variant="outline-light">
+              Explore Curriculum
+            </EditorialButton>
+          </div>
+        </FadeIn>
 
-          <FadeIn direction="left" delay={0.2} className="w-full lg:max-w-md xl:max-w-lg">
-            <div className="relative h-[280px] w-full overflow-hidden rounded-3xl border border-white/10 shadow-2xl sm:h-[360px] md:h-[420px] lg:h-[480px]">
-              <Image
-                src="/highlights/Akomapa-68.jpg"
-                alt="Akomapa Academy scholars collaborating in a learning session"
-                fill
-                priority
-                sizes="(min-width: 1024px) 40vw, 100vw"
-                className="object-cover object-center"
-              />
-              <div className="absolute inset-0 bg-gradient-to-t from-black/35 via-transparent to-transparent" />
-            </div>
-          </FadeIn>
-        </div>
+        <FadeIn direction="left" delay={0.15} className="relative lg:col-span-5">
+          <span
+            aria-hidden="true"
+            className="absolute -top-3 left-0 z-10 h-1 w-24 bg-[#eeba2b] md:w-36"
+          />
+          <div className="relative aspect-[4/3] overflow-hidden rounded-md border border-[#FCFAEF]/25 bg-[#0F4C5C] lg:aspect-[4/5]">
+            <Image
+              src="/highlights/Akomapa-68.jpg"
+              alt="Akomapa Academy scholars collaborating in a learning session"
+              fill
+              priority
+              sizes="(min-width: 1024px) 38vw, 100vw"
+              className="object-cover object-center"
+            />
+          </div>
+        </FadeIn>
       </div>
-    </section>
+    </EditorialBand>
   );
 }

--- a/src/components/academy/AcademyTestimonials.tsx
+++ b/src/components/academy/AcademyTestimonials.tsx
@@ -1,19 +1,25 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
-import { ChevronLeft, ChevronRight, Quote } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import Image from "@/components/common/Image";
 import { FadeIn } from "@/components/animations";
+import {
+  EditorialBand,
+  EditorialEyebrow,
+  EditorialHeading,
+  EditorialLead,
+} from "@/components/shared/EditorialPrimitives";
 import { academyTestimonials } from "@/data/academy";
 
 export default function AcademyTestimonials() {
   const [currentIndex, setCurrentIndex] = useState(0);
-  const [isHovered, setIsHovered] = useState(false);
+  const [isPaused, setIsPaused] = useState(false);
   const shouldReduceMotion = useReducedMotion();
 
   useEffect(() => {
-    if (isHovered || shouldReduceMotion) {
+    if (isPaused || shouldReduceMotion) {
       return;
     }
 
@@ -24,7 +30,7 @@ export default function AcademyTestimonials() {
     }, 30000);
 
     return () => clearInterval(timer);
-  }, [isHovered, shouldReduceMotion]);
+  }, [isPaused, shouldReduceMotion]);
 
   const handlePrevious = () => {
     setCurrentIndex((prev) =>
@@ -41,103 +47,128 @@ export default function AcademyTestimonials() {
   const testimonial = academyTestimonials[currentIndex];
 
   return (
-    <section className="overflow-x-hidden bg-[#F4F1E8] py-16 dark:bg-[#1C1F1E] md:py-24">
-      <div className="site-container mx-auto px-4 sm:px-6">
-        <FadeIn direction="up" className="mx-auto mb-10 max-w-3xl space-y-3 text-center sm:space-y-4">
-          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#0097b2] dark:text-[#66C4DC] sm:text-sm">
+    <EditorialBand
+      tone="cream"
+      marker="05"
+      id="academy-testimonials"
+      aria-labelledby="academy-testimonials-heading"
+      className="bg-[#F4F1E8] dark:bg-[#1C1F1E]"
+    >
+      <FadeIn>
+        <div className="max-w-3xl">
+          <EditorialEyebrow className="text-[#0F4C5C] dark:text-[#66C4DC]">
             Testimonials
-          </p>
-          <h2 className="text-2xl font-bold text-[#0B2F3A] dark:text-[#FCFAEF] sm:text-3xl md:text-4xl">
+          </EditorialEyebrow>
+          <EditorialHeading id="academy-testimonials-heading" className="mt-4">
             Voices From Our Scholars
-          </h2>
-          <p className="text-base leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80 sm:text-lg">
+          </EditorialHeading>
+          <EditorialLead className="mt-5">
             Hear from students and professionals whose leadership journeys were
             shaped by the Akomapa Academy experience.
-          </p>
-        </FadeIn>
+          </EditorialLead>
+        </div>
+      </FadeIn>
 
+      <div
+        className="relative mx-auto mt-12 max-w-4xl"
+        onMouseEnter={() => setIsPaused(true)}
+        onMouseLeave={() => setIsPaused(false)}
+        onFocusCapture={() => setIsPaused(true)}
+        onBlurCapture={(event) => {
+          if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+            setIsPaused(false);
+          }
+        }}
+      >
         <div
-          className="relative mx-auto max-w-4xl"
-          onMouseEnter={() => setIsHovered(true)}
-          onMouseLeave={() => setIsHovered(false)}
+          className="border border-[#1C1F1E]/15 bg-[#FCFAEF] px-6 py-8 dark:border-[#FCFAEF]/20 dark:bg-[#121514] md:px-10 md:py-10"
+          aria-live="polite"
+          aria-atomic="true"
         >
           <AnimatePresence mode="wait">
             <motion.div
               key={currentIndex}
-              initial={shouldReduceMotion ? false : { opacity: 0, x: 20 }}
-              animate={{ opacity: 1, x: 0 }}
-              exit={
-                shouldReduceMotion ? { opacity: 0 } : { opacity: 0, x: -20 }
-              }
-              transition={{ duration: shouldReduceMotion ? 0.01 : 0.3 }}
-              className="flex min-h-[380px] flex-col rounded-2xl border border-[#E6E7E7]/80 bg-white/95 p-8 shadow-xl dark:border-[#2E3433] dark:bg-[#2F3332] md:min-h-[340px] md:p-12"
+              initial={shouldReduceMotion ? false : { opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: shouldReduceMotion ? 1 : 0 }}
+              transition={{ duration: shouldReduceMotion ? 0 : 0.25 }}
             >
-              <div className="absolute left-8 top-8 text-[#0097b2] opacity-20 dark:text-[#66C4DC]">
-                <Quote size={64} />
-              </div>
+              <blockquote className="font-heading text-xl leading-relaxed text-[#1C1F1E] dark:text-[#FCFAEF] md:text-2xl">
+                <span className="sr-only">Quote from {testimonial.name}: </span>
+                &quot;{testimonial.quote}&quot;
+              </blockquote>
 
-              <div className="relative z-10 flex h-full flex-col">
-                <div className="flex flex-1 flex-col justify-center">
-                  <blockquote className="text-xl leading-relaxed text-[#2F3332] dark:text-[#E6E7E7] md:text-2xl">
-                    &quot;{testimonial.quote}&quot;
-                  </blockquote>
+              <footer className="mt-8 flex items-center gap-4 border-t border-[#1C1F1E]/15 pt-6 dark:border-[#FCFAEF]/20">
+                <div className="relative h-14 w-14 shrink-0 overflow-hidden rounded-md bg-[#E6E7E7] dark:bg-[#2F3332]">
+                  <Image
+                    src={testimonial.image}
+                    alt=""
+                    width={56}
+                    height={56}
+                    className="h-full w-full object-cover"
+                  />
                 </div>
-
-                <div className="flex items-center">
-                  <div className="mr-4 h-16 w-16 overflow-hidden rounded-full">
-                    <Image
-                      src={testimonial.image}
-                      alt={testimonial.name}
-                      width={64}
-                      height={64}
-                      className="h-full w-full object-cover"
-                    />
-                  </div>
-                  <div>
-                    <div className="text-lg font-bold text-[#1C1F1E] dark:text-[#FCFAEF]">
-                      {testimonial.name}
-                    </div>
-                    <div className="text-[#0097b2] dark:text-[#66C4DC]">
-                      {testimonial.title}
-                    </div>
-                  </div>
+                <div>
+                  <cite className="not-italic font-heading text-lg font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+                    {testimonial.name}
+                  </cite>
+                  <p className="text-sm text-[#0097b2] dark:text-[#66C4DC]">
+                    {testimonial.title}
+                  </p>
                 </div>
-              </div>
+              </footer>
             </motion.div>
           </AnimatePresence>
+        </div>
 
-          <div className="mt-8 flex justify-center gap-2">
-            {academyTestimonials.map((_, index) => (
+        <div className="mt-6 flex flex-wrap items-center justify-between gap-4">
+          <div className="flex gap-2" role="tablist" aria-label="Testimonials">
+            {academyTestimonials.map((item, index) => (
               <button
-                key={academyTestimonials[index].id}
+                key={item.id}
+                type="button"
+                role="tab"
+                aria-selected={index === currentIndex}
                 onClick={() => setCurrentIndex(index)}
-                className={`h-3 w-3 rounded-full transition-colors ${
+                className={`inline-flex h-11 min-w-11 items-center justify-center rounded-md px-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] focus-visible:ring-offset-2 ${
                   index === currentIndex
-                    ? "bg-[#0097b2] dark:bg-[#66C4DC]"
-                    : "bg-[#0097b2]/30 dark:bg-[#66C4DC]/30"
+                    ? "text-[#0097b2] dark:text-[#66C4DC]"
+                    : "text-[#0097b2]/40 dark:text-[#66C4DC]/40"
                 }`}
-                aria-label={`Go to testimonial ${index + 1}`}
-              />
+                aria-label={`Show testimonial ${index + 1} from ${item.name}`}
+              >
+                <span
+                  aria-hidden="true"
+                  className={`block h-2.5 w-2.5 rounded-full ${
+                    index === currentIndex
+                      ? "bg-current"
+                      : "bg-current opacity-50"
+                  }`}
+                />
+              </button>
             ))}
           </div>
 
-          <button
-            onClick={handlePrevious}
-            className="absolute -left-1 top-1/2 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full border border-[#E6E7E7] bg-white text-[#0097b2] shadow-md transition hover:bg-[#FCFAEF] focus:outline-none focus:ring-2 focus:ring-[#0097b2] dark:border-[#2E3433] dark:bg-[#2F3332] dark:text-[#66C4DC] md:-left-5"
-            aria-label="Previous testimonial"
-          >
-            <ChevronLeft className="h-6 w-6" />
-          </button>
-
-          <button
-            onClick={handleNext}
-            className="absolute -right-1 top-1/2 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full border border-[#E6E7E7] bg-white text-[#0097b2] shadow-md transition hover:bg-[#FCFAEF] focus:outline-none focus:ring-2 focus:ring-[#0097b2] dark:border-[#2E3433] dark:bg-[#2F3332] dark:text-[#66C4DC] md:-right-5"
-            aria-label="Next testimonial"
-          >
-            <ChevronRight className="h-6 w-6" />
-          </button>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={handlePrevious}
+              className="inline-flex h-11 w-11 items-center justify-center rounded-md border border-[#1C1F1E]/15 text-[#0097b2] transition-colors hover:border-[#0097b2] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] focus-visible:ring-offset-2 dark:border-[#FCFAEF]/25 dark:text-[#66C4DC]"
+              aria-label="Previous testimonial"
+            >
+              <ChevronLeft className="h-5 w-5" aria-hidden="true" />
+            </button>
+            <button
+              type="button"
+              onClick={handleNext}
+              className="inline-flex h-11 w-11 items-center justify-center rounded-md border border-[#1C1F1E]/15 text-[#0097b2] transition-colors hover:border-[#0097b2] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] focus-visible:ring-offset-2 dark:border-[#FCFAEF]/25 dark:text-[#66C4DC]"
+              aria-label="Next testimonial"
+            >
+              <ChevronRight className="h-5 w-5" aria-hidden="true" />
+            </button>
+          </div>
         </div>
       </div>
-    </section>
+    </EditorialBand>
   );
 }

--- a/src/components/academy/ApplySection.tsx
+++ b/src/components/academy/ApplySection.tsx
@@ -1,61 +1,52 @@
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
 import { FadeIn } from "@/components/animations";
+import {
+  EditorialBand,
+  EditorialButton,
+  EditorialEyebrow,
+  EditorialHeading,
+  EditorialLead,
+} from "@/components/shared/EditorialPrimitives";
 import { LEADERSHIP_APP_FORM_URL } from "@/config/links";
-
-const ctaBaseClass =
-  "group inline-flex items-center justify-center gap-2 rounded-half px-8 py-6 h-auto text-base sm:text-lg font-medium transition-all duration-300 transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2";
 
 export default function ApplySection() {
   return (
-    <section
-      className="relative overflow-hidden bg-gradient-to-r from-[#0097b2] to-[#0F4C5C] py-20 text-[#FCFAEF] md:py-28"
+    <EditorialBand
+      tone="teal"
+      marker="06"
+      id="apply"
       aria-labelledby="apply-heading"
+      className="border-t border-[#FCFAEF]/15 bg-[#0F4C5C]"
     >
-      <div className="pointer-events-none absolute inset-0 overflow-hidden">
-        <div className="absolute -top-24 right-12 h-64 w-64 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
-        <div className="absolute bottom-0 -left-16 h-80 w-80 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
-        <div className="absolute top-1/2 left-1/2 h-96 w-96 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[#F5C94D]/8 blur-3xl" />
-      </div>
-
-      <div className="site-container relative z-10 mx-auto px-4 sm:px-6">
-        <FadeIn className="mx-auto max-w-3xl text-center">
-          <p className="text-sm font-semibold uppercase tracking-[0.25em] text-[#F5C94D]">
+      <FadeIn>
+        <div className="mx-auto max-w-3xl text-center">
+          <EditorialEyebrow tone="gold" className="text-[#F5C94D]">
             Become a Scholar
-          </p>
-          <h2
+          </EditorialEyebrow>
+          <EditorialHeading
             id="apply-heading"
-            className="mt-4 text-3xl font-bold leading-tight sm:text-4xl md:text-5xl"
+            className="mt-4 text-[#FCFAEF] md:text-[2.6rem]"
           >
             Ready to Lead With Purpose?
-          </h2>
-          <p className="mx-auto mt-6 max-w-2xl text-base leading-relaxed text-[#FCFAEF]/85 sm:text-lg">
+          </EditorialHeading>
+          <EditorialLead className="mx-auto mt-6 max-w-2xl text-[#FCFAEF]/85 dark:text-[#FCFAEF]/85">
             The Akomapa Academy welcomes students and emerging health
             professionals who are committed to ethical leadership, community
             partnership, and creating lasting change in global health.
-          </p>
-          <div className="mt-10 flex flex-col justify-center gap-3 sm:flex-row sm:gap-4">
-            <Button
-              asChild
-              className={`${ctaBaseClass} bg-[#eeba2b] px-10 py-7 text-lg text-[#FCFAEF] shadow-lg hover:bg-[#eeba2b]/80 hover:shadow-xl focus-visible:ring-[#F5C94D] md:text-xl`}
+          </EditorialLead>
+          <div className="mt-10 flex flex-col items-center justify-center gap-3 sm:flex-row sm:gap-4">
+            <EditorialButton
+              href={LEADERSHIP_APP_FORM_URL}
+              variant="amber"
+              external
             >
-              <a
-                href={LEADERSHIP_APP_FORM_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Apply to the Academy
-              </a>
-            </Button>
-            <Button
-              asChild
-              className={`${ctaBaseClass} bg-[#0097b2] text-[#FCFAEF] shadow-lg hover:bg-[#0097b2]/80 hover:shadow-xl focus-visible:ring-[#8DD4E6]`}
-            >
-              <Link href="/get-involved">Other Ways to Get Involved</Link>
-            </Button>
+              Apply to the Academy
+            </EditorialButton>
+            <EditorialButton href="/get-involved" variant="outline-light">
+              Other Ways to Get Involved
+            </EditorialButton>
           </div>
-        </FadeIn>
-      </div>
-    </section>
+        </div>
+      </FadeIn>
+    </EditorialBand>
   );
 }

--- a/src/components/academy/CertificationSection.tsx
+++ b/src/components/academy/CertificationSection.tsx
@@ -1,7 +1,12 @@
-import { CheckCircle2 } from "lucide-react";
 import Image from "@/components/common/Image";
-import { Button } from "@/components/ui/button";
 import { FadeIn } from "@/components/animations";
+import {
+  EditorialBand,
+  EditorialButton,
+  EditorialEyebrow,
+  EditorialHeading,
+  EditorialLead,
+} from "@/components/shared/EditorialPrimitives";
 import { academyCurriculum } from "@/data/academy";
 import { LEADERSHIP_APP_FORM_URL } from "@/config/links";
 
@@ -11,73 +16,68 @@ const certificationRequirements = [
   "Present an applied community-centered capstone project",
 ] as const;
 
-const ctaBaseClass =
-  "group inline-flex items-center justify-center gap-2 rounded-half px-8 py-6 h-auto text-base sm:text-lg font-medium transition-all duration-300 transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2";
-
 export default function CertificationSection() {
   return (
-    <section className="relative overflow-hidden bg-gradient-to-r from-[#0097b2] to-[#0F4C5C] py-16 text-[#FCFAEF] md:py-24">
-      <div className="pointer-events-none absolute inset-0 overflow-hidden">
-        <div className="absolute -top-16 left-12 h-48 w-48 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
-        <div className="absolute bottom-0 right-0 h-64 w-64 rounded-full bg-[#F5C94D]/10 blur-3xl" />
+    <EditorialBand
+      tone="teal"
+      marker="04"
+      id="certification"
+      aria-labelledby="certification-heading"
+      className="border-y border-[#FCFAEF]/15 bg-[#0F4C5C]"
+    >
+      <div className="grid items-start gap-10 lg:grid-cols-12 lg:gap-16">
+        <FadeIn direction="up" delay={0.1} className="relative lg:col-span-5">
+          <span
+            aria-hidden="true"
+            className="absolute -top-3 left-0 z-10 h-1 w-24 bg-[#eeba2b] md:w-36"
+          />
+          <div className="relative aspect-[4/3] overflow-hidden rounded-md border border-[#FCFAEF]/25 bg-[#0F4C5C] lg:aspect-[4/5]">
+            <Image
+              src="/highlights/Akomapa-40.jpg"
+              alt="Academy scholars in a capstone presentation"
+              fill
+              sizes="(min-width: 1024px) 40vw, 100vw"
+              className="object-cover object-center"
+            />
+          </div>
+        </FadeIn>
+
+        <FadeIn direction="up" delay={0.15} className="lg:col-span-7">
+          <EditorialEyebrow tone="gold" className="text-[#F5C94D]">
+            Certification
+          </EditorialEyebrow>
+          <EditorialHeading
+            id="certification-heading"
+            className="mt-4 text-[#FCFAEF]"
+          >
+            {academyCurriculum.certificationName}
+          </EditorialHeading>
+          <EditorialLead className="mt-5 text-[#FCFAEF]/85 dark:text-[#FCFAEF]/85">
+            {academyCurriculum.certificationDescription}
+          </EditorialLead>
+
+          <ul className="mt-8 space-y-4 border-t border-[#FCFAEF]/25 pt-6">
+            {certificationRequirements.map((requirement) => (
+              <li
+                key={requirement}
+                className="border-b border-[#FCFAEF]/15 pb-4 text-base leading-relaxed text-[#FCFAEF]/90 last:border-b-0 last:pb-0"
+              >
+                {requirement}
+              </li>
+            ))}
+          </ul>
+
+          <div className="mt-8">
+            <EditorialButton
+              href={LEADERSHIP_APP_FORM_URL}
+              variant="amber"
+              external
+            >
+              Apply Now
+            </EditorialButton>
+          </div>
+        </FadeIn>
       </div>
-
-      <div className="site-container relative z-10 mx-auto px-4 sm:px-6">
-        <div className="mx-auto grid max-w-6xl items-center gap-10 lg:grid-cols-2 lg:gap-16">
-          <FadeIn direction="up" delay={0.1}>
-            <div className="relative h-[280px] w-full overflow-hidden rounded-3xl border border-white/10 shadow-2xl sm:h-[360px] md:h-[420px]">
-              <Image
-                src="/highlights/Akomapa-40.jpg"
-                alt="Academy scholars in a capstone presentation"
-                fill
-                sizes="(min-width: 1024px) 50vw, 100vw"
-                className="object-cover object-center"
-              />
-              <div className="absolute inset-0 bg-gradient-to-t from-black/35 via-transparent to-transparent" />
-            </div>
-          </FadeIn>
-
-          <FadeIn direction="up" delay={0.2}>
-            <div>
-              <p className="text-sm font-semibold uppercase tracking-[0.25em] text-[#F5C94D]">
-                Certification
-              </p>
-              <h2 className="mt-4 text-3xl font-bold leading-tight md:text-4xl">
-                {academyCurriculum.certificationName}
-              </h2>
-              <p className="mt-4 text-base leading-relaxed text-[#FCFAEF]/85 sm:text-lg">
-                {academyCurriculum.certificationDescription}
-              </p>
-
-              <ul className="mt-6 space-y-3">
-                {certificationRequirements.map((requirement) => (
-                  <li key={requirement} className="flex items-start gap-3">
-                    <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-[#F5C94D]" />
-                    <span className="text-base text-[#FCFAEF]/90">
-                      {requirement}
-                    </span>
-                  </li>
-                ))}
-              </ul>
-
-              <div className="mt-8">
-                <Button
-                  asChild
-                  className={`${ctaBaseClass} bg-[#eeba2b] text-[#FCFAEF] shadow-lg hover:bg-[#eeba2b]/80 hover:shadow-xl focus-visible:ring-[#F5C94D]`}
-                >
-                  <a
-                    href={LEADERSHIP_APP_FORM_URL}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Apply Now
-                  </a>
-                </Button>
-              </div>
-            </div>
-          </FadeIn>
-        </div>
-      </div>
-    </section>
+    </EditorialBand>
   );
 }

--- a/src/components/academy/CurriculumSection.tsx
+++ b/src/components/academy/CurriculumSection.tsx
@@ -1,17 +1,17 @@
 "use client";
 
 import { useState } from "react";
-import { motion, AnimatePresence } from "framer-motion";
-import { CheckCircle2, ChevronDown, Clock, Users } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { FadeIn } from "@/components/animations";
+import {
+  EditorialBand,
+  EditorialChevron,
+  EditorialEyebrow,
+  EditorialHeading,
+  EditorialLead,
+} from "@/components/shared/EditorialPrimitives";
 import { academyCurriculum, academyFaculty } from "@/data/academy";
 import type { AcademyModule } from "@/lib/types";
-
-const accentColors = ["#0097b2", "#F5C94D", "#66C4DC", "#eeba2b"] as const;
-
-function getAccentColor(index: number) {
-  return accentColors[index % accentColors.length];
-}
 
 function resolveFacultyNames(contributorIds: string[]): string {
   return contributorIds
@@ -22,133 +22,149 @@ function resolveFacultyNames(contributorIds: string[]): string {
 
 function ModuleAccordion({ modules }: { modules: AcademyModule[] }) {
   const [openId, setOpenId] = useState<string | null>(modules[0]?.id ?? null);
+  const shouldReduceMotion = useReducedMotion();
 
   return (
-    <div className="w-full space-y-3 sm:space-y-4">
-      {modules.map((module, index) => {
+    <ol className="w-full border-t border-[#FCFAEF]/25">
+      {modules.map((module) => {
         const isOpen = openId === module.id;
-        const accent = getAccentColor(index);
+        const panelId = `module-content-${module.id}`;
+        const buttonId = `module-toggle-${module.id}`;
 
         return (
-          <div
+          <li
             key={module.id}
-            className="overflow-hidden rounded-2xl border border-white/20 bg-[#0B2F3A]/60 text-[#FCFAEF] shadow-lg shadow-black/30 backdrop-blur-sm transition-all duration-200 hover:-translate-y-0.5"
+            className="border-b border-[#FCFAEF]/25"
+            value={module.order}
           >
             <button
+              id={buttonId}
               type="button"
               onClick={() => setOpenId(isOpen ? null : module.id)}
-              className="flex w-full items-start justify-between gap-3 px-4 py-4 text-left sm:items-center sm:gap-4 sm:px-6 sm:py-5"
+              className="flex min-h-11 w-full items-start justify-between gap-4 py-5 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0F4C5C] sm:items-center sm:py-6"
               aria-expanded={isOpen}
-              aria-controls={`module-content-${module.id}`}
+              aria-controls={panelId}
             >
-              <div className="min-w-0 flex-1 space-y-2 sm:space-y-3">
-                <span
-                  className="inline-flex items-center rounded-full px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.2em] sm:px-3 sm:text-xs sm:tracking-[0.3em]"
-                  style={{
-                    color: accent,
-                    backgroundColor: `${accent}1A`,
-                  }}
-                >
-                  Module {module.order}
+              <div className="min-w-0 flex-1">
+                <span className="font-subheading text-xs font-bold uppercase tracking-[0.2em] text-[#F5C94D]">
+                  Module {String(module.order).padStart(2, "0")}
                 </span>
-                <h3 className="text-base font-semibold leading-tight text-[#FCFAEF] sm:text-lg md:text-xl">
+                <h3 className="mt-2 font-heading text-lg font-semibold leading-tight text-[#FCFAEF] sm:text-xl md:text-2xl">
                   {module.title}
                 </h3>
               </div>
-              <ChevronDown
-                className={`mt-1 h-4 w-4 flex-shrink-0 text-[#FCFAEF] transition-transform duration-200 sm:mt-0 sm:h-5 sm:w-5 ${
-                  isOpen ? "rotate-180" : ""
+              <EditorialChevron
+                className={`mt-1 h-5 w-5 shrink-0 text-[#FCFAEF] transition-transform duration-200 motion-reduce:transition-none ${
+                  isOpen ? "rotate-[-90deg]" : "rotate-90"
                 }`}
               />
             </button>
 
             <AnimatePresence initial={false}>
-              {isOpen && (
+              {isOpen ? (
                 <motion.div
-                  id={`module-content-${module.id}`}
-                  initial={{ height: 0, opacity: 0 }}
+                  id={panelId}
+                  role="region"
+                  aria-labelledby={buttonId}
+                  initial={
+                    shouldReduceMotion
+                      ? false
+                      : { height: 0, opacity: 0 }
+                  }
                   animate={{ height: "auto", opacity: 1 }}
-                  exit={{ height: 0, opacity: 0 }}
-                  transition={{ duration: 0.3, ease: "easeInOut" }}
+                  exit={
+                    shouldReduceMotion
+                      ? { opacity: 1 }
+                      : { height: 0, opacity: 0 }
+                  }
+                  transition={
+                    shouldReduceMotion
+                      ? { duration: 0 }
+                      : { duration: 0.3, ease: "easeInOut" }
+                  }
                   style={{ overflow: "hidden" }}
                 >
-                  <div className="space-y-4 px-4 pb-4 sm:px-6 sm:pb-6">
+                  <div className="space-y-5 pb-6">
                     <p className="text-sm leading-relaxed text-[#FCFAEF]/85 sm:text-base">
                       {module.description}
                     </p>
 
                     <div>
-                      <h4 className="text-xs font-bold uppercase tracking-widest text-[#F5C94D]">
+                      <h4 className="font-subheading text-xs font-bold uppercase tracking-[0.2em] text-[#F5C94D]">
                         Learning Objectives
                       </h4>
-                      <ul className="mt-2 space-y-1.5">
+                      <ul className="mt-3 space-y-2 border-l border-[#FCFAEF]/25 pl-4">
                         {module.learningObjectives.map((objective) => (
                           <li
                             key={objective}
-                            className="flex items-start gap-2 text-sm text-[#FCFAEF]/85"
+                            className="text-sm leading-relaxed text-[#FCFAEF]/85"
                           >
-                            <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-[#F5C94D]" />
-                            <span>{objective}</span>
+                            {objective}
                           </li>
                         ))}
                       </ul>
                     </div>
 
-                    <div className="flex flex-wrap items-center gap-3 text-xs text-[#FCFAEF]/70">
+                    <dl className="flex flex-wrap gap-x-8 gap-y-3 text-sm text-[#FCFAEF]/80">
                       {module.duration ? (
-                        <span className="inline-flex items-center gap-1.5 rounded-full bg-white/10 px-3 py-1 font-semibold text-[#FCFAEF]">
-                          <Clock className="h-3 w-3" />
-                          {module.duration}
-                        </span>
+                        <div>
+                          <dt className="font-subheading text-xs font-bold uppercase tracking-[0.2em] text-[#FCFAEF]/60">
+                            Duration
+                          </dt>
+                          <dd className="mt-1">{module.duration}</dd>
+                        </div>
                       ) : null}
-                      <span className="inline-flex items-center gap-1.5">
-                        <Users className="h-3 w-3 text-[#F5C94D]" />
-                        {resolveFacultyNames(module.facultyContributors)}
-                      </span>
-                    </div>
+                      <div>
+                        <dt className="font-subheading text-xs font-bold uppercase tracking-[0.2em] text-[#FCFAEF]/60">
+                          Faculty
+                        </dt>
+                        <dd className="mt-1">
+                          {resolveFacultyNames(module.facultyContributors)}
+                        </dd>
+                      </div>
+                    </dl>
                   </div>
                 </motion.div>
-              )}
+              ) : null}
             </AnimatePresence>
-          </div>
+          </li>
         );
       })}
-    </div>
+    </ol>
   );
 }
 
 export default function CurriculumSection() {
   return (
-    <section
+    <EditorialBand
+      tone="teal"
+      marker="02"
       id="curriculum"
-      className="relative scroll-mt-20 overflow-hidden bg-gradient-to-r from-[#0097b2] to-[#0F4C5C] py-16 text-[#FCFAEF] md:py-24"
+      aria-labelledby="curriculum-heading"
+      className="scroll-mt-20 border-y border-[#FCFAEF]/15 bg-[#0F4C5C]"
     >
-      <div className="pointer-events-none absolute inset-0 overflow-hidden">
-        <div className="absolute -top-24 -left-24 h-64 w-64 rounded-full bg-[#FCFAEF]/10 blur-3xl" />
-        <div className="absolute bottom-0 right-0 h-80 w-80 rounded-full bg-[#F5C94D]/10 blur-3xl" />
-      </div>
-
-      <div className="site-container relative z-10 mx-auto px-4 sm:px-6">
-        <FadeIn>
-          <div className="mx-auto mb-12 max-w-3xl space-y-4 text-center">
-            <p className="text-sm font-semibold uppercase tracking-[0.2em] text-[#F5C94D]">
-              Curriculum
-            </p>
-            <h2 className="text-3xl font-bold md:text-4xl">
-              8 Modules. One Transformative Journey.
-            </h2>
-            <p className="text-base leading-relaxed text-[#FCFAEF]/85 sm:text-lg">
-              A {academyCurriculum.totalDuration} program covering ethical
-              leadership, community partnership, research, innovation, and an
-              applied capstone project.
-            </p>
-          </div>
-        </FadeIn>
-
-        <div className="mx-auto max-w-3xl">
-          <ModuleAccordion modules={academyCurriculum.modules} />
+      <FadeIn>
+        <div className="max-w-3xl">
+          <EditorialEyebrow tone="gold" className="text-[#F5C94D]">
+            Curriculum
+          </EditorialEyebrow>
+          <EditorialHeading
+            id="curriculum-heading"
+            className="mt-4 text-[#FCFAEF]"
+          >
+            8 Modules. One Transformative Journey.
+          </EditorialHeading>
+          <EditorialLead className="mt-5 text-[#FCFAEF]/85 dark:text-[#FCFAEF]/85">
+            A {academyCurriculum.totalDuration} program covering ethical
+            leadership, community partnership, research, innovation, and an
+            applied capstone project.
+          </EditorialLead>
         </div>
+      </FadeIn>
+
+      <div className="mx-auto mt-12 max-w-3xl">
+        <ModuleAccordion modules={academyCurriculum.modules} />
       </div>
-    </section>
+    </EditorialBand>
   );
 }

--- a/src/components/academy/FacultyGrid.tsx
+++ b/src/components/academy/FacultyGrid.tsx
@@ -1,6 +1,12 @@
 import { Linkedin, Mail } from "lucide-react";
 import Image from "@/components/common/Image";
 import { FadeIn, FadeInStagger, FadeInStaggerItem } from "@/components/animations";
+import {
+  EditorialBand,
+  EditorialEyebrow,
+  EditorialHeading,
+  EditorialLead,
+} from "@/components/shared/EditorialPrimitives";
 import { academyFaculty } from "@/data/academy";
 import type { FacultyMember } from "@/lib/types";
 
@@ -8,8 +14,8 @@ function FacultyCard({ faculty }: { faculty: FacultyMember }) {
   const hasLinks = faculty.socialLinks?.linkedin || faculty.socialLinks?.email;
 
   return (
-    <div className="group flex flex-col overflow-hidden rounded-[28px] border border-[#E6E7E7]/80 bg-white/95 shadow-sm transition-all duration-500 hover:-translate-y-1 hover:shadow-xl dark:border-[#2E3433] dark:bg-[#1C1F1E]/95">
-      <div className="relative h-80 w-full overflow-hidden sm:h-96 md:h-[28rem] lg:h-[24rem]">
+    <article className="flex h-full flex-col border-t border-[#1C1F1E]/15 pt-6 dark:border-[#FCFAEF]/20">
+      <div className="relative aspect-[4/5] w-full overflow-hidden rounded-md border border-[#1C1F1E]/10 bg-[#E6E7E7] dark:border-[#FCFAEF]/15 dark:bg-[#2F3332]">
         <Image
           src={faculty.image}
           alt={`${faculty.name}, ${faculty.title}`}
@@ -19,82 +25,87 @@ function FacultyCard({ faculty }: { faculty: FacultyMember }) {
         />
       </div>
 
-      <div className="flex flex-col gap-2 px-6 py-6">
-        <p className="text-xs uppercase tracking-[0.3em] text-[#0097b2] dark:text-[#66C4DC]">
+      <div className="flex flex-1 flex-col gap-2 pt-5">
+        <p className="font-subheading text-xs font-bold uppercase tracking-[0.2em] text-[#0097b2] dark:text-[#66C4DC]">
           {faculty.institution}
         </p>
-        <h3 className="text-xl font-semibold text-[#0B2F3A] dark:text-[#FCFAEF]">
+        <h3 className="font-heading text-xl font-semibold leading-snug text-[#1C1F1E] dark:text-[#FCFAEF]">
           {faculty.name}
         </h3>
-        <p className="text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
+        <p className="text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
           {faculty.title}
         </p>
 
-        <div className="mt-2 flex flex-wrap gap-1.5">
+        <ul className="mt-2 flex flex-wrap gap-x-3 gap-y-1">
           {faculty.specialties.map((specialty) => (
-            <span
+            <li
               key={specialty}
-              className="rounded-full bg-[#0097b2]/8 px-2.5 py-0.5 text-xs text-[#0097b2] dark:bg-[#66C4DC]/12 dark:text-[#66C4DC]"
+              className="text-xs leading-relaxed text-[#2F3332]/70 dark:text-[#E6E7E7]/70"
             >
               {specialty}
-            </span>
+            </li>
           ))}
-        </div>
+        </ul>
 
         {hasLinks ? (
-          <div className="mt-2 flex items-center gap-3 pt-2">
+          <div className="mt-auto flex items-center gap-3 pt-4">
             {faculty.socialLinks?.linkedin ? (
               <a
                 href={faculty.socialLinks.linkedin}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-[#E6E7E7] text-[#0B2F3A] transition-colors hover:bg-[#0097b2]/10 dark:border-[#2E3433] dark:text-[#FCFAEF] dark:hover:bg-[#0097b2]/20"
+                className="inline-flex h-11 w-11 items-center justify-center rounded-md border border-[#1C1F1E]/15 text-[#1C1F1E] transition-colors hover:border-[#0097b2] hover:text-[#0097b2] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] focus-visible:ring-offset-2 dark:border-[#FCFAEF]/25 dark:text-[#FCFAEF] dark:hover:border-[#66C4DC] dark:hover:text-[#66C4DC]"
                 aria-label={`${faculty.name} on LinkedIn`}
               >
-                <Linkedin className="h-4 w-4" />
+                <Linkedin className="h-4 w-4" aria-hidden="true" />
               </a>
             ) : null}
             {faculty.socialLinks?.email ? (
               <a
                 href={`mailto:${faculty.socialLinks.email}`}
-                className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-[#E6E7E7] text-[#0B2F3A] transition-colors hover:bg-[#0097b2]/10 dark:border-[#2E3433] dark:text-[#FCFAEF] dark:hover:bg-[#0097b2]/20"
+                className="inline-flex h-11 w-11 items-center justify-center rounded-md border border-[#1C1F1E]/15 text-[#1C1F1E] transition-colors hover:border-[#0097b2] hover:text-[#0097b2] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] focus-visible:ring-offset-2 dark:border-[#FCFAEF]/25 dark:text-[#FCFAEF] dark:hover:border-[#66C4DC] dark:hover:text-[#66C4DC]"
                 aria-label={`Email ${faculty.name}`}
               >
-                <Mail className="h-4 w-4" />
+                <Mail className="h-4 w-4" aria-hidden="true" />
               </a>
             ) : null}
           </div>
         ) : null}
       </div>
-    </div>
+    </article>
   );
 }
 
 export default function FacultyGrid() {
   return (
-    <section className="overflow-x-hidden bg-[#FCFAEF] py-16 dark:bg-[#1C1F1E] md:py-24">
-      <div className="site-container mx-auto px-4 sm:px-6">
-        <FadeIn direction="up" className="mx-auto mb-10 max-w-3xl space-y-3 text-center sm:space-y-4">
-          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#0097b2] dark:text-[#66C4DC] sm:text-sm">
+    <EditorialBand
+      tone="cream"
+      marker="03"
+      id="faculty"
+      aria-labelledby="faculty-heading"
+    >
+      <FadeIn>
+        <div className="max-w-3xl">
+          <EditorialEyebrow className="text-[#0F4C5C] dark:text-[#66C4DC]">
             Faculty
-          </p>
-          <h2 className="text-2xl font-bold text-[#0B2F3A] dark:text-[#FCFAEF] sm:text-3xl md:text-4xl">
+          </EditorialEyebrow>
+          <EditorialHeading id="faculty-heading" className="mt-4">
             Learn From Leaders in the Field
-          </h2>
-          <p className="text-base leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80 sm:text-lg">
+          </EditorialHeading>
+          <EditorialLead className="mt-5">
             Our faculty bring decades of experience across community medicine,
             health systems, clinical education, and public health leadership.
-          </p>
-        </FadeIn>
+          </EditorialLead>
+        </div>
+      </FadeIn>
 
-        <FadeInStagger className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4 sm:gap-6">
-          {academyFaculty.map((faculty) => (
-            <FadeInStaggerItem key={faculty.id}>
-              <FacultyCard faculty={faculty} />
-            </FadeInStaggerItem>
-          ))}
-        </FadeInStagger>
-      </div>
-    </section>
+      <FadeInStagger className="mt-12 grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-4 sm:gap-6 lg:gap-8">
+        {academyFaculty.map((faculty) => (
+          <FadeInStaggerItem key={faculty.id}>
+            <FacultyCard faculty={faculty} />
+          </FadeInStaggerItem>
+        ))}
+      </FadeInStagger>
+    </EditorialBand>
   );
 }

--- a/src/components/academy/WhyEthicalLeadership.tsx
+++ b/src/components/academy/WhyEthicalLeadership.tsx
@@ -1,91 +1,96 @@
-import { AlertTriangle, Shield, Sparkles } from "lucide-react";
 import Image from "@/components/common/Image";
-import { FadeIn, FadeInStagger, FadeInStaggerItem } from "@/components/animations";
+import { FadeIn } from "@/components/animations";
+import {
+  EditorialBand,
+  EditorialEyebrow,
+  EditorialHeading,
+  EditorialLead,
+} from "@/components/shared/EditorialPrimitives";
 import { academyOverview } from "@/data/academy";
 
 const reasons = [
   {
-    icon: AlertTriangle,
     title: "The Gap in Health Education",
     description:
       "Most health professional training emphasizes clinical knowledge but overlooks ethics, power analysis, and community partnership — the skills that determine whether interventions help or harm.",
-    accentColor: "#0097b2",
   },
   {
-    icon: Shield,
     title: "Why Ethics and Partnership Matter",
     description:
       "Health professionals make decisions that affect communities, institutions, and public trust. Ethical leadership equips them to examine power, listen across differences, and use evidence responsibly.",
-    accentColor: "#eeba2b",
   },
   {
-    icon: Sparkles,
     title: "The Akomapa Difference",
     description:
       "The Academy combines faculty dialogue, case-based study, community practice, and mentorship — preparing leaders who build solutions with the people those solutions are intended to serve.",
-    accentColor: "#0F4C5C",
   },
 ] as const;
 
 export default function WhyEthicalLeadership() {
   return (
-    <section className="overflow-x-hidden bg-[#FCFAEF] py-16 dark:bg-[#1C1F1E] md:py-24">
-      <div className="site-container mx-auto px-4 sm:px-6">
-        <FadeIn direction="up" className="mx-auto mb-10 max-w-3xl space-y-3 text-center sm:space-y-4">
-          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#0097b2] dark:text-[#66C4DC] sm:text-sm">
+    <EditorialBand
+      tone="cream"
+      marker="01"
+      id="why-ethical-leadership"
+      aria-labelledby="why-ethical-leadership-heading"
+    >
+      <FadeIn>
+        <div className="max-w-3xl">
+          <EditorialEyebrow className="text-[#0F4C5C] dark:text-[#66C4DC]">
             Why It Matters
-          </p>
-          <h2 className="text-2xl font-bold text-[#1C1F1E] dark:text-[#FCFAEF] sm:text-3xl md:text-4xl">
+          </EditorialEyebrow>
+          <EditorialHeading id="why-ethical-leadership-heading" className="mt-4">
             The Case for Ethical Leadership
-          </h2>
-          <p className="text-base leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80 sm:text-lg">
+          </EditorialHeading>
+          <EditorialLead className="mt-5">
             {academyOverview.whyItMatters}
-          </p>
+          </EditorialLead>
+        </div>
+      </FadeIn>
+
+      <div className="mt-12 grid items-start gap-10 lg:grid-cols-12 lg:gap-16">
+        <FadeIn direction="up" delay={0.1} className="relative lg:col-span-5">
+          <span
+            aria-hidden="true"
+            className="absolute -top-3 left-0 z-10 h-1 w-24 bg-[#eeba2b] md:w-36"
+          />
+          <div className="relative aspect-[4/3] overflow-hidden rounded-md border border-[#1C1F1E]/15 bg-[#FCFAEF] dark:border-[#FCFAEF]/20 dark:bg-[#121514]">
+            <Image
+              src="/highlights/Akomapa-61.jpg"
+              alt="Students and faculty engaged in collaborative learning"
+              fill
+              sizes="(min-width: 1024px) 40vw, 100vw"
+              className="object-cover object-center"
+            />
+          </div>
         </FadeIn>
 
-        <div className="mx-auto grid max-w-6xl items-center gap-10 lg:grid-cols-2 lg:gap-16">
-          <FadeIn direction="up" delay={0.1}>
-            <div className="relative h-[280px] w-full overflow-hidden rounded-3xl shadow-2xl sm:h-[360px] md:h-[420px]">
-              <Image
-                src="/highlights/Akomapa-61.jpg"
-                alt="Students and faculty engaged in collaborative learning"
-                fill
-                sizes="(min-width: 1024px) 50vw, 100vw"
-                className="object-cover object-center"
-              />
-              <div className="absolute inset-0 bg-gradient-to-t from-black/25 via-transparent to-transparent" />
-            </div>
-          </FadeIn>
-
-          <FadeInStagger className="space-y-4" staggerDelay={0.1}>
-            {reasons.map((reason) => (
-              <FadeInStaggerItem key={reason.title} direction="up">
-                <div className="rounded-2xl border border-[#E6E7E7]/80 bg-white/95 p-6 shadow-sm transition-all duration-500 hover:-translate-y-1 hover:shadow-xl dark:border-[#2E3433] dark:bg-[#1C1F1E]/95">
-                  <div className="flex items-start gap-4">
-                    <span
-                      className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-lg"
-                      style={{
-                        backgroundColor: `${reason.accentColor}15`,
-                        color: reason.accentColor,
-                      }}
-                    >
-                      <reason.icon className="h-5 w-5" />
-                    </span>
-                    <div>
-                      <h3 className="text-lg font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
-                        {reason.title}
-                      </h3>
-                      <p className="mt-1.5 text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
-                        {reason.description}
-                      </p>
-                    </div>
-                  </div>
+        <FadeIn delay={0.15} className="lg:col-span-7">
+          <ol className="border-t border-[#1C1F1E]/15 dark:border-[#FCFAEF]/20">
+            {reasons.map((reason, index) => (
+              <li
+                key={reason.title}
+                className="grid gap-4 border-b border-[#1C1F1E]/15 py-7 sm:grid-cols-[auto_1fr] sm:gap-8 dark:border-[#FCFAEF]/20"
+              >
+                <span
+                  aria-hidden="true"
+                  className="font-heading text-3xl font-semibold tracking-[-0.06em] text-[#0097b2]/55 dark:text-[#66C4DC]/65"
+                >
+                  {String(index + 1).padStart(2, "0")}
+                </span>
+                <div>
+                  <h3 className="font-heading text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+                    {reason.title}
+                  </h3>
+                  <p className="mt-3 text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80 md:text-base">
+                    {reason.description}
+                  </p>
                 </div>
-              </FadeInStaggerItem>
+              </li>
             ))}
-          </FadeInStagger>
-        </div>
+          </ol>
+        </FadeIn>
       </div>
-    </section>
+    </EditorialBand>
   );
 }

--- a/src/components/academy/__tests__/AcademyEditorial.test.tsx
+++ b/src/components/academy/__tests__/AcademyEditorial.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import AcademyHero from "@/components/academy/AcademyHero";
+import ApplySection from "@/components/academy/ApplySection";
+import CurriculumSection from "@/components/academy/CurriculumSection";
+import FacultyGrid from "@/components/academy/FacultyGrid";
+import WhyEthicalLeadership from "@/components/academy/WhyEthicalLeadership";
+import { LEADERSHIP_APP_FORM_URL } from "@/config/links";
+import {
+  academyCurriculum,
+  academyFaculty,
+  academyOverview,
+} from "@/data/academy";
+
+describe("Academy editorial sections", () => {
+  it("renders a single flat hero with approved copy, metrics, and apply destination", () => {
+    render(<AcademyHero />);
+
+    const heading = screen.getByRole("heading", {
+      level: 1,
+      name: "Akomapa Academy",
+    });
+    const hero = heading.closest("section");
+
+    expect(hero).toHaveAttribute("data-editorial-tone", "teal");
+    expect(hero?.className).not.toContain("gradient");
+    expect(screen.getByText(academyOverview.title)).toBeVisible();
+    expect(screen.getByText(academyOverview.description)).toBeVisible();
+    expect(screen.getByText(academyCurriculum.totalDuration)).toBeVisible();
+    expect(screen.getByText("Core Modules")).toBeVisible();
+    expect(screen.getByText("Expert Faculty")).toBeVisible();
+
+    const apply = screen.getByRole("link", { name: /Become a Scholar/i });
+    expect(apply).toHaveAttribute("href", LEADERSHIP_APP_FORM_URL);
+    expect(apply).toHaveAttribute("target", "_blank");
+
+    expect(
+      screen.getByRole("link", { name: /Explore Curriculum/i }),
+    ).toHaveAttribute("href", "#curriculum");
+  });
+
+  it("presents why-it-matters as a numbered editorial list without card surfaces", () => {
+    render(<WhyEthicalLeadership />);
+
+    const section = screen.getByRole("region", {
+      name: "The Case for Ethical Leadership",
+    });
+    expect(section).toHaveAttribute("data-editorial-tone", "cream");
+    expect(screen.getByText(academyOverview.whyItMatters)).toBeVisible();
+
+    const items = within(section).getAllByRole("listitem");
+    expect(items).toHaveLength(3);
+    expect(section.querySelector("[data-slot='card']")).toBeNull();
+  });
+
+  it("keeps curriculum modules in semantic order without glass styling", () => {
+    render(<CurriculumSection />);
+
+    const section = screen.getByRole("region", {
+      name: "8 Modules. One Transformative Journey.",
+    });
+    expect(section).toHaveAttribute("id", "curriculum");
+    expect(section.className).not.toContain("gradient");
+
+    const list = section.querySelector("ol");
+    expect(list).not.toBeNull();
+
+    const items = Array.from(list!.children).filter(
+      (child) => child.tagName === "LI",
+    );
+    expect(items).toHaveLength(academyCurriculum.modules.length);
+    expect(
+      items.map(
+        (item) =>
+          within(item as HTMLElement).getByRole("heading", { level: 3 })
+            .textContent,
+      ),
+    ).toEqual(academyCurriculum.modules.map((module) => module.title));
+  });
+
+  it("supports long faculty credentials without fixed-height image shells", () => {
+    render(<FacultyGrid />);
+
+    const section = screen.getByRole("region", {
+      name: "Learn From Leaders in the Field",
+    });
+    expect(section).toHaveAttribute("data-editorial-tone", "cream");
+
+    for (const faculty of academyFaculty) {
+      expect(screen.getByText(faculty.name)).toBeVisible();
+      expect(screen.getByText(faculty.title)).toBeVisible();
+      expect(screen.getByText(faculty.institution)).toBeVisible();
+    }
+
+    const images = section.querySelectorAll("img");
+    for (const image of images) {
+      const shell = image.closest("div");
+      expect(shell?.className ?? "").not.toMatch(/\bh-\d+\b/);
+      expect(shell?.className ?? "").not.toMatch(/min-h-\[/);
+    }
+  });
+
+  it("keeps the apply journey destinations intact", () => {
+    render(<ApplySection />);
+
+    expect(
+      screen.getByRole("link", { name: /Apply to the Academy/i }),
+    ).toHaveAttribute("href", LEADERSHIP_APP_FORM_URL);
+    expect(
+      screen.getByRole("link", { name: /Other Ways to Get Involved/i }),
+    ).toHaveAttribute("href", "/get-involved");
+  });
+});

--- a/src/components/programs/GhltpTestimonialsCarousel.tsx
+++ b/src/components/programs/GhltpTestimonialsCarousel.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { AnimatePresence, MotionDiv } from "@/components/motion/framer";
-import { ArrowLeft, ArrowRight, Quote } from "lucide-react";
+import { useReducedMotion } from "framer-motion";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import Image from "@/components/common/Image";
 
 const testimonials = [
@@ -26,115 +27,136 @@ const testimonials = [
 
 export default function GhltpTestimonialsCarousel() {
   const [currentIndex, setCurrentIndex] = useState(0);
-  const [isHovered, setIsHovered] = useState(false);
+  const [isPaused, setIsPaused] = useState(false);
+  const shouldReduceMotion = useReducedMotion();
 
   useEffect(() => {
-    if (isHovered) {
+    if (isPaused || shouldReduceMotion) {
       return;
     }
 
     const timer = setInterval(() => {
       setCurrentIndex((prev) =>
-        prev === testimonials.length - 1 ? 0 : prev + 1
+        prev === testimonials.length - 1 ? 0 : prev + 1,
       );
     }, 5000);
 
     return () => clearInterval(timer);
-  }, [isHovered]);
+  }, [isPaused, shouldReduceMotion]);
 
   const handlePrevious = () => {
     setCurrentIndex((prev) =>
-      prev === 0 ? testimonials.length - 1 : prev - 1
+      prev === 0 ? testimonials.length - 1 : prev - 1,
     );
   };
 
   const handleNext = () => {
     setCurrentIndex((prev) =>
-      prev === testimonials.length - 1 ? 0 : prev + 1
+      prev === testimonials.length - 1 ? 0 : prev + 1,
     );
   };
 
+  const testimonial = testimonials[currentIndex];
+
   return (
     <div
-      className="relative max-w-4xl mx-auto"
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
+      className="relative mx-auto max-w-4xl"
+      role="region"
+      aria-roledescription="carousel"
+      aria-label="Voices from participants"
+      onMouseEnter={() => setIsPaused(true)}
+      onMouseLeave={() => setIsPaused(false)}
+      onFocusCapture={() => setIsPaused(true)}
+      onBlurCapture={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+          setIsPaused(false);
+        }
+      }}
     >
-      <AnimatePresence mode="wait">
-        <MotionDiv
-          key={currentIndex}
-          initial={{ opacity: 0, x: 20 }}
-          animate={{ opacity: 1, x: 0 }}
-          exit={{ opacity: 0, x: -20 }}
-          transition={{ duration: 0.3 }}
-          className="bg-white/90 dark:bg-[#2F3332] rounded-2xl shadow-xl p-8 md:p-12 min-h-[300px] flex flex-col"
-        >
-          <div className="absolute top-8 left-8 text-[#0097b2] dark:text-[#66C4DC] opacity-20">
-            <Quote size={64} />
-          </div>
+      <div
+        className="border border-[#FCFAEF]/25 bg-[#0B2F3A] px-6 py-8 md:px-10 md:py-10"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        <AnimatePresence mode="wait">
+          <MotionDiv
+            key={currentIndex}
+            initial={shouldReduceMotion ? false : { opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: shouldReduceMotion ? 1 : 0 }}
+            transition={{ duration: shouldReduceMotion ? 0 : 0.25 }}
+          >
+            <blockquote className="font-heading text-xl leading-relaxed text-[#FCFAEF] md:text-2xl">
+              <span className="sr-only">Quote from {testimonial.name}: </span>
+              &quot;{testimonial.quote}&quot;
+            </blockquote>
 
-          <div className="relative z-10 flex flex-col h-full">
-            <div className="flex-1 flex flex-col justify-center">
-              <blockquote className="text-xl md:text-2xl leading-relaxed text-[#2F3332] dark:text-[#E6E7E7]">
-                &quot;{testimonials[currentIndex].quote}&quot;
-              </blockquote>
-            </div>
-
-            <div className="flex items-center mt-8">
-              <div className="rounded-full overflow-hidden h-16 w-16 mr-4">
+            <footer className="mt-8 flex items-center gap-4 border-t border-[#FCFAEF]/20 pt-6">
+              <div className="relative h-14 w-14 shrink-0 overflow-hidden rounded-md bg-[#2F3332]">
                 <Image
-                  src={testimonials[currentIndex].image}
-                  alt={`Headshot of ${testimonials[currentIndex].name}, ${testimonials[currentIndex].title}`}
-                  width={64}
-                  height={64}
-                  className="object-cover h-full w-full"
+                  src={testimonial.image}
+                  alt=""
+                  width={56}
+                  height={56}
+                  className="h-full w-full object-cover"
                 />
               </div>
               <div>
-                <div className="font-bold text-lg text-[#1C1F1E] dark:text-[#FCFAEF]">
-                  {testimonials[currentIndex].name}
-                </div>
-                <div className="text-[#eeba2b] dark:text-[#F5C94D]">
-                  {testimonials[currentIndex].title}
-                </div>
+                <cite className="not-italic font-heading text-lg font-semibold text-[#FCFAEF]">
+                  {testimonial.name}
+                </cite>
+                <p className="text-sm text-[#F5C94D]">{testimonial.title}</p>
               </div>
-            </div>
-          </div>
-        </MotionDiv>
-      </AnimatePresence>
-
-      <div className="flex justify-center mt-8 gap-2">
-        {testimonials.map((_, index) => (
-          <button
-            key={index}
-            onClick={() => setCurrentIndex(index)}
-            className={`h-3 w-3 rounded-full ${
-              index === currentIndex ? "bg-[#F5C94D]" : "bg-[#FCFAEF]/30"
-            }`}
-            aria-label={`Go to testimonial ${index + 1}`}
-          />
-        ))}
+            </footer>
+          </MotionDiv>
+        </AnimatePresence>
       </div>
 
-      {testimonials.length > 1 && (
-        <>
-          <button
-            onClick={handlePrevious}
-            className="absolute top-1/2 -left-4 md:-left-8 transform -translate-y-1/2 bg-white/90 dark:bg-[#2F3332] rounded-full p-2 shadow-md hover:bg-white dark:hover:bg-gray-700 transition"
-            aria-label="Previous testimonial"
-          >
-            <ArrowLeft className="h-6 w-6 text-[#0097b2]" />
-          </button>
+      <div className="mt-6 flex flex-wrap items-center justify-between gap-4">
+        <div className="flex gap-2" role="tablist" aria-label="Participant quotes">
+          {testimonials.map((item, index) => (
+            <button
+              key={item.id}
+              type="button"
+              role="tab"
+              aria-selected={index === currentIndex}
+              onClick={() => setCurrentIndex(index)}
+              className={`inline-flex h-11 min-w-11 items-center justify-center rounded-md px-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0F4C5C] ${
+                index === currentIndex ? "text-[#F5C94D]" : "text-[#FCFAEF]/40"
+              }`}
+              aria-label={`Show testimonial ${index + 1} from ${item.name}`}
+            >
+              <span
+                aria-hidden="true"
+                className={`block h-2.5 w-2.5 rounded-full ${
+                  index === currentIndex ? "bg-current" : "bg-current opacity-50"
+                }`}
+              />
+            </button>
+          ))}
+        </div>
 
-          <button
-            onClick={handleNext}
-            className="absolute top-1/2 -right-4 md:-right-8 transform -translate-y-1/2 bg-white/90 dark:bg-[#2F3332] rounded-full p-2 shadow-md hover:bg-white dark:hover:bg-gray-700 transition"
-            aria-label="Next testimonial"
-          >
-            <ArrowRight className="h-6 w-6 text-[#0097b2]" />
-          </button>
-        </>
-      )}
+        {testimonials.length > 1 ? (
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={handlePrevious}
+              className="inline-flex h-11 w-11 items-center justify-center rounded-md border border-[#FCFAEF]/40 text-[#FCFAEF] transition-colors hover:border-[#eeba2b] hover:text-[#eeba2b] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0F4C5C]"
+              aria-label="Previous testimonial"
+            >
+              <ChevronLeft className="h-5 w-5" aria-hidden="true" />
+            </button>
+            <button
+              type="button"
+              onClick={handleNext}
+              className="inline-flex h-11 w-11 items-center justify-center rounded-md border border-[#FCFAEF]/40 text-[#FCFAEF] transition-colors hover:border-[#eeba2b] hover:text-[#eeba2b] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0F4C5C]"
+              aria-label="Next testimonial"
+            >
+              <ChevronRight className="h-5 w-5" aria-hidden="true" />
+            </button>
+          </div>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/src/components/programs/GhltpTestimonialsCarousel.tsx
+++ b/src/components/programs/GhltpTestimonialsCarousel.tsx
@@ -63,7 +63,7 @@ export default function GhltpTestimonialsCarousel() {
       className="relative mx-auto max-w-4xl"
       role="region"
       aria-roledescription="carousel"
-      aria-label="Voices from participants"
+      aria-label="Participant testimonial carousel"
       onMouseEnter={() => setIsPaused(true)}
       onMouseLeave={() => setIsPaused(false)}
       onFocusCapture={() => setIsPaused(true)}

--- a/src/components/programs/ProgramDetailHero.tsx
+++ b/src/components/programs/ProgramDetailHero.tsx
@@ -1,0 +1,115 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
+import Image from "@/components/common/Image";
+import { FadeIn } from "@/components/animations";
+import {
+  EditorialBand,
+  EditorialButton,
+  EditorialChevron,
+  EditorialEyebrow,
+  EditorialHeading,
+  EditorialLead,
+  type EditorialButtonVariant,
+} from "@/components/shared/EditorialPrimitives";
+
+export type ProgramDetailCta = {
+  href: string;
+  label: string;
+  variant?: EditorialButtonVariant;
+  external?: boolean;
+};
+
+type ProgramDetailHeroProps = {
+  eyebrow: string;
+  title: string;
+  titleId?: string;
+  lead: string;
+  image: string;
+  imageAlt: string;
+  ctas?: ProgramDetailCta[];
+  backHref?: string;
+  backLabel?: string;
+  children?: ReactNode;
+};
+
+export default function ProgramDetailHero({
+  eyebrow,
+  title,
+  titleId = "program-detail-hero-heading",
+  lead,
+  image,
+  imageAlt,
+  ctas = [],
+  backHref = "/programs",
+  backLabel = "Back to Programs",
+  children,
+}: ProgramDetailHeroProps) {
+  return (
+    <EditorialBand
+      tone="teal"
+      aria-labelledby={titleId}
+      className="border-b border-[#FCFAEF]/20 bg-[#0F4C5C]"
+      containerClassName="py-14 sm:py-16 md:py-20 lg:py-24"
+    >
+      <FadeIn>
+        <Link
+          href={backHref}
+          className="mb-8 inline-flex min-h-11 w-fit items-center gap-2 text-sm font-semibold text-[#FCFAEF]/85 transition-colors hover:text-[#eeba2b] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0F4C5C]"
+        >
+          <EditorialChevron className="h-4 w-4" />
+          {backLabel}
+        </Link>
+      </FadeIn>
+
+      <div className="grid gap-12 lg:grid-cols-12 lg:items-end lg:gap-16">
+        <FadeIn className="lg:col-span-7 lg:pb-4">
+          <EditorialEyebrow tone="gold" className="text-[#F5C94D]">
+            {eyebrow}
+          </EditorialEyebrow>
+          <EditorialHeading
+            as="h1"
+            id={titleId}
+            className="mt-5 max-w-4xl text-[2.1rem] text-[#FCFAEF] sm:text-[2.75rem] md:text-[3.4rem] lg:text-[3.9rem]"
+          >
+            {title}
+          </EditorialHeading>
+          <EditorialLead className="mt-6 max-w-3xl text-[#FCFAEF]/88 dark:text-[#FCFAEF]/88">
+            {lead}
+          </EditorialLead>
+          {ctas.length > 0 ? (
+            <div className="mt-8 flex flex-wrap gap-3 sm:gap-4">
+              {ctas.map((cta) => (
+                <EditorialButton
+                  key={`${cta.href}-${cta.label}`}
+                  href={cta.href}
+                  variant={cta.variant ?? "solid"}
+                  external={cta.external}
+                >
+                  {cta.label}
+                </EditorialButton>
+              ))}
+            </div>
+          ) : null}
+          {children}
+        </FadeIn>
+
+        <FadeIn direction="left" delay={0.15} className="relative lg:col-span-5">
+          <span
+            aria-hidden="true"
+            className="absolute -top-3 left-0 z-10 h-1 w-24 bg-[#eeba2b] md:w-36"
+          />
+          <div className="relative aspect-[4/3] overflow-hidden rounded-md border border-[#FCFAEF]/25 bg-[#0F4C5C] lg:aspect-[4/5]">
+            <Image
+              src={image}
+              alt={imageAlt}
+              fill
+              priority
+              sizes="(min-width: 1024px) 38vw, 100vw"
+              className="object-cover"
+            />
+          </div>
+        </FadeIn>
+      </div>
+    </EditorialBand>
+  );
+}

--- a/src/components/programs/ProgramFactSummary.tsx
+++ b/src/components/programs/ProgramFactSummary.tsx
@@ -1,0 +1,68 @@
+import { cn } from "@/lib/utils";
+
+export type ProgramFact = {
+  label: string;
+  value: string;
+};
+
+type ProgramFactSummaryProps = {
+  facts: ProgramFact[];
+  /** Use on deep-teal / teal bands. */
+  tone?: "light" | "dark";
+  className?: string;
+};
+
+export default function ProgramFactSummary({
+  facts,
+  tone = "dark",
+  className,
+}: ProgramFactSummaryProps) {
+  const border =
+    tone === "dark"
+      ? "border-[#FCFAEF]/25"
+      : "border-[#1C1F1E]/15 dark:border-[#FCFAEF]/20";
+  const labelColor =
+    tone === "dark"
+      ? "text-[#FCFAEF]/65"
+      : "text-[#2F3332]/70 dark:text-[#E6E7E7]/70";
+  const valueColor =
+    tone === "dark"
+      ? "text-[#FCFAEF]"
+      : "text-[#1C1F1E] dark:text-[#FCFAEF]";
+
+  return (
+    <dl
+      data-program-fact-summary
+      className={cn(
+        "grid border-y sm:grid-cols-2",
+        border,
+        className,
+      )}
+    >
+      {facts.map((fact, index) => (
+        <div
+          key={fact.label}
+          className={cn(
+            "flex min-h-28 flex-col justify-between px-1 py-6 sm:px-6",
+            border,
+            index % 2 === 1 ? "sm:border-l" : "",
+            index >= 2 ? "border-t" : "",
+            facts.length > 2 && index < 2 ? "border-b-0 sm:border-b-0" : "",
+          )}
+        >
+          <dt
+            className={cn(
+              "font-subheading text-xs font-bold uppercase tracking-[0.2em]",
+              labelColor,
+            )}
+          >
+            {fact.label}
+          </dt>
+          <dd className={cn("mt-3 text-base leading-relaxed", valueColor)}>
+            {fact.value}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/src/components/programs/ProgramQuoteBand.tsx
+++ b/src/components/programs/ProgramQuoteBand.tsx
@@ -1,0 +1,103 @@
+import Image from "@/components/common/Image";
+import { FadeIn } from "@/components/animations";
+import {
+  EditorialBand,
+  EditorialEyebrow,
+  type EditorialBandTone,
+} from "@/components/shared/EditorialPrimitives";
+
+type ProgramQuoteBandProps = {
+  eyebrow?: string;
+  quote: string;
+  attribution: string;
+  role?: string;
+  image?: string;
+  imageAlt?: string;
+  tone?: EditorialBandTone;
+  marker?: string;
+  id?: string;
+  className?: string;
+};
+
+export default function ProgramQuoteBand({
+  eyebrow = "From the Founders",
+  quote,
+  attribution,
+  role,
+  image,
+  imageAlt,
+  tone = "cream",
+  marker,
+  id = "program-quote",
+  className,
+}: ProgramQuoteBandProps) {
+  const onDark = tone === "teal" || tone === "onyx";
+
+  return (
+    <EditorialBand
+      tone={tone}
+      marker={marker}
+      id={id}
+      aria-labelledby={`${id}-heading`}
+      className={className}
+    >
+      <FadeIn>
+        <EditorialEyebrow
+          tone={onDark ? "gold" : "teal"}
+          className={onDark ? "text-[#F5C94D]" : undefined}
+        >
+          {eyebrow}
+        </EditorialEyebrow>
+        <h2 id={`${id}-heading`} className="sr-only">
+          {eyebrow}
+        </h2>
+
+        <blockquote
+          className={`mt-6 max-w-4xl border-l-2 border-[#eeba2b] pl-6 font-heading text-xl leading-relaxed md:text-2xl ${
+            onDark
+              ? "text-[#FCFAEF]"
+              : "text-[#1C1F1E] dark:text-[#FCFAEF]"
+          }`}
+        >
+          &quot;{quote}&quot;
+        </blockquote>
+
+        <footer className="mt-8 flex items-center gap-4">
+          {image ? (
+            <div className="relative h-14 w-14 shrink-0 overflow-hidden rounded-md bg-[#E6E7E7] dark:bg-[#2F3332]">
+              <Image
+                src={image}
+                alt={imageAlt ?? ""}
+                width={56}
+                height={56}
+                className="h-full w-full object-cover"
+              />
+            </div>
+          ) : null}
+          <div>
+            <cite
+              className={`not-italic font-heading text-lg font-semibold ${
+                onDark
+                  ? "text-[#FCFAEF]"
+                  : "text-[#1C1F1E] dark:text-[#FCFAEF]"
+              }`}
+            >
+              {attribution}
+            </cite>
+            {role ? (
+              <p
+                className={`text-sm ${
+                  onDark
+                    ? "text-[#FCFAEF]/75"
+                    : "text-[#2F3332]/75 dark:text-[#E6E7E7]/75"
+                }`}
+              >
+                {role}
+              </p>
+            ) : null}
+          </div>
+        </footer>
+      </FadeIn>
+    </EditorialBand>
+  );
+}

--- a/src/components/programs/__tests__/ProgramsEditorial.test.tsx
+++ b/src/components/programs/__tests__/ProgramsEditorial.test.tsx
@@ -126,7 +126,7 @@ describe("GHLTP editorial contracts", () => {
     render(<GhltpTestimonialsCarousel />);
 
     expect(
-      screen.getByRole("region", { name: "Voices from participants" }),
+      screen.getByRole("region", { name: "Participant testimonial carousel" }),
     ).toBeVisible();
     expect(
       screen.getByRole("button", { name: /Previous testimonial/i }),

--- a/src/components/programs/__tests__/ProgramsEditorial.test.tsx
+++ b/src/components/programs/__tests__/ProgramsEditorial.test.tsx
@@ -1,0 +1,151 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import ProgramsContent from "@/app/(main)/programs/Content";
+import GhltpContent from "@/app/(main)/programs/akomapa-ghltp/Content";
+import YoungAdvocatesContent from "@/app/(main)/programs/akomapa-young-advocates/Content";
+import GhltpTestimonialsCarousel from "@/components/programs/GhltpTestimonialsCarousel";
+import ProgramDetailHero from "@/components/programs/ProgramDetailHero";
+import ProgramFactSummary from "@/components/programs/ProgramFactSummary";
+
+describe("Programs listing editorial system", () => {
+  it("renders a flat hero and preserves all program destinations", () => {
+    render(<ProgramsContent />);
+
+    const heading = screen.getByRole("heading", {
+      level: 1,
+      name: /Students\. Communities\. Partnerships/,
+    });
+    const hero = heading.closest("section");
+    expect(hero).toHaveAttribute("data-editorial-tone", "teal");
+    expect(hero?.className).not.toContain("gradient");
+
+    expect(
+      screen.getByRole("link", { name: /Explore Akomapa Clinics/i }),
+    ).toHaveAttribute("href", "/community-hubs");
+    expect(
+      screen.getByRole("link", { name: /Discover the Akomapa Network/i }),
+    ).toHaveAttribute("href", "/programs/akomapa-network");
+    expect(
+      screen.getByRole("link", { name: /Join the Leadership Program/i }),
+    ).toHaveAttribute("href", "/programs/akomapa-ghltp");
+    expect(
+      screen.getByRole("link", { name: /Join the Akomapa Young Advocates/i }),
+    ).toHaveAttribute("href", "/programs/akomapa-young-advocates");
+    expect(
+      screen.getByRole("link", { name: /Discover the Akomapa Foods & Stores/i }),
+    ).toHaveAttribute("href", "/programs/akomapa-foods");
+  });
+
+  it("exposes impact metrics as a semantic definition list", () => {
+    render(<ProgramsContent />);
+
+    const section = screen.getByRole("region", {
+      name: "Building a Movement, One Program at a Time",
+    });
+    const list = section.querySelector("dl");
+    expect(list).not.toBeNull();
+    expect(within(section).getByText("Students Trained")).toBeVisible();
+    expect(within(section).getByText("Partner Clinics")).toBeVisible();
+    expect(within(section).getByText("Programs & Initiatives")).toBeVisible();
+    expect(within(section).getByText("Global Mentors")).toBeVisible();
+  });
+});
+
+describe("Program detail editorial helpers", () => {
+  it("renders ProgramDetailHero with back link, heading, and CTAs", () => {
+    render(
+      <ProgramDetailHero
+        eyebrow="Test Program"
+        title="Program Title"
+        lead="Program lead copy."
+        image="/highlights/Akomapa-40.jpg"
+        imageAlt="Program image"
+        ctas={[
+          { href: "/get-involved", label: "Apply Now", variant: "amber" },
+          { href: "/contact", label: "Become a Mentor", variant: "outline-light" },
+        ]}
+      />,
+    );
+
+    const heading = screen.getByRole("heading", {
+      level: 1,
+      name: "Program Title",
+    });
+    expect(heading.closest("section")).toHaveAttribute(
+      "data-editorial-tone",
+      "teal",
+    );
+    expect(screen.getByRole("link", { name: /Back to Programs/i })).toHaveAttribute(
+      "href",
+      "/programs",
+    );
+    expect(screen.getByRole("link", { name: "Apply Now" })).toHaveAttribute(
+      "href",
+      "/get-involved",
+    );
+    expect(screen.getByRole("link", { name: "Become a Mentor" })).toHaveAttribute(
+      "href",
+      "/contact",
+    );
+  });
+
+  it("associates fact summary labels with values in a definition list", () => {
+    render(
+      <ProgramFactSummary
+        facts={[
+          { label: "Duration", value: "10–16 weeks (semester-long)" },
+          { label: "Format", value: "Virtual and hybrid delivery" },
+        ]}
+      />,
+    );
+
+    const list = document.querySelector("[data-program-fact-summary]");
+    expect(list?.tagName).toBe("DL");
+    expect(list?.querySelectorAll("dt")).toHaveLength(2);
+    expect(list?.querySelectorAll("dd")).toHaveLength(2);
+    expect(screen.getByText("Duration")).toBeVisible();
+    expect(screen.getByText("10–16 weeks (semester-long)")).toBeVisible();
+  });
+});
+
+describe("GHLTP editorial contracts", () => {
+  it("preserves mentor and overview CTA destinations", () => {
+    render(<GhltpContent />);
+
+    expect(screen.getByRole("heading", { level: 1 })).toBeVisible();
+    expect(
+      screen.getAllByRole("link", { name: /Become a Mentor/i })[0],
+    ).toHaveAttribute("href", "/contact");
+    expect(
+      screen.getByRole("link", { name: /Download Program Overview/i }),
+    ).toHaveAttribute("href", "/programs");
+    expect(document.querySelector("[data-program-fact-summary]")).not.toBeNull();
+  });
+
+  it("exposes an accessible labeled carousel region", () => {
+    render(<GhltpTestimonialsCarousel />);
+
+    expect(
+      screen.getByRole("region", { name: "Voices from participants" }),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: /Previous testimonial/i }),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: /Next testimonial/i }),
+    ).toBeVisible();
+  });
+});
+
+describe("Young Advocates editorial contracts", () => {
+  it("preserves impact testids and approved impact heading", () => {
+    render(<YoungAdvocatesContent />);
+
+    const section = screen.getByTestId("young-advocates-impact-section");
+    expect(
+      within(section).getByRole("heading", { name: "Our Impact" }),
+    ).toBeVisible();
+    expect(screen.getByTestId("young-advocates-impact-grid")).toBeVisible();
+    expect(screen.getAllByTestId("young-advocates-impact-card")).toHaveLength(4);
+  });
+});

--- a/src/components/roadmap/RoadmapPhases.tsx
+++ b/src/components/roadmap/RoadmapPhases.tsx
@@ -1,136 +1,117 @@
-"use client";
-
-import { useState } from "react";
-import { Target, Globe, TrendingUp, CheckCircle, type LucideIcon } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
-import { MotionDiv } from "@/components/motion/framer";
+import { FadeIn } from "@/components/animations";
+import {
+  EditorialBand,
+  EditorialEyebrow,
+  EditorialHeading,
+  EditorialLead,
+} from "@/components/shared/EditorialPrimitives";
 import { phases } from "./phases";
 
-const iconMap: Record<(typeof phases)[number]["icon"], LucideIcon> = {
-  Target,
-  TrendingUp,
-  Globe,
-};
-
 export default function RoadmapPhases() {
-  const [activePhase, setActivePhase] = useState(1);
-
   return (
-    <>
-      {/* Phase Navigation */}
-      <section className="py-8 bg-[#FCFAEF] dark:bg-[#1C1F1E]">
-        <div className="site-container mx-auto px-4">
-          <div className="flex flex-wrap justify-center gap-4">
-            {phases.map((phase) => {
-              const Icon = iconMap[phase.icon];
-              return (
-                <Button
-                  key={phase.id}
-                  onClick={() => setActivePhase(phase.id)}
-                  variant={activePhase === phase.id ? "default" : "outline"}
-                  className={`rounded-full px-6 py-3 ${
-                    activePhase === phase.id
-                      ? `${phase.color} text-[#FCFAEF] hover:${phase.color}`
-                      : "border-[#0097b2] text-[#0097b2] hover:bg-[#0097b2] hover:text-[#FCFAEF] dark:border-[#66C4DC] dark:text-[#66C4DC] dark:hover:bg-[#66C4DC] dark:hover:text-[#1C1F1E]"
-                  }`}
-                >
-                  <Icon className="h-4 w-4 mr-2" />
-                  {phase.title.split(":")[1]}
-                </Button>
-              );
-            })}
-          </div>
+    <EditorialBand
+      tone="cream"
+      marker="01"
+      id="roadmap-phases"
+      aria-labelledby="roadmap-phases-heading"
+    >
+      <FadeIn>
+        <div className="max-w-3xl">
+          <EditorialEyebrow className="text-[#0F4C5C] dark:text-[#66C4DC]">
+            Three Phases
+          </EditorialEyebrow>
+          <EditorialHeading id="roadmap-phases-heading" className="mt-4">
+            Akomapa&apos;s 3-Year Roadmap
+          </EditorialHeading>
+          <EditorialLead className="mt-5">
+            Each phase builds on the last—from launching care and learning
+            systems, to testing sustainability models, to scaling what works.
+          </EditorialLead>
         </div>
-      </section>
+      </FadeIn>
 
-      {/* Active Phase Details */}
-      <section className="py-16">
-        <div className="site-container mx-auto px-4">
-          {phases.map((phase) => {
-            const Icon = iconMap[phase.icon];
-            return (
-              <MotionDiv
-                key={phase.id}
-                initial={{ opacity: 0, y: 20 }}
-                animate={{
-                  opacity: activePhase === phase.id ? 1 : 0,
-                  y: activePhase === phase.id ? 0 : 20,
-                }}
-                transition={{ duration: 0.5 }}
-                className={`${activePhase === phase.id ? "block" : "hidden"}`}
+      <nav aria-label="Roadmap phases" className="mt-10">
+        <ol className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:gap-4">
+          {phases.map((phase) => (
+            <li key={phase.id}>
+              <a
+                href={`#phase-${phase.id}`}
+                className="inline-flex min-h-11 items-center rounded-md border border-[#1C1F1E]/15 px-4 py-2 text-sm font-semibold text-[#0F4C5C] transition-colors hover:border-[#0097b2] hover:text-[#0097b2] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] focus-visible:ring-offset-2 dark:border-[#FCFAEF]/25 dark:text-[#66C4DC] dark:hover:border-[#66C4DC]"
               >
-                <div className="max-w-4xl mx-auto">
-                  {/* Phase Header */}
-                  <div className="text-center mb-12">
-                    <div className="flex items-center justify-center mb-4">
-                      <div
-                        className={`w-16 h-16 rounded-full ${phase.color} flex items-center justify-center mr-4`}
-                      >
-                        <Icon className="h-8 w-8 text-white" />
-                      </div>
-                      <div>
-                        <h2 className="text-3xl md:text-4xl font-bold text-[#1C1F1E] dark:text-[#FCFAEF]">
-                          {phase.title}
-                        </h2>
-                        <p className="text-lg text-[#0097b2] dark:text-[#66C4DC] font-medium">
-                          {phase.period}
-                        </p>
-                      </div>
-                    </div>
+                <span className="mr-2 font-subheading text-xs tracking-[0.15em] uppercase opacity-70">
+                  Phase {phase.id}
+                </span>
+                {phase.title.split(": ")[1] ?? phase.title}
+              </a>
+            </li>
+          ))}
+        </ol>
+      </nav>
 
-                    <div className="bg-white dark:bg-[#2F3332] rounded-xl p-6 shadow-lg mb-8">
-                      <h3 className="text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF] mb-3">
-                        Focus
-                      </h3>
-                      <p className="text-[#2F3332] dark:text-[#E6E7E7] text-lg">
-                        {phase.focus}
-                      </p>
-                    </div>
+      <ol className="mt-14 space-y-0 border-t border-[#1C1F1E]/15 dark:border-[#FCFAEF]/20">
+        {phases.map((phase) => (
+          <li
+            key={phase.id}
+            id={`phase-${phase.id}`}
+            className="scroll-mt-28 border-b border-[#1C1F1E]/15 py-12 dark:border-[#FCFAEF]/20 lg:py-16"
+          >
+            <FadeIn>
+              <div className="grid gap-8 lg:grid-cols-12 lg:gap-12">
+                <div className="lg:col-span-4">
+                  <span
+                    aria-hidden="true"
+                    className="font-heading text-4xl font-semibold tracking-[-0.06em] text-[#0097b2]/55 dark:text-[#66C4DC]/65"
+                  >
+                    {String(phase.id).padStart(2, "0")}
+                  </span>
+                  <h3 className="mt-3 font-heading text-2xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF] md:text-3xl">
+                    {phase.title}
+                  </h3>
+                  <p className="mt-3 font-subheading text-xs font-bold uppercase tracking-[0.2em] text-[#0097b2] dark:text-[#66C4DC]">
+                    {phase.period}
+                  </p>
+                </div>
 
-                    <div className="bg-gradient-to-r from-[#0097b2] to-[#eeba2b] rounded-xl p-6 text-white">
-                      <h3 className="text-xl font-semibold mb-3 flex items-center">
-                        <Target className="h-5 w-5 mr-2" />
-                        Goal
-                      </h3>
-                      <p className="text-lg">
-                        {phase.goal.replace(/'/g, "&apos;")}
-                      </p>
-                    </div>
+                <div className="lg:col-span-8 space-y-8">
+                  <div>
+                    <h4 className="font-subheading text-xs font-bold uppercase tracking-[0.2em] text-[#2F3332]/70 dark:text-[#E6E7E7]/70">
+                      Focus
+                    </h4>
+                    <p className="mt-2 text-base leading-relaxed text-[#1C1F1E] dark:text-[#FCFAEF] md:text-lg">
+                      {phase.focus}
+                    </p>
                   </div>
 
-                  {/* Achievements Grid */}
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                    {phase.achievements.map((achievement, index) => (
-                      <MotionDiv
-                        key={index}
-                        initial={{ opacity: 0, x: -20 }}
-                        animate={{ opacity: 1, x: 0 }}
-                        transition={{ delay: index * 0.1 }}
-                      >
-                        <Card className="h-full hover:shadow-lg transition-all duration-300 border-0 shadow-md bg-white dark:bg-[#2F3332] group">
-                          <CardContent className="p-6">
-                            <div className="flex items-start">
-                              <div
-                                className={`w-8 h-8 rounded-full ${phase.color} flex items-center justify-center mr-4 mt-1`}
-                              >
-                                <CheckCircle className="h-4 w-4 text-white" />
-                              </div>
-                              <p className="text-[#2F3332] dark:text-[#E6E7E7] group-hover:text-[#0097b2] dark:group-hover:text-[#66C4DC] transition-colors">
-                                {achievement}
-                              </p>
-                            </div>
-                          </CardContent>
-                        </Card>
-                      </MotionDiv>
-                    ))}
+                  <div className="border-l-2 border-[#eeba2b] pl-5">
+                    <h4 className="font-subheading text-xs font-bold uppercase tracking-[0.2em] text-[#C9920F] dark:text-[#F5C94D]">
+                      Goal
+                    </h4>
+                    <p className="mt-2 text-base leading-relaxed text-[#1C1F1E] dark:text-[#FCFAEF] md:text-lg">
+                      {phase.goal}
+                    </p>
+                  </div>
+
+                  <div>
+                    <h4 className="font-subheading text-xs font-bold uppercase tracking-[0.2em] text-[#2F3332]/70 dark:text-[#E6E7E7]/70">
+                      Key Milestones
+                    </h4>
+                    <ul className="mt-4 space-y-3 border-t border-[#1C1F1E]/10 pt-4 dark:border-[#FCFAEF]/15">
+                      {phase.achievements.map((achievement) => (
+                        <li
+                          key={achievement}
+                          className="text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80 md:text-base"
+                        >
+                          {achievement}
+                        </li>
+                      ))}
+                    </ul>
                   </div>
                 </div>
-              </MotionDiv>
-            );
-          })}
-        </div>
-      </section>
-    </>
+              </div>
+            </FadeIn>
+          </li>
+        ))}
+      </ol>
+    </EditorialBand>
   );
 }

--- a/src/components/roadmap/__tests__/RoadmapEditorial.test.tsx
+++ b/src/components/roadmap/__tests__/RoadmapEditorial.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import RoadmapContent from "@/app/(main)/roadmap/Content";
+import RoadmapPhases from "@/components/roadmap/RoadmapPhases";
+import { phases } from "@/components/roadmap/phases";
+
+describe("Roadmap editorial system", () => {
+  it("renders a single h1 and flat hero without emoji ornamentation", () => {
+    render(<RoadmapContent />);
+
+    const heading = screen.getByRole("heading", {
+      level: 1,
+      name: "Building sustainable care, one step at a time.",
+    });
+    const hero = heading.closest("section");
+    expect(hero).toHaveAttribute("data-editorial-band");
+    expect(heading.textContent).not.toMatch(/🧭|📣/);
+    expect(document.querySelectorAll("h1")).toHaveLength(1);
+  });
+
+  it("presents phases as a readable ordered sequence with periods and goals", () => {
+    render(<RoadmapPhases />);
+
+    const section = screen.getByRole("region", {
+      name: "Akomapa's 3-Year Roadmap",
+    });
+    const list = section.querySelector("ol.mt-14, ol[class*='mt-14']") ??
+      within(section).getAllByRole("list").at(-1);
+    expect(list).toBeTruthy();
+
+    for (const phase of phases) {
+      expect(screen.getByText(phase.title)).toBeVisible();
+      expect(screen.getByText(phase.period)).toBeVisible();
+      expect(screen.getByText(phase.focus)).toBeVisible();
+      expect(screen.getByText(phase.goal)).toBeVisible();
+      expect(document.getElementById(`phase-${phase.id}`)).not.toBeNull();
+    }
+
+    expect(section.querySelector("[data-slot='card']")).toBeNull();
+  });
+
+  it("preserves roadmap CTA destinations", () => {
+    render(<RoadmapContent />);
+
+    const partnerLinks = screen.getAllByRole("link", { name: /Partner With Us/i });
+    expect(partnerLinks[0]).toHaveAttribute("href", "/partnerships");
+    expect(screen.getByRole("link", { name: /^Donate$/i })).toHaveAttribute(
+      "href",
+      "/partnerships",
+    );
+    expect(screen.getByRole("link", { name: /Contact Us/i })).toHaveAttribute(
+      "href",
+      "mailto:akomapahealth@gmail.com",
+    );
+  });
+
+  it("keeps chronology independent of color-only status cues", () => {
+    render(<RoadmapContent />);
+
+    const timeline = screen.getByRole("region", {
+      name: "Our Journey Timeline",
+    });
+    const items = within(timeline).getAllByRole("listitem");
+    expect(items).toHaveLength(phases.length);
+    expect(
+      items.map((item) => within(item).getByRole("heading", { level: 3 }).textContent),
+    ).toEqual(phases.map((phase) => phase.title));
+  });
+});


### PR DESCRIPTION
## Summary
- Restyle Academy, Programs listing, four program-detail pages, and Roadmap onto the shared `EditorialPrimitives` system from #179/#181, replacing gradients, glow, glass, and page-local CTA chrome with flat editorial bands, numbering, and semantic lists.
- Extract family helpers (`ProgramDetailHero`, `ProgramFactSummary`, `ProgramQuoteBand`) proven by Academy + program routes; harden GHLTP/Academy carousels for keyboard, reduced motion, and 44×44 targets.
- Preserve approved copy, metrics, CTA destinations, YA impact testids, and the `/programs/akomapa-ghip` → GHIP redirect. Do not restyle `/global-health-immersion-program`.
- Add structural unit tests and route-level editorial E2E across light/dark and key viewports.

Closes #182

## Test plan
- [x] `nvm use 22`
- [x] lint, typecheck, unit tests, production build
- [x] `e2e/academy-programs-roadmap-editorial.spec.ts` (7 routes × themes/viewports, content/CTA contracts, reduced motion, GHIP redirect)
- [x] `e2e/young-advocates-impact.spec.ts`
- [x] `e2e/cta-links.spec.ts` (GHLTP mentor → `/contact`)
- [x] `e2e/responsive-pages.spec.ts` and `e2e/typography-regression.spec.ts`
- [x] Spot-check light/dark at 390 / 768 / 1024 / 1280 / 1440 / 1536 on `/academy`, `/programs`, each detail route, `/roadmap`