### PR TITLE
Design/restyle legal error loading and not found surfaces

### DIFF
--- a/e2e/conversion-family-editorial.spec.ts
+++ b/e2e/conversion-family-editorial.spec.ts
@@ -201,15 +201,16 @@ test.describe("conversion family editorial contracts", () => {
     await page.goto("/donate", { waitUntil: "domcontentloaded" });
     const paymentPanel = page.getByTestId("donation-payment-methods-partner");
     const instructionsToggle = paymentPanel.getByRole("button", {
-      name: "View Mobile Money instructions",
+      name: /Mobile Money instructions/i,
     });
     await expect(instructionsToggle).toBeVisible();
+    await expect(instructionsToggle).toHaveAttribute("aria-expanded", "false");
     await instructionsToggle.click();
-    await expect(
-      paymentPanel.getByRole("button", {
-        name: "Hide Mobile Money instructions",
-      }),
-    ).toBeVisible();
+    // Prefer aria-expanded + revealed content over exact toggle label timing.
+    await expect(instructionsToggle).toHaveAttribute("aria-expanded", "true", {
+      timeout: 10_000,
+    });
+    await expect(paymentPanel.getByRole("alert")).toBeVisible();
     await expect(
       paymentPanel.getByRole("heading", { name: "Let us thank you" }),
     ).toBeVisible();

--- a/e2e/conversion-family-editorial.spec.ts
+++ b/e2e/conversion-family-editorial.spec.ts
@@ -153,6 +153,7 @@ test.describe("conversion family editorial contracts", () => {
   test("exercises contact and donation follow-up states without real submissions", async ({
     page,
   }) => {
+    test.setTimeout(90_000);
     await preparePage(page, "light");
 
     await page.route("**/api/contact", async (route) => {
@@ -191,6 +192,8 @@ test.describe("conversion family editorial contracts", () => {
       page.getByRole("status").getByText("Message Sent Successfully!"),
     ).toBeVisible();
 
+    // Clear contact mocks before donate so they cannot interfere with navigation.
+    await page.unroute("**/api/contact");
     await page.route("**/api/donation-follow-up", async (route) => {
       await route.fulfill({
         status: 500,
@@ -200,16 +203,28 @@ test.describe("conversion family editorial contracts", () => {
     });
     await page.goto("/donate", { waitUntil: "domcontentloaded" });
     const paymentPanel = page.getByTestId("donation-payment-methods-partner");
+    await expect(
+      paymentPanel.getByText(/Complete a new manual transfer for each month/i),
+    ).toBeVisible();
+
+    // Match both View/Hide labels so the locator survives the toggle rename.
     const instructionsToggle = paymentPanel.getByRole("button", {
       name: /Mobile Money instructions/i,
     });
+    await instructionsToggle.scrollIntoViewIfNeeded();
     await expect(instructionsToggle).toBeVisible();
     await expect(instructionsToggle).toHaveAttribute("aria-expanded", "false");
-    await instructionsToggle.click();
-    // Prefer aria-expanded + revealed content over exact toggle label timing.
-    await expect(instructionsToggle).toHaveAttribute("aria-expanded", "true", {
-      timeout: 10_000,
-    });
+
+    // Retry until expanded — FadeIn/layout can swallow the first pointer event
+    // under full-suite load.
+    await expect(async () => {
+      if ((await instructionsToggle.getAttribute("aria-expanded")) !== "true") {
+        await instructionsToggle.click({ force: true });
+      }
+      await expect(instructionsToggle).toHaveAttribute("aria-expanded", "true");
+      await expect(paymentPanel.getByText("0249292898")).toBeVisible();
+    }).toPass({ timeout: 15_000 });
+
     await expect(paymentPanel.getByRole("alert")).toBeVisible();
     await expect(
       paymentPanel.getByRole("heading", { name: "Let us thank you" }),

--- a/e2e/legal-utility-editorial.spec.ts
+++ b/e2e/legal-utility-editorial.spec.ts
@@ -1,0 +1,299 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+import { announcementCampaign } from "../src/data/announcements";
+
+const legalRoutes = [
+  {
+    path: "/privacy",
+    heading: "Privacy Policy",
+    lastUpdated: "Last updated: May 9, 2026",
+    sectionHeading: "Who we are and what this policy covers",
+  },
+  {
+    path: "/terms",
+    heading: "Terms of Service",
+    lastUpdated: "Last updated: May 9, 2026",
+    sectionHeading: "Agreement to these terms",
+  },
+] as const;
+
+const viewports = [
+  { name: "mobile-390", width: 390, height: 844 },
+  { name: "tablet-768", width: 768, height: 1024 },
+  { name: "ipad-pro-1024", width: 1024, height: 1366 },
+  { name: "laptop-1280", width: 1280, height: 800 },
+  { name: "desktop-1440", width: 1440, height: 900 },
+  { name: "wide-1536", width: 1536, height: 960 },
+] as const;
+
+const themes = ["light", "dark"] as const;
+
+async function preparePage(page: Page, theme: (typeof themes)[number]) {
+  await page.addInitScript(
+    ({ version, storedTheme }) => {
+      localStorage.setItem("akomapa-announcements-dismissed", version);
+      localStorage.setItem("akomapa-theme", storedTheme);
+      document.documentElement.classList.remove("light", "dark");
+      document.documentElement.classList.add(storedTheme);
+
+      const style = document.createElement("style");
+      style.textContent =
+        "*,*::before,*::after{transition-duration:0s!important;animation-duration:0s!important}";
+      document.documentElement.append(style);
+    },
+    { version: announcementCampaign.version, storedTheme: theme },
+  );
+}
+
+async function expectNoOverflow(page: Page) {
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => document.documentElement.scrollWidth <= window.innerWidth + 1,
+      ),
+    )
+    .toBe(true);
+}
+
+async function expectElementInViewport(locator: Locator) {
+  const contained = await locator.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    return rect.left >= -1 && rect.right <= window.innerWidth + 1;
+  });
+  expect(contained).toBe(true);
+}
+
+test.describe("legal utility editorial contracts", () => {
+  test("preserves privacy and terms copy, links, and editorial structure", async ({
+    page,
+  }) => {
+    await preparePage(page, "light");
+    await page.setViewportSize({ width: 1280, height: 800 });
+
+    await page.goto("/privacy", { waitUntil: "domcontentloaded" });
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Privacy Policy" }),
+    ).toBeVisible();
+    await expect(page.locator("main h1")).toHaveCount(1);
+    await expect(page.getByText("Last updated: May 9, 2026")).toBeVisible();
+    await expect(
+      page.getByRole("heading", {
+        level: 2,
+        name: "Who we are and what this policy covers",
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "akomapahealth@gmail.com" }).first(),
+    ).toHaveAttribute("href", "mailto:akomapahealth@gmail.com");
+    await expect(
+      page.getByRole("link", { name: "contact page" }),
+    ).toHaveAttribute("href", "/contact");
+    await expect(
+      page.locator('[data-editorial-band][data-editorial-tone="teal"]').first(),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-editorial-band][data-editorial-tone="cream"]').first(),
+    ).toBeVisible();
+    await expect(page.locator("[data-legal-prose-article]")).toBeVisible();
+    await expect(
+      page.locator("[data-publication-article-measure]"),
+    ).toBeVisible();
+
+    const privacyGradientBands = await page
+      .locator("[data-editorial-band]")
+      .evaluateAll((nodes) =>
+        nodes.filter((node) => node.className.includes("gradient")).length,
+      );
+    expect(privacyGradientBands).toBe(0);
+
+    await page.goto("/terms", { waitUntil: "domcontentloaded" });
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Terms of Service" }),
+    ).toBeVisible();
+    await expect(page.getByText("Last updated: May 9, 2026")).toBeVisible();
+    await expect(
+      page.getByRole("heading", {
+        level: 2,
+        name: "Agreement to these terms",
+      }),
+    ).toBeVisible();
+    await expect(
+      page.locator("#acceptance").getByRole("link", { name: "Privacy Policy" }),
+    ).toHaveAttribute("href", "/privacy");
+    await expect(
+      page.getByRole("link", { name: "contact page" }),
+    ).toHaveAttribute("href", "/contact");
+    await expect(page.getByText("www.akomapahealth.org")).toBeVisible();
+  });
+
+  test("renders accessible not-found recovery navigation", async ({ page }) => {
+    await preparePage(page, "light");
+    await page.setViewportSize({ width: 1280, height: 800 });
+
+    await page.goto("/this-route-does-not-exist-186", {
+      waitUntil: "domcontentloaded",
+    });
+
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Page Not Found" }),
+    ).toBeVisible();
+    await expect(page.locator("main h1")).toHaveCount(1);
+    await expect(
+      page.getByRole("link", { name: "Back to Homepage" }),
+    ).toHaveAttribute("href", "/");
+
+    const recovery = page.getByRole("navigation", { name: "Helpful links" });
+    await expect(recovery).toBeVisible();
+    await expect(
+      recovery.getByRole("link", { name: "Get Involved" }),
+    ).toHaveAttribute("href", "/get-involved");
+    await expect(
+      recovery.getByRole("link", { name: "Contact" }),
+    ).toHaveAttribute("href", "/contact");
+
+    const homepageCta = page.getByRole("link", { name: "Back to Homepage" });
+    await homepageCta.focus();
+    await expect(homepageCta).toBeFocused();
+  });
+
+  test("keeps reduced-motion loading semantics calm during soft navigation", async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({
+      reducedMotion: "reduce",
+      colorScheme: "light",
+      viewport: { width: 1280, height: 800 },
+    });
+    const page = await context.newPage();
+    await preparePage(page, "light");
+
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+
+    await page.route("**/privacy**", async (route) => {
+      // Delay the destination document/RSC payload so (main)/loading.tsx can paint.
+      await new Promise((resolve) => setTimeout(resolve, 2500));
+      await route.continue();
+    });
+
+    const privacyLink = page.locator('a[href="/privacy"]').first();
+    await expect(privacyLink).toBeVisible();
+    await privacyLink.click({ noWaitAfter: true });
+
+    const loading = page.locator("[data-route-loading-state]");
+    const sawLoading = await loading
+      .waitFor({ state: "visible", timeout: 4_000 })
+      .then(() => true)
+      .catch(() => false);
+
+    if (sawLoading) {
+      await expect(loading).toHaveAttribute("aria-busy", "true");
+      await expect(page.getByRole("status")).toContainText(/Loading/i);
+      await expect(page.locator("[data-route-loading-spinner]")).toHaveClass(
+        /motion-reduce:animate-none/,
+      );
+    }
+
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Privacy Policy" }),
+    ).toBeVisible({ timeout: 20_000 });
+    await expect(page.locator("[data-route-loading-state]")).toHaveCount(0);
+
+    await context.close();
+  });
+
+  test("supports reduced motion and 200% zoom-equivalent reflow on utility surfaces", async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({
+      reducedMotion: "reduce",
+      colorScheme: "light",
+      viewport: { width: 720, height: 900 },
+    });
+    const page = await context.newPage();
+    await preparePage(page, "light");
+
+    for (const width of [720, 320]) {
+      await page.setViewportSize({ width, height: 900 });
+
+      for (const route of legalRoutes) {
+        await page.goto(route.path, { waitUntil: "domcontentloaded" });
+        await expect(
+          page.getByRole("heading", { level: 1, name: route.heading }),
+        ).toBeVisible();
+        await expectNoOverflow(page);
+
+        const motionState = await page
+          .locator("[data-editorial-band]")
+          .evaluateAll((bands) =>
+            bands.map((band) => {
+              const style = getComputedStyle(band);
+              return { opacity: style.opacity, transform: style.transform };
+            }),
+          );
+        expect(
+          motionState.every(
+            ({ opacity, transform }) =>
+              opacity === "1" && (transform === "none" || transform === "matrix(1, 0, 0, 1, 0, 0)"),
+          ),
+        ).toBe(true);
+      }
+
+      await page.goto("/this-route-does-not-exist-186-zoom", {
+        waitUntil: "domcontentloaded",
+      });
+      await expect(
+        page.getByRole("heading", { level: 1, name: "Page Not Found" }),
+      ).toBeVisible();
+      await expectNoOverflow(page);
+    }
+
+    await context.close();
+  });
+
+  for (const viewport of viewports) {
+    for (const theme of themes) {
+      test(`${viewport.name} · ${theme} · legal and not-found stay readable`, async ({
+        page,
+      }) => {
+        test.setTimeout(90_000);
+        await preparePage(page, theme);
+        await page.setViewportSize(viewport);
+
+        for (const route of legalRoutes) {
+          await page.goto(route.path, { waitUntil: "domcontentloaded" });
+          await expect(page.locator("main h1")).toHaveCount(1);
+          await expect(
+            page.getByRole("heading", { level: 1, name: route.heading }),
+          ).toBeVisible();
+          await expect(page.getByText(route.lastUpdated)).toBeVisible();
+          await expect(
+            page.getByRole("heading", {
+              level: 2,
+              name: route.sectionHeading,
+            }),
+          ).toBeVisible();
+          await expectElementInViewport(page.locator("main h1"));
+          await expectNoOverflow(page);
+
+          const bands = page.locator("[data-editorial-band]");
+          await expect(bands.first()).toBeVisible();
+          const gradientBands = await bands.evaluateAll((nodes) =>
+            nodes.filter((node) => node.className.includes("gradient")).length,
+          );
+          expect(gradientBands).toBe(0);
+        }
+
+        await page.goto("/this-route-does-not-exist-186", {
+          waitUntil: "domcontentloaded",
+        });
+        await expect(
+          page.getByRole("heading", { level: 1, name: "Page Not Found" }),
+        ).toBeVisible();
+        await expectElementInViewport(page.locator("main h1"));
+        await expectNoOverflow(page);
+        await expect(
+          page.getByRole("navigation", { name: "Helpful links" }),
+        ).toBeVisible();
+      });
+    }
+  }
+});

--- a/e2e/legal-utility-editorial.spec.ts
+++ b/e2e/legal-utility-editorial.spec.ts
@@ -177,12 +177,21 @@ test.describe("legal utility editorial contracts", () => {
     });
     const page = await context.newPage();
     await preparePage(page, "light");
+    await page.goto("/", { waitUntil: "networkidle" });
 
-    await page.goto("/", { waitUntil: "domcontentloaded" });
+    let releasePrivacy: (() => void) | undefined;
+    const privacyGate = new Promise<void>((resolve) => {
+      releasePrivacy = resolve;
+    });
 
     await page.route("**/privacy**", async (route) => {
-      // Delay the destination document/RSC payload so (main)/loading.tsx can paint.
-      await new Promise((resolve) => setTimeout(resolve, 2500));
+      const url = route.request().url();
+      // Hold only the route/RSC payload so loading.tsx can paint; let static chunks through.
+      if (url.includes("/_next/static")) {
+        await route.continue();
+        return;
+      }
+      await privacyGate;
       await route.continue();
     });
 
@@ -191,12 +200,13 @@ test.describe("legal utility editorial contracts", () => {
     await privacyLink.click({ noWaitAfter: true });
 
     const loading = page.locator("[data-route-loading-state]");
-    const sawLoading = await loading
-      .waitFor({ state: "visible", timeout: 4_000 })
+    const loadingVisible = await loading
+      .waitFor({ state: "visible", timeout: 8_000 })
       .then(() => true)
       .catch(() => false);
 
-    if (sawLoading) {
+    if (loadingVisible) {
+      // Assert while the gate still holds the destination closed.
       await expect(loading).toHaveAttribute("aria-busy", "true");
       await expect(page.getByRole("status")).toContainText(/Loading/i);
       await expect(page.locator("[data-route-loading-spinner]")).toHaveClass(
@@ -204,10 +214,29 @@ test.describe("legal utility editorial contracts", () => {
       );
     }
 
+    releasePrivacy?.();
+
     await expect(
       page.getByRole("heading", { level: 1, name: "Privacy Policy" }),
     ).toBeVisible({ timeout: 20_000 });
     await expect(page.locator("[data-route-loading-state]")).toHaveCount(0);
+
+    // Reduced-motion contract remains covered even when prefetch skips loading UI.
+    const motionState = await page
+      .locator("[data-editorial-band]")
+      .evaluateAll((bands) =>
+        bands.map((band) => {
+          const style = getComputedStyle(band);
+          return { opacity: style.opacity, transform: style.transform };
+        }),
+      );
+    expect(
+      motionState.every(
+        ({ opacity, transform }) =>
+          opacity === "1" &&
+          (transform === "none" || transform === "matrix(1, 0, 0, 1, 0, 0)"),
+      ),
+    ).toBe(true);
 
     await context.close();
   });

--- a/e2e/legal-utility-editorial.spec.ts
+++ b/e2e/legal-utility-editorial.spec.ts
@@ -74,12 +74,15 @@ test.describe("legal utility editorial contracts", () => {
       page.getByRole("heading", { level: 1, name: "Privacy Policy" }),
     ).toBeVisible();
     await expect(page.locator("main h1")).toHaveCount(1);
-    await expect(page.getByText("Last updated: May 9, 2026")).toBeVisible();
+    await expect(page.getByText("Last updated: May 9, 2026").first()).toBeVisible();
     await expect(
       page.getByRole("heading", {
         level: 2,
         name: "Who we are and what this policy covers",
       }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("navigation", { name: "On this page" }),
     ).toBeVisible();
     await expect(
       page.getByRole("link", { name: "akomapahealth@gmail.com" }).first(),
@@ -94,6 +97,7 @@ test.describe("legal utility editorial contracts", () => {
       page.locator('[data-editorial-band][data-editorial-tone="cream"]').first(),
     ).toBeVisible();
     await expect(page.locator("[data-legal-prose-article]")).toBeVisible();
+    await expect(page.locator("[data-legal-section]").first()).toBeVisible();
     await expect(
       page.locator("[data-publication-article-measure]"),
     ).toBeVisible();
@@ -109,7 +113,7 @@ test.describe("legal utility editorial contracts", () => {
     await expect(
       page.getByRole("heading", { level: 1, name: "Terms of Service" }),
     ).toBeVisible();
-    await expect(page.getByText("Last updated: May 9, 2026")).toBeVisible();
+    await expect(page.getByText("Last updated: May 9, 2026").first()).toBeVisible();
     await expect(
       page.getByRole("heading", {
         level: 2,
@@ -123,6 +127,9 @@ test.describe("legal utility editorial contracts", () => {
       page.getByRole("link", { name: "contact page" }),
     ).toHaveAttribute("href", "/contact");
     await expect(page.getByText("www.akomapahealth.org")).toBeVisible();
+    await expect(
+      page.getByRole("navigation", { name: "On this page" }),
+    ).toBeVisible();
   });
 
   test("renders accessible not-found recovery navigation", async ({ page }) => {
@@ -140,6 +147,11 @@ test.describe("legal utility editorial contracts", () => {
     await expect(
       page.getByRole("link", { name: "Back to Homepage" }),
     ).toHaveAttribute("href", "/");
+    await expect(page.getByRole("link", { name: "Contact us" })).toHaveAttribute(
+      "href",
+      "/contact",
+    );
+    await expect(page.locator("[data-route-not-found-state]")).toBeVisible();
 
     const recovery = page.getByRole("navigation", { name: "Helpful links" });
     await expect(recovery).toBeVisible();
@@ -264,7 +276,7 @@ test.describe("legal utility editorial contracts", () => {
           await expect(
             page.getByRole("heading", { level: 1, name: route.heading }),
           ).toBeVisible();
-          await expect(page.getByText(route.lastUpdated)).toBeVisible();
+          await expect(page.getByText(route.lastUpdated).first()).toBeVisible();
           await expect(
             page.getByRole("heading", {
               level: 2,

--- a/src/app/(main)/__tests__/error.test.tsx
+++ b/src/app/(main)/__tests__/error.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const captureException = vi.fn();
+
+vi.mock("@/lib/sentry", () => ({
+  captureException: (...args: unknown[]) => captureException(...args),
+}));
+
+import MainError from "../error";
+
+describe("MainError boundary", () => {
+  beforeEach(() => {
+    captureException.mockClear();
+  });
+
+  it("captures the exception and still offers retry recovery", () => {
+    const reset = vi.fn();
+    const error = Object.assign(new Error("boom"), { digest: "d1" });
+
+    render(<MainError error={error} reset={reset} />);
+
+    expect(captureException).toHaveBeenCalledWith(error);
+    expect(
+      screen.getByRole("heading", { level: 1, name: "We hit a snag" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Try again" })).toBeInTheDocument();
+  });
+});

--- a/src/app/(main)/privacy/Content.tsx
+++ b/src/app/(main)/privacy/Content.tsx
@@ -1,426 +1,374 @@
 import { FadeIn } from "@/components/animations";
-import { HeroEntranceH1, HeroEntranceP } from "@/components/motion/HeroEntrance";
 import Breadcrumb from "@/components/layout/Breadcrumb";
+import {
+  LegalLastUpdated,
+  LegalProseArticle,
+  LegalSectionRule,
+  legalBodyClassName as body,
+  legalHeadingClassName as h2,
+  legalLinkClassName as link,
+  legalListClassName as list,
+  legalSectionClassName as section,
+  legalSubheadingClassName as h3,
+} from "@/components/legal/LegalDocumentPrimitives";
+import { PublicationArticleMeasure } from "@/components/publication";
+import {
+  EditorialBand,
+  EditorialEyebrow,
+  EditorialHeading,
+  EditorialLead,
+} from "@/components/shared/EditorialPrimitives";
 import Link from "next/link";
 
 const LAST_UPDATED = "May 9, 2026";
 
-const body =
-  "text-base sm:text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed";
-const h2 =
-  "text-xl sm:text-2xl md:text-3xl font-bold text-[#1C1F1E] dark:text-[#FCFAEF]";
-const list =
-  `${body} list-disc list-outside space-y-2 pl-6 sm:pl-7 [&_strong]:text-[#1C1F1E] dark:[&_strong]:text-[#FCFAEF]`;
-
-function SectionRule({ variant }: { variant: "teal" | "amber" }) {
-  const bg = variant === "teal" ? "bg-[#0097b2]" : "bg-[#eeba2b]";
-  return (
-    <div className="flex items-center gap-2 mb-4" aria-hidden>
-      <div className={`h-1 w-8 ${bg} rounded-full`} />
-      <div className={`h-1 w-1 ${bg} rounded-full`} />
-    </div>
-  );
-}
-
 export default function Content() {
   return (
-    <>
+    <div data-rebrand-page className="bg-background text-foreground">
       <div className="site-container mx-auto">
         <Breadcrumb />
       </div>
 
-      <section
-        className="relative py-16 sm:py-20 md:py-28 bg-gradient-to-r from-[#0097b2] to-[#0F4C5C] overflow-hidden"
+      <EditorialBand
+        tone="teal"
+        aria-labelledby="privacy-policy-title"
+        className="border-b border-[#FCFAEF]/20 bg-[#0F4C5C]"
+        containerClassName="py-14 sm:py-16 md:py-20 lg:py-24"
+      >
+        <FadeIn>
+          <EditorialEyebrow tone="gold" className="text-[#F5C94D]">
+            Legal
+          </EditorialEyebrow>
+          <EditorialHeading
+            as="h1"
+            id="privacy-policy-title"
+            className="mt-5 max-w-4xl text-[2.35rem] text-[#FCFAEF] sm:text-[3rem] md:text-[3.7rem] lg:text-[4.35rem]"
+          >
+            Privacy Policy
+          </EditorialHeading>
+          <EditorialLead className="mt-6 max-w-3xl text-[#FCFAEF]/88 dark:text-[#FCFAEF]/88">
+            Your privacy matters. Here is how we collect, use, and protect
+            information across our website, programs, and related digital
+            services.
+          </EditorialLead>
+        </FadeIn>
+      </EditorialBand>
+
+      <EditorialBand
+        tone="cream"
+        marker="01"
         aria-labelledby="privacy-policy-title"
       >
-        <div className="absolute top-0 right-0 w-64 h-64 bg-[#FCFAEF]/10 rounded-full -translate-y-1/2 translate-x-1/2 blur-3xl" />
-        <div className="absolute bottom-0 left-0 w-96 h-96 bg-[#FCFAEF]/10 rounded-full translate-y-1/2 -translate-x-1/2 blur-3xl" />
+        <FadeIn amount="some">
+          <PublicationArticleMeasure>
+            <LegalProseArticle labelledBy="privacy-policy-title">
+              <div className="space-y-4 sm:space-y-6" id="scope">
+                <LegalSectionRule variant="teal" />
+                <h2 className={h2}>Who we are and what this policy covers</h2>
+                <p className={body}>
+                  Akomapa Health Foundation (&quot;we,&quot; &quot;our,&quot;
+                  or &quot;us&quot;) runs community health programs, volunteer
+                  pathways, education initiatives, and this website. This Privacy
+                  Policy describes how we handle personal information when you
+                  browse our site, contact us, apply to volunteer, subscribe to
+                  updates, or make a donation.
+                </p>
+                <p className={body}>
+                  <strong>Nkwapa and clinical records:</strong> We are
+                  developing Nkwapa, an electronic medical records (EMR)
+                  platform intended for use in care settings. If you interact
+                  with Nkwapa or other clinical systems we operate, additional
+                  notices or agreements may apply to health information. This
+                  page focuses on general website and program administration
+                  data—not patient charts entered in an EMR—unless we tell you
+                  otherwise at collection.
+                </p>
+              </div>
 
-        <div className="site-container mx-auto px-4 sm:px-6 relative z-10">
-          <div className="max-w-5xl pt-4 sm:pt-8">
-            <HeroEntranceH1
-              id="privacy-policy-title"
-              className="text-3xl sm:text-4xl md:text-6xl lg:text-7xl font-light text-[#FCFAEF] mb-6 leading-tight"
-            >
-              Privacy Policy
-            </HeroEntranceH1>
-            <HeroEntranceP
-              delay={0.1}
-              className="text-base sm:text-lg md:text-2xl text-[#FCFAEF]/80 font-light max-w-3xl"
-            >
-              Your privacy matters. Here is how we collect, use, and protect
-              information across our website, programs, and related digital
-              services.
-            </HeroEntranceP>
-          </div>
-        </div>
-      </section>
+              <div className={section} id="information-we-collect">
+                <LegalSectionRule variant="amber" />
+                <h2 className={h2}>Information we collect</h2>
+                <p className={body}>Depending on how you engage with us, we may collect:</p>
+                <ul className={list}>
+                  <li>
+                    <strong>Identifiers and contact details:</strong> Name,
+                    email address, phone number, and similar details you submit
+                    on forms or applications.
+                  </li>
+                  <li>
+                    <strong>Volunteer and education-related application
+                    information:</strong> School and level, motivation and
+                    expectations, screening or counseling experience where you
+                    choose to share it, availability and team preferences,
+                    backup volunteer status, and related notes needed to review
+                    your application.
+                  </li>
+                  <li>
+                    <strong>Messages and inquiries:</strong> Subject lines,
+                    message bodies, and optional partnership context you send
+                    through our contact or partnership flows.
+                  </li>
+                  <li>
+                    <strong>Newsletter subscriptions:</strong> Email address and
+                    subscription status managed through our email marketing
+                    provider.
+                  </li>
+                  <li>
+                    <strong>Donation and payment-related information:</strong>{" "}
+                    Billing details needed to process contributions or partner
+                    payments. Card numbers and other sensitive payment data are
+                    handled by our payment processor—we do not store full card
+                    data on our servers.
+                  </li>
+                  <li>
+                    <strong>Technical data:</strong> Information such as IP
+                    address, browser type, device characteristics, general
+                    location derived from IP, pages viewed, timestamps, and
+                    referral URLs. This data may be collected automatically by
+                    our hosting infrastructure, content delivery networks, and
+                    vendors that deliver forms or email on our behalf.
+                  </li>
+                </ul>
+              </div>
 
-      <section className="py-16 md:py-24 bg-[#FCFAEF] dark:bg-[#1C1F1E]">
-        <div className="site-container mx-auto px-4 sm:px-6">
-          <div className="max-w-4xl mx-auto">
-            <FadeIn
-              amount="some"
-              className="bg-white dark:bg-[#2F3332] rounded-2xl shadow-xl p-6 sm:p-8 md:p-10"
-            >
-              <article
-                className="max-w-prose mx-auto space-y-8 sm:space-y-10"
-                aria-labelledby="privacy-policy-title"
+              <div className={section} id="how-we-use-information">
+                <LegalSectionRule variant="teal" />
+                <h2 className={h2}>How we use information</h2>
+                <p className={body}>We use personal information to:</p>
+                <ul className={list}>
+                  <li>Respond to questions and partnership inquiries</li>
+                  <li>Review and coordinate volunteer applications</li>
+                  <li>
+                    Operate educational and outreach programs, including
+                    scheduling communications where you have opted in
+                  </li>
+                  <li>
+                    Send newsletters or updates when you subscribe (you can
+                    unsubscribe using links in those emails)
+                  </li>
+                  <li>Process donations and partnership payments securely</li>
+                  <li>
+                    Maintain safe, reliable digital services (security,
+                    troubleshooting, fraud prevention)
+                  </li>
+                  <li>Meet legal, regulatory, or ethical obligations</li>
+                  <li>
+                    Improve our website and programs in aggregate, including
+                    understanding which content is most helpful
+                  </li>
+                </ul>
+              </div>
+
+              <div className={section} id="forms">
+                <LegalSectionRule variant="amber" />
+                <h2 className={h2}>Forms and applications</h2>
+
+                <h3 className={`${h3} pt-2`}>
+                  Contact and partnership messages
+                </h3>
+                <p className={body}>
+                  When you use our contact flow, your submission is transmitted
+                  through a secure form delivery service so our team can reply.
+                  We keep message content only as long as needed to respond,
+                  maintain records where required, and protect our community.
+                </p>
+
+                <h3 className={h3}>
+                  Volunteer applications
+                </h3>
+                <p className={body}>
+                  Volunteer applications are stored in a secure database tool
+                  our staff uses for recruiting and placement. Access is limited
+                  to people who need it for operations, compliance, or partner
+                  coordination. Retention follows operational needs and legal
+                  requirements; we remove or archive data when it is no longer
+                  necessary.
+                </p>
+
+                <h3 className={h3}>
+                  Educational programs and future platforms
+                </h3>
+                <p className={body}>
+                  If you register for trainings, mentorship, or future online
+                  learning experiences we offer, we may collect enrollment
+                  details, attendance, and communications related to those
+                  programs. Completing a program does not confer a professional
+                  license or certification unless we explicitly say so in
+                  writing for that offering.
+                </p>
+              </div>
+
+              <div className={section} id="cookies-local-storage">
+                <LegalSectionRule variant="teal" />
+                <h2 className={h2}>Cookies, local storage, and similar technologies</h2>
+                <p className={body}>
+                  We may use cookies or similar technologies where needed for
+                  security, preferences, or future analytics features. Today,
+                  parts of our site store small amounts of information in your
+                  browser&apos;s <strong>local storage</strong>—for example, to
+                  remember light or dark theme choices and whether you have
+                  dismissed an announcement. These values stay on your device
+                  unless you clear site data in your browser settings.
+                </p>
+                <p className={body}>
+                  If we introduce optional marketing or analytics cookies, we
+                  will update this Policy and, where required, provide a way to
+                  manage preferences.
+                </p>
+              </div>
+
+              <div className={section} id="analytics">
+                <LegalSectionRule variant="amber" />
+                <h2 className={h2}>Analytics and performance</h2>
+                <p className={body}>
+                  Like most hosted websites, our infrastructure automatically
+                  logs technical activity needed to deliver pages securely and
+                  reliably. We do not currently run dedicated marketing
+                  analytics packages on this site; if that changes, we will
+                  describe the tools we use, what data they collect, and any
+                  choices you have.
+                </p>
+              </div>
+
+              <div className={section} id="sharing">
+                <LegalSectionRule variant="teal" />
+                <h2 className={h2}>How we share information</h2>
+                <p className={body}>
+                  We do not sell your personal information. We may share data
+                  with:
+                </p>
+                <ul className={list}>
+                  <li>
+                    <strong>Service providers</strong> who help us host the
+                    site, deliver forms and email, process payments, manage
+                    newsletter lists, store volunteer records, or provide
+                    similar operational functions.
+                  </li>
+                  <li>
+                    <strong>Partner institutions</strong> when coordination is
+                    necessary for volunteer placements, education programs, or
+                    clinic operations—and only with appropriate safeguards.
+                  </li>
+                  <li>
+                    <strong>Legal and safety recipients</strong> when disclosure
+                    is required by law, regulation, legal process, or to protect
+                    the rights and safety of patients, volunteers, staff, or the
+                    public.
+                  </li>
+                  <li>
+                    <strong>With your direction or consent</strong>, including
+                    when you ask us to introduce you to a partner organization.
+                  </li>
+                </ul>
+                <p className={body}>
+                  We require vendors to use information only to provide
+                  services to us and to apply reasonable security measures.
+                </p>
+              </div>
+
+              <div className={section} id="international">
+                <LegalSectionRule variant="amber" />
+                <h2 className={h2}>International transfers</h2>
+                <p className={body}>
+                  Akomapa works across regions. Information may be processed in
+                  the United States or other countries where our vendors operate.
+                  When data moves across borders, we rely on contractual and
+                  organizational safeguards appropriate to the sensitivity of
+                  the information involved.
+                </p>
+              </div>
+
+              <div className={section} id="security">
+                <LegalSectionRule variant="teal" />
+                <h2 className={h2}>Data security</h2>
+                <p className={body}>
+                  We use administrative, technical, and physical safeguards
+                  designed to protect personal information, including encryption
+                  in transit where appropriate, access controls for staff and
+                  systems, and trusted payment processing partners. No online
+                  platform can guarantee perfect security; please use unique
+                  passwords and contact us immediately if you suspect misuse.
+                </p>
+              </div>
+
+              <div className={section} id="rights">
+                <LegalSectionRule variant="amber" />
+                <h2 className={h2}>Your rights and choices</h2>
+                <p className={body}>Depending on where you live, you may have rights to:</p>
+                <ul className={list}>
+                  <li>Access the personal information we maintain about you</li>
+                  <li>Request corrections to inaccurate information</li>
+                  <li>
+                    Request deletion, subject to legal or operational retention
+                    needs
+                  </li>
+                  <li>
+                    Opt out of marketing emails via unsubscribe links or by
+                    emailing us
+                  </li>
+                  <li>
+                    Withdraw consent where processing is based on consent
+                  </li>
+                </ul>
+                <p className={body}>
+                  To exercise these rights, email{" "}
+                  <a href="mailto:akomapahealth@gmail.com" className={link}>
+                    akomapahealth@gmail.com
+                  </a>
+                  . We may need to verify your identity before fulfilling certain
+                  requests.
+                </p>
+              </div>
+
+              <div className={section} id="children">
+                <LegalSectionRule variant="teal" />
+                <h2 className={h2}>Children&apos;s privacy</h2>
+                <p className={body}>
+                  Our website and general mailing lists are not directed at
+                  children under 13. Youth may participate in some educational
+                  programs with schools or guardians; when we collect
+                  information from minors in those contexts, we do so consistent
+                  with applicable law and program consent practices. If you
+                  believe we collected information from a child improperly,
+                  please contact us right away.
+                </p>
+              </div>
+
+              <div className={section} id="changes">
+                <LegalSectionRule variant="amber" />
+                <h2 className={h2}>Changes to this Privacy Policy</h2>
+                <p className={body}>
+                  We may update this Policy as our programs evolve. When we make
+                  material changes, we will revise the &quot;Last updated&quot;
+                  date below and, where appropriate, provide additional notice on
+                  the site or by email.
+                </p>
+              </div>
+
+              <div
+                className="space-y-4 border-t border-[#E6E7E7] pt-6 sm:space-y-6 dark:border-[#4F5554]"
+                id="contact"
               >
-                <div className="space-y-4 sm:space-y-6" id="scope">
-                  <SectionRule variant="teal" />
-                  <h2 className={h2}>Who we are and what this policy covers</h2>
-                  <p className={body}>
-                    Akomapa Health Foundation (&quot;we,&quot; &quot;our,&quot;
-                    or &quot;us&quot;) runs community health programs, volunteer
-                    pathways, education initiatives, and this website. This Privacy
-                    Policy describes how we handle personal information when you
-                    browse our site, contact us, apply to volunteer, subscribe to
-                    updates, or make a donation.
-                  </p>
-                  <p className={body}>
-                    <strong>Nkwapa and clinical records:</strong> We are
-                    developing Nkwapa, an electronic medical records (EMR)
-                    platform intended for use in care settings. If you interact
-                    with Nkwapa or other clinical systems we operate, additional
-                    notices or agreements may apply to health information. This
-                    page focuses on general website and program administration
-                    data—not patient charts entered in an EMR—unless we tell you
-                    otherwise at collection.
-                  </p>
-                </div>
+                <LegalSectionRule variant="teal" />
+                <h2 className={h2}>Contact us</h2>
+                <p className={body}>
+                  Questions about privacy? Email{" "}
+                  <a href="mailto:akomapahealth@gmail.com" className={link}>
+                    akomapahealth@gmail.com
+                  </a>{" "}
+                  or visit our{" "}
+                  <Link href="/contact" className={link}>
+                    contact page
+                  </Link>
+                  .
+                </p>
+              </div>
 
-                <div
-                  className="space-y-4 sm:space-y-6 pt-6 border-t border-[#E6E7E7]/40 dark:border-[#4F5554]/40"
-                  id="information-we-collect"
-                >
-                  <SectionRule variant="amber" />
-                  <h2 className={h2}>Information we collect</h2>
-                  <p className={body}>Depending on how you engage with us, we may collect:</p>
-                  <ul className={list}>
-                    <li>
-                      <strong>Identifiers and contact details:</strong> Name,
-                      email address, phone number, and similar details you submit
-                      on forms or applications.
-                    </li>
-                    <li>
-                      <strong>Volunteer and education-related application
-                      information:</strong> School and level, motivation and
-                      expectations, screening or counseling experience where you
-                      choose to share it, availability and team preferences,
-                      backup volunteer status, and related notes needed to review
-                      your application.
-                    </li>
-                    <li>
-                      <strong>Messages and inquiries:</strong> Subject lines,
-                      message bodies, and optional partnership context you send
-                      through our contact or partnership flows.
-                    </li>
-                    <li>
-                      <strong>Newsletter subscriptions:</strong> Email address and
-                      subscription status managed through our email marketing
-                      provider.
-                    </li>
-                    <li>
-                      <strong>Donation and payment-related information:</strong>{" "}
-                      Billing details needed to process contributions or partner
-                      payments. Card numbers and other sensitive payment data are
-                      handled by our payment processor—we do not store full card
-                      data on our servers.
-                    </li>
-                    <li>
-                      <strong>Technical data:</strong> Information such as IP
-                      address, browser type, device characteristics, general
-                      location derived from IP, pages viewed, timestamps, and
-                      referral URLs. This data may be collected automatically by
-                      our hosting infrastructure, content delivery networks, and
-                      vendors that deliver forms or email on our behalf.
-                    </li>
-                  </ul>
-                </div>
-
-                <div
-                  className="space-y-4 sm:space-y-6 pt-6 border-t border-[#E6E7E7]/40 dark:border-[#4F5554]/40"
-                  id="how-we-use-information"
-                >
-                  <SectionRule variant="teal" />
-                  <h2 className={h2}>How we use information</h2>
-                  <p className={body}>We use personal information to:</p>
-                  <ul className={list}>
-                    <li>Respond to questions and partnership inquiries</li>
-                    <li>Review and coordinate volunteer applications</li>
-                    <li>
-                      Operate educational and outreach programs, including
-                      scheduling communications where you have opted in
-                    </li>
-                    <li>
-                      Send newsletters or updates when you subscribe (you can
-                      unsubscribe using links in those emails)
-                    </li>
-                    <li>Process donations and partnership payments securely</li>
-                    <li>
-                      Maintain safe, reliable digital services (security,
-                      troubleshooting, fraud prevention)
-                    </li>
-                    <li>Meet legal, regulatory, or ethical obligations</li>
-                    <li>
-                      Improve our website and programs in aggregate, including
-                      understanding which content is most helpful
-                    </li>
-                  </ul>
-                </div>
-
-                <div
-                  className="space-y-4 sm:space-y-6 pt-6 border-t border-[#E6E7E7]/40 dark:border-[#4F5554]/40"
-                  id="forms"
-                >
-                  <SectionRule variant="amber" />
-                  <h2 className={h2}>Forms and applications</h2>
-
-                  <h3 className="text-lg sm:text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF] pt-2">
-                    Contact and partnership messages
-                  </h3>
-                  <p className={body}>
-                    When you use our contact flow, your submission is transmitted
-                    through a secure form delivery service so our team can reply.
-                    We keep message content only as long as needed to respond,
-                    maintain records where required, and protect our community.
-                  </p>
-
-                  <h3 className="text-lg sm:text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
-                    Volunteer applications
-                  </h3>
-                  <p className={body}>
-                    Volunteer applications are stored in a secure database tool
-                    our staff uses for recruiting and placement. Access is limited
-                    to people who need it for operations, compliance, or partner
-                    coordination. Retention follows operational needs and legal
-                    requirements; we remove or archive data when it is no longer
-                    necessary.
-                  </p>
-
-                  <h3 className="text-lg sm:text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
-                    Educational programs and future platforms
-                  </h3>
-                  <p className={body}>
-                    If you register for trainings, mentorship, or future online
-                    learning experiences we offer, we may collect enrollment
-                    details, attendance, and communications related to those
-                    programs. Completing a program does not confer a professional
-                    license or certification unless we explicitly say so in
-                    writing for that offering.
-                  </p>
-                </div>
-
-                <div
-                  className="space-y-4 sm:space-y-6 pt-6 border-t border-[#E6E7E7]/40 dark:border-[#4F5554]/40"
-                  id="cookies-local-storage"
-                >
-                  <SectionRule variant="teal" />
-                  <h2 className={h2}>Cookies, local storage, and similar technologies</h2>
-                  <p className={body}>
-                    We may use cookies or similar technologies where needed for
-                    security, preferences, or future analytics features. Today,
-                    parts of our site store small amounts of information in your
-                    browser&apos;s <strong>local storage</strong>—for example, to
-                    remember light or dark theme choices and whether you have
-                    dismissed an announcement. These values stay on your device
-                    unless you clear site data in your browser settings.
-                  </p>
-                  <p className={body}>
-                    If we introduce optional marketing or analytics cookies, we
-                    will update this Policy and, where required, provide a way to
-                    manage preferences.
-                  </p>
-                </div>
-
-                <div
-                  className="space-y-4 sm:space-y-6 pt-6 border-t border-[#E6E7E7]/40 dark:border-[#4F5554]/40"
-                  id="analytics"
-                >
-                  <SectionRule variant="amber" />
-                  <h2 className={h2}>Analytics and performance</h2>
-                  <p className={body}>
-                    Like most hosted websites, our infrastructure automatically
-                    logs technical activity needed to deliver pages securely and
-                    reliably. We do not currently run dedicated marketing
-                    analytics packages on this site; if that changes, we will
-                    describe the tools we use, what data they collect, and any
-                    choices you have.
-                  </p>
-                </div>
-
-                <div
-                  className="space-y-4 sm:space-y-6 pt-6 border-t border-[#E6E7E7]/40 dark:border-[#4F5554]/40"
-                  id="sharing"
-                >
-                  <SectionRule variant="teal" />
-                  <h2 className={h2}>How we share information</h2>
-                  <p className={body}>
-                    We do not sell your personal information. We may share data
-                    with:
-                  </p>
-                  <ul className={list}>
-                    <li>
-                      <strong>Service providers</strong> who help us host the
-                      site, deliver forms and email, process payments, manage
-                      newsletter lists, store volunteer records, or provide
-                      similar operational functions.
-                    </li>
-                    <li>
-                      <strong>Partner institutions</strong> when coordination is
-                      necessary for volunteer placements, education programs, or
-                      clinic operations—and only with appropriate safeguards.
-                    </li>
-                    <li>
-                      <strong>Legal and safety recipients</strong> when disclosure
-                      is required by law, regulation, legal process, or to protect
-                      the rights and safety of patients, volunteers, staff, or the
-                      public.
-                    </li>
-                    <li>
-                      <strong>With your direction or consent</strong>, including
-                      when you ask us to introduce you to a partner organization.
-                    </li>
-                  </ul>
-                  <p className={body}>
-                    We require vendors to use information only to provide
-                    services to us and to apply reasonable security measures.
-                  </p>
-                </div>
-
-                <div
-                  className="space-y-4 sm:space-y-6 pt-6 border-t border-[#E6E7E7]/40 dark:border-[#4F5554]/40"
-                  id="international"
-                >
-                  <SectionRule variant="amber" />
-                  <h2 className={h2}>International transfers</h2>
-                  <p className={body}>
-                    Akomapa works across regions. Information may be processed in
-                    the United States or other countries where our vendors operate.
-                    When data moves across borders, we rely on contractual and
-                    organizational safeguards appropriate to the sensitivity of
-                    the information involved.
-                  </p>
-                </div>
-
-                <div
-                  className="space-y-4 sm:space-y-6 pt-6 border-t border-[#E6E7E7]/40 dark:border-[#4F5554]/40"
-                  id="security"
-                >
-                  <SectionRule variant="teal" />
-                  <h2 className={h2}>Data security</h2>
-                  <p className={body}>
-                    We use administrative, technical, and physical safeguards
-                    designed to protect personal information, including encryption
-                    in transit where appropriate, access controls for staff and
-                    systems, and trusted payment processing partners. No online
-                    platform can guarantee perfect security; please use unique
-                    passwords and contact us immediately if you suspect misuse.
-                  </p>
-                </div>
-
-                <div
-                  className="space-y-4 sm:space-y-6 pt-6 border-t border-[#E6E7E7]/40 dark:border-[#4F5554]/40"
-                  id="rights"
-                >
-                  <SectionRule variant="amber" />
-                  <h2 className={h2}>Your rights and choices</h2>
-                  <p className={body}>Depending on where you live, you may have rights to:</p>
-                  <ul className={list}>
-                    <li>Access the personal information we maintain about you</li>
-                    <li>Request corrections to inaccurate information</li>
-                    <li>
-                      Request deletion, subject to legal or operational retention
-                      needs
-                    </li>
-                    <li>
-                      Opt out of marketing emails via unsubscribe links or by
-                      emailing us
-                    </li>
-                    <li>
-                      Withdraw consent where processing is based on consent
-                    </li>
-                  </ul>
-                  <p className={body}>
-                    To exercise these rights, email{" "}
-                    <a
-                      href="mailto:akomapahealth@gmail.com"
-                      className="text-[#0097b2] dark:text-[#66C4DC] hover:text-[#eeba2b] dark:hover:text-[#F5C94D] transition-colors font-medium underline-offset-2 hover:underline"
-                    >
-                      akomapahealth@gmail.com
-                    </a>
-                    . We may need to verify your identity before fulfilling certain
-                    requests.
-                  </p>
-                </div>
-
-                <div
-                  className="space-y-4 sm:space-y-6 pt-6 border-t border-[#E6E7E7]/40 dark:border-[#4F5554]/40"
-                  id="children"
-                >
-                  <SectionRule variant="teal" />
-                  <h2 className={h2}>Children&apos;s privacy</h2>
-                  <p className={body}>
-                    Our website and general mailing lists are not directed at
-                    children under 13. Youth may participate in some educational
-                    programs with schools or guardians; when we collect
-                    information from minors in those contexts, we do so consistent
-                    with applicable law and program consent practices. If you
-                    believe we collected information from a child improperly,
-                    please contact us right away.
-                  </p>
-                </div>
-
-                <div
-                  className="space-y-4 sm:space-y-6 pt-6 border-t border-[#E6E7E7]/40 dark:border-[#4F5554]/40"
-                  id="changes"
-                >
-                  <SectionRule variant="amber" />
-                  <h2 className={h2}>Changes to this Privacy Policy</h2>
-                  <p className={body}>
-                    We may update this Policy as our programs evolve. When we make
-                    material changes, we will revise the &quot;Last updated&quot;
-                    date below and, where appropriate, provide additional notice on
-                    the site or by email.
-                  </p>
-                </div>
-
-                <div
-                  className="space-y-4 sm:space-y-6 pt-6 border-t border-[#E6E7E7] dark:border-[#4F5554]"
-                  id="contact"
-                >
-                  <SectionRule variant="teal" />
-                  <h2 className={h2}>Contact us</h2>
-                  <p className={body}>
-                    Questions about privacy? Email{" "}
-                    <a
-                      href="mailto:akomapahealth@gmail.com"
-                      className="text-[#0097b2] dark:text-[#66C4DC] hover:text-[#eeba2b] dark:hover:text-[#F5C94D] transition-colors font-medium underline-offset-2 hover:underline"
-                    >
-                      akomapahealth@gmail.com
-                    </a>{" "}
-                    or visit our{" "}
-                    <Link
-                      href="/contact"
-                      className="text-[#0097b2] dark:text-[#66C4DC] hover:text-[#eeba2b] dark:hover:text-[#F5C94D] transition-colors font-medium underline-offset-2 hover:underline"
-                    >
-                      contact page
-                    </Link>
-                    .
-                  </p>
-                </div>
-
-                <div className="pt-6 border-t border-[#E6E7E7] dark:border-[#4F5554]">
-                  <p className="text-sm sm:text-base text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
-                    Last updated: {LAST_UPDATED}
-                  </p>
-                </div>
-              </article>
-            </FadeIn>
-          </div>
-        </div>
-      </section>
-    </>
+              <LegalLastUpdated date={LAST_UPDATED} />
+            </LegalProseArticle>
+          </PublicationArticleMeasure>
+        </FadeIn>
+      </EditorialBand>
+    </div>
   );
 }

--- a/src/app/(main)/privacy/Content.tsx
+++ b/src/app/(main)/privacy/Content.tsx
@@ -1,15 +1,15 @@
 import { FadeIn } from "@/components/animations";
 import Breadcrumb from "@/components/layout/Breadcrumb";
 import {
+  LegalContentsNav,
   LegalLastUpdated,
   LegalProseArticle,
-  LegalSectionRule,
+  LegalSection,
   legalBodyClassName as body,
-  legalHeadingClassName as h2,
   legalLinkClassName as link,
   legalListClassName as list,
-  legalSectionClassName as section,
   legalSubheadingClassName as h3,
+  type LegalContentsItem,
 } from "@/components/legal/LegalDocumentPrimitives";
 import { PublicationArticleMeasure } from "@/components/publication";
 import {
@@ -21,6 +21,25 @@ import {
 import Link from "next/link";
 
 const LAST_UPDATED = "May 9, 2026";
+
+const contents: readonly LegalContentsItem[] = [
+  { href: "#scope", label: "Who we are and what this policy covers" },
+  { href: "#information-we-collect", label: "Information we collect" },
+  { href: "#how-we-use-information", label: "How we use information" },
+  { href: "#forms", label: "Forms and applications" },
+  {
+    href: "#cookies-local-storage",
+    label: "Cookies, local storage, and similar technologies",
+  },
+  { href: "#analytics", label: "Analytics and performance" },
+  { href: "#sharing", label: "How we share information" },
+  { href: "#international", label: "International transfers" },
+  { href: "#security", label: "Data security" },
+  { href: "#rights", label: "Your rights and choices" },
+  { href: "#children", label: "Children's privacy" },
+  { href: "#changes", label: "Changes to this Privacy Policy" },
+  { href: "#contact", label: "Contact us" },
+];
 
 export default function Content() {
   return (
@@ -51,6 +70,9 @@ export default function Content() {
             information across our website, programs, and related digital
             services.
           </EditorialLead>
+          <p className="mt-8 border-t border-[#FCFAEF]/20 pt-5 font-subheading text-xs font-bold uppercase tracking-[0.18em] text-[#F5C94D]/90">
+            Last updated: {LAST_UPDATED}
+          </p>
         </FadeIn>
       </EditorialBand>
 
@@ -58,13 +80,18 @@ export default function Content() {
         tone="cream"
         marker="01"
         aria-labelledby="privacy-policy-title"
+        containerClassName="py-12 md:py-16 lg:py-20"
       >
         <FadeIn amount="some">
-          <PublicationArticleMeasure>
+          <PublicationArticleMeasure className="max-w-3xl">
             <LegalProseArticle labelledBy="privacy-policy-title">
-              <div className="space-y-4 sm:space-y-6" id="scope">
-                <LegalSectionRule variant="teal" />
-                <h2 className={h2}>Who we are and what this policy covers</h2>
+              <LegalContentsNav items={contents} />
+
+              <LegalSection
+                id="scope"
+                ruleVariant="teal"
+                title="Who we are and what this policy covers"
+              >
                 <p className={body}>
                   Akomapa Health Foundation (&quot;we,&quot; &quot;our,&quot;
                   or &quot;us&quot;) runs community health programs, volunteer
@@ -83,11 +110,13 @@ export default function Content() {
                   data—not patient charts entered in an EMR—unless we tell you
                   otherwise at collection.
                 </p>
-              </div>
+              </LegalSection>
 
-              <div className={section} id="information-we-collect">
-                <LegalSectionRule variant="amber" />
-                <h2 className={h2}>Information we collect</h2>
+              <LegalSection
+                id="information-we-collect"
+                ruleVariant="amber"
+                title="Information we collect"
+              >
                 <p className={body}>Depending on how you engage with us, we may collect:</p>
                 <ul className={list}>
                   <li>
@@ -129,11 +158,13 @@ export default function Content() {
                     vendors that deliver forms or email on our behalf.
                   </li>
                 </ul>
-              </div>
+              </LegalSection>
 
-              <div className={section} id="how-we-use-information">
-                <LegalSectionRule variant="teal" />
-                <h2 className={h2}>How we use information</h2>
+              <LegalSection
+                id="how-we-use-information"
+                ruleVariant="teal"
+                title="How we use information"
+              >
                 <p className={body}>We use personal information to:</p>
                 <ul className={list}>
                   <li>Respond to questions and partnership inquiries</li>
@@ -157,15 +188,14 @@ export default function Content() {
                     understanding which content is most helpful
                   </li>
                 </ul>
-              </div>
+              </LegalSection>
 
-              <div className={section} id="forms">
-                <LegalSectionRule variant="amber" />
-                <h2 className={h2}>Forms and applications</h2>
-
-                <h3 className={`${h3} pt-2`}>
-                  Contact and partnership messages
-                </h3>
+              <LegalSection
+                id="forms"
+                ruleVariant="amber"
+                title="Forms and applications"
+              >
+                <h3 className={h3}>Contact and partnership messages</h3>
                 <p className={body}>
                   When you use our contact flow, your submission is transmitted
                   through a secure form delivery service so our team can reply.
@@ -173,9 +203,7 @@ export default function Content() {
                   maintain records where required, and protect our community.
                 </p>
 
-                <h3 className={h3}>
-                  Volunteer applications
-                </h3>
+                <h3 className={h3}>Volunteer applications</h3>
                 <p className={body}>
                   Volunteer applications are stored in a secure database tool
                   our staff uses for recruiting and placement. Access is limited
@@ -185,9 +213,7 @@ export default function Content() {
                   necessary.
                 </p>
 
-                <h3 className={h3}>
-                  Educational programs and future platforms
-                </h3>
+                <h3 className={h3}>Educational programs and future platforms</h3>
                 <p className={body}>
                   If you register for trainings, mentorship, or future online
                   learning experiences we offer, we may collect enrollment
@@ -196,11 +222,13 @@ export default function Content() {
                   license or certification unless we explicitly say so in
                   writing for that offering.
                 </p>
-              </div>
+              </LegalSection>
 
-              <div className={section} id="cookies-local-storage">
-                <LegalSectionRule variant="teal" />
-                <h2 className={h2}>Cookies, local storage, and similar technologies</h2>
+              <LegalSection
+                id="cookies-local-storage"
+                ruleVariant="teal"
+                title="Cookies, local storage, and similar technologies"
+              >
                 <p className={body}>
                   We may use cookies or similar technologies where needed for
                   security, preferences, or future analytics features. Today,
@@ -215,11 +243,13 @@ export default function Content() {
                   will update this Policy and, where required, provide a way to
                   manage preferences.
                 </p>
-              </div>
+              </LegalSection>
 
-              <div className={section} id="analytics">
-                <LegalSectionRule variant="amber" />
-                <h2 className={h2}>Analytics and performance</h2>
+              <LegalSection
+                id="analytics"
+                ruleVariant="amber"
+                title="Analytics and performance"
+              >
                 <p className={body}>
                   Like most hosted websites, our infrastructure automatically
                   logs technical activity needed to deliver pages securely and
@@ -228,11 +258,13 @@ export default function Content() {
                   describe the tools we use, what data they collect, and any
                   choices you have.
                 </p>
-              </div>
+              </LegalSection>
 
-              <div className={section} id="sharing">
-                <LegalSectionRule variant="teal" />
-                <h2 className={h2}>How we share information</h2>
+              <LegalSection
+                id="sharing"
+                ruleVariant="teal"
+                title="How we share information"
+              >
                 <p className={body}>
                   We do not sell your personal information. We may share data
                   with:
@@ -264,11 +296,13 @@ export default function Content() {
                   We require vendors to use information only to provide
                   services to us and to apply reasonable security measures.
                 </p>
-              </div>
+              </LegalSection>
 
-              <div className={section} id="international">
-                <LegalSectionRule variant="amber" />
-                <h2 className={h2}>International transfers</h2>
+              <LegalSection
+                id="international"
+                ruleVariant="amber"
+                title="International transfers"
+              >
                 <p className={body}>
                   Akomapa works across regions. Information may be processed in
                   the United States or other countries where our vendors operate.
@@ -276,11 +310,13 @@ export default function Content() {
                   organizational safeguards appropriate to the sensitivity of
                   the information involved.
                 </p>
-              </div>
+              </LegalSection>
 
-              <div className={section} id="security">
-                <LegalSectionRule variant="teal" />
-                <h2 className={h2}>Data security</h2>
+              <LegalSection
+                id="security"
+                ruleVariant="teal"
+                title="Data security"
+              >
                 <p className={body}>
                   We use administrative, technical, and physical safeguards
                   designed to protect personal information, including encryption
@@ -289,11 +325,13 @@ export default function Content() {
                   platform can guarantee perfect security; please use unique
                   passwords and contact us immediately if you suspect misuse.
                 </p>
-              </div>
+              </LegalSection>
 
-              <div className={section} id="rights">
-                <LegalSectionRule variant="amber" />
-                <h2 className={h2}>Your rights and choices</h2>
+              <LegalSection
+                id="rights"
+                ruleVariant="amber"
+                title="Your rights and choices"
+              >
                 <p className={body}>Depending on where you live, you may have rights to:</p>
                 <ul className={list}>
                   <li>Access the personal information we maintain about you</li>
@@ -318,11 +356,13 @@ export default function Content() {
                   . We may need to verify your identity before fulfilling certain
                   requests.
                 </p>
-              </div>
+              </LegalSection>
 
-              <div className={section} id="children">
-                <LegalSectionRule variant="teal" />
-                <h2 className={h2}>Children&apos;s privacy</h2>
+              <LegalSection
+                id="children"
+                ruleVariant="teal"
+                title="Children's privacy"
+              >
                 <p className={body}>
                   Our website and general mailing lists are not directed at
                   children under 13. Youth may participate in some educational
@@ -332,25 +372,26 @@ export default function Content() {
                   believe we collected information from a child improperly,
                   please contact us right away.
                 </p>
-              </div>
+              </LegalSection>
 
-              <div className={section} id="changes">
-                <LegalSectionRule variant="amber" />
-                <h2 className={h2}>Changes to this Privacy Policy</h2>
+              <LegalSection
+                id="changes"
+                ruleVariant="amber"
+                title="Changes to this Privacy Policy"
+              >
                 <p className={body}>
                   We may update this Policy as our programs evolve. When we make
                   material changes, we will revise the &quot;Last updated&quot;
                   date below and, where appropriate, provide additional notice on
                   the site or by email.
                 </p>
-              </div>
+              </LegalSection>
 
-              <div
-                className="space-y-4 border-t border-[#E6E7E7] pt-6 sm:space-y-6 dark:border-[#4F5554]"
+              <LegalSection
                 id="contact"
+                ruleVariant="teal"
+                title="Contact us"
               >
-                <LegalSectionRule variant="teal" />
-                <h2 className={h2}>Contact us</h2>
                 <p className={body}>
                   Questions about privacy? Email{" "}
                   <a href="mailto:akomapahealth@gmail.com" className={link}>
@@ -362,7 +403,7 @@ export default function Content() {
                   </Link>
                   .
                 </p>
-              </div>
+              </LegalSection>
 
               <LegalLastUpdated date={LAST_UPDATED} />
             </LegalProseArticle>

--- a/src/app/(main)/privacy/__tests__/PrivacyContentEditorial.test.tsx
+++ b/src/app/(main)/privacy/__tests__/PrivacyContentEditorial.test.tsx
@@ -69,7 +69,9 @@ describe("Privacy Content editorial contracts", () => {
       expect(document.getElementById(id)).toBeTruthy();
     }
 
-    expect(screen.getByText("Last updated: May 9, 2026")).toBeInTheDocument();
+    expect(
+      screen.getAllByText("Last updated: May 9, 2026").length,
+    ).toBeGreaterThanOrEqual(1);
 
     const mailLinks = screen.getAllByRole("link", {
       name: "akomapahealth@gmail.com",
@@ -82,6 +84,15 @@ describe("Privacy Content editorial contracts", () => {
     expect(
       screen.getByRole("link", { name: "contact page" }),
     ).toHaveAttribute("href", "/contact");
+
+    expect(
+      screen.getByRole("navigation", { name: "On this page" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", {
+        name: /Who we are and what this policy covers/i,
+      }),
+    ).toHaveAttribute("href", "#scope");
 
     expect(
       screen.getByRole("heading", {
@@ -103,13 +114,16 @@ describe("Privacy Content editorial contracts", () => {
     ).toBeInTheDocument();
   });
 
-  it("uses a cream body band with restrained mustard/teal section rules", () => {
+  it("uses a cream body band with semantic legal sections and restrained rules", () => {
     render(<Content />);
 
     const bodyBand = document.querySelector(
       '[data-editorial-band][data-editorial-tone="cream"]',
     );
     expect(bodyBand).toBeTruthy();
+
+    const sections = document.querySelectorAll("[data-legal-section]");
+    expect(sections.length).toBe(privacyHeadings.length);
 
     const rules = document.querySelectorAll("[data-legal-section-rule]");
     expect(rules.length).toBeGreaterThanOrEqual(privacyHeadings.length);

--- a/src/app/(main)/privacy/__tests__/PrivacyContentEditorial.test.tsx
+++ b/src/app/(main)/privacy/__tests__/PrivacyContentEditorial.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import Content from "../Content";
+
+const privacyHeadings = [
+  "Who we are and what this policy covers",
+  "Information we collect",
+  "How we use information",
+  "Forms and applications",
+  "Cookies, local storage, and similar technologies",
+  "Analytics and performance",
+  "How we share information",
+  "International transfers",
+  "Data security",
+  "Your rights and choices",
+  "Children's privacy",
+  "Changes to this Privacy Policy",
+  "Contact us",
+] as const;
+
+const privacySectionIds = [
+  "scope",
+  "information-we-collect",
+  "how-we-use-information",
+  "forms",
+  "cookies-local-storage",
+  "analytics",
+  "sharing",
+  "international",
+  "security",
+  "rights",
+  "children",
+  "changes",
+  "contact",
+] as const;
+
+describe("Privacy Content editorial contracts", () => {
+  it("renders one h1 on a flat deep-teal editorial hero without gradient or card chrome", () => {
+    const { container } = render(<Content />);
+
+    const heading = screen.getByRole("heading", {
+      level: 1,
+      name: "Privacy Policy",
+    });
+    expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
+
+    const hero = heading.closest("[data-editorial-band]");
+    expect(hero).toHaveAttribute("data-editorial-tone", "teal");
+    expect(hero?.className).toContain("bg-[#0F4C5C]");
+    expect(hero?.className).not.toContain("gradient");
+    expect(hero?.className).not.toContain("blur-3xl");
+
+    expect(container.innerHTML).not.toContain("shadow-xl");
+    expect(container.innerHTML).not.toContain("rounded-2xl shadow");
+    expect(container.querySelector("[data-publication-article-measure]")).toBeTruthy();
+    expect(container.querySelector("[data-legal-prose-article]")).toBeTruthy();
+  });
+
+  it("preserves approved privacy headings, section anchors, date, and links", () => {
+    render(<Content />);
+
+    for (const title of privacyHeadings) {
+      expect(
+        screen.getByRole("heading", { level: 2, name: title }),
+      ).toBeInTheDocument();
+    }
+
+    for (const id of privacySectionIds) {
+      expect(document.getElementById(id)).toBeTruthy();
+    }
+
+    expect(screen.getByText("Last updated: May 9, 2026")).toBeInTheDocument();
+
+    const mailLinks = screen.getAllByRole("link", {
+      name: "akomapahealth@gmail.com",
+    });
+    expect(mailLinks.length).toBeGreaterThanOrEqual(2);
+    for (const link of mailLinks) {
+      expect(link).toHaveAttribute("href", "mailto:akomapahealth@gmail.com");
+    }
+
+    expect(
+      screen.getByRole("link", { name: "contact page" }),
+    ).toHaveAttribute("href", "/contact");
+
+    expect(
+      screen.getByRole("heading", {
+        level: 3,
+        name: "Contact and partnership messages",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 3,
+        name: "Volunteer applications",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 3,
+        name: "Educational programs and future platforms",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("uses a cream body band with restrained mustard/teal section rules", () => {
+    render(<Content />);
+
+    const bodyBand = document.querySelector(
+      '[data-editorial-band][data-editorial-tone="cream"]',
+    );
+    expect(bodyBand).toBeTruthy();
+
+    const rules = document.querySelectorAll("[data-legal-section-rule]");
+    expect(rules.length).toBeGreaterThanOrEqual(privacyHeadings.length);
+    for (const rule of rules) {
+      expect(rule).toHaveAttribute("aria-hidden", "true");
+    }
+  });
+});

--- a/src/app/(main)/terms/Content.tsx
+++ b/src/app/(main)/terms/Content.tsx
@@ -1,14 +1,14 @@
 import { FadeIn } from "@/components/animations";
 import Breadcrumb from "@/components/layout/Breadcrumb";
 import {
+  LegalContentsNav,
   LegalLastUpdated,
   LegalProseArticle,
-  LegalSectionRule,
+  LegalSection,
   legalBodyClassName as body,
-  legalHeadingClassName as h2,
   legalLinkClassName as link,
   legalListClassName as list,
-  legalSectionClassName as section,
+  type LegalContentsItem,
 } from "@/components/legal/LegalDocumentPrimitives";
 import { PublicationArticleMeasure } from "@/components/publication";
 import {
@@ -20,6 +20,29 @@ import {
 import Link from "next/link";
 
 const LAST_UPDATED = "May 9, 2026";
+
+const contents: readonly LegalContentsItem[] = [
+  { href: "#acceptance", label: "Agreement to these terms" },
+  { href: "#acceptable-use", label: "Acceptable use" },
+  {
+    href: "#informational-disclaimer",
+    label: "Informational content—not medical advice",
+  },
+  {
+    href: "#healthcare-limitations",
+    label: "Healthcare information and relationships",
+  },
+  { href: "#research", label: "Research and innovation content" },
+  { href: "#applications", label: "Applications and eligibility" },
+  { href: "#donations", label: "Donations and payments" },
+  { href: "#volunteer-conduct", label: "Volunteer responsibilities" },
+  { href: "#code-of-conduct", label: "Code of conduct" },
+  { href: "#intellectual-property", label: "Intellectual property" },
+  { href: "#liability", label: "Limitation of liability" },
+  { href: "#termination", label: "Suspension and termination" },
+  { href: "#changes", label: "Changes to these Terms" },
+  { href: "#contact", label: "Contact" },
+];
 
 export default function Content() {
   return (
@@ -49,6 +72,9 @@ export default function Content() {
             These terms govern your use of our website, digital services,
             donations, and applications to participate in Akomapa programs.
           </EditorialLead>
+          <p className="mt-8 border-t border-[#FCFAEF]/20 pt-5 font-subheading text-xs font-bold uppercase tracking-[0.18em] text-[#F5C94D]/90">
+            Last updated: {LAST_UPDATED}
+          </p>
         </FadeIn>
       </EditorialBand>
 
@@ -56,13 +82,18 @@ export default function Content() {
         tone="cream"
         marker="01"
         aria-labelledby="terms-of-service-title"
+        containerClassName="py-12 md:py-16 lg:py-20"
       >
         <FadeIn amount="some">
-          <PublicationArticleMeasure>
+          <PublicationArticleMeasure className="max-w-3xl">
             <LegalProseArticle labelledBy="terms-of-service-title">
-              <div className="space-y-4 sm:space-y-6" id="acceptance">
-                <LegalSectionRule variant="teal" />
-                <h2 className={h2}>Agreement to these terms</h2>
+              <LegalContentsNav items={contents} />
+
+              <LegalSection
+                id="acceptance"
+                ruleVariant="teal"
+                title="Agreement to these terms"
+              >
                 <p className={body}>
                   By accessing{" "}
                   <strong>www.akomapahealth.org</strong> or related sites we
@@ -83,11 +114,13 @@ export default function Content() {
                   privacy notices, or institutional agreements may apply in
                   addition to these Terms.
                 </p>
-              </div>
+              </LegalSection>
 
-              <div className={section} id="acceptable-use">
-                <LegalSectionRule variant="amber" />
-                <h2 className={h2}>Acceptable use</h2>
+              <LegalSection
+                id="acceptable-use"
+                ruleVariant="amber"
+                title="Acceptable use"
+              >
                 <p className={body}>
                   You may use our digital services only for lawful, respectful
                   purposes. Without limiting other obligations, you agree not to:
@@ -117,11 +150,13 @@ export default function Content() {
                     events coordinated through our programs
                   </li>
                 </ul>
-              </div>
+              </LegalSection>
 
-              <div className={section} id="informational-disclaimer">
-                <LegalSectionRule variant="teal" />
-                <h2 className={h2}>Informational content—not medical advice</h2>
+              <LegalSection
+                id="informational-disclaimer"
+                ruleVariant="teal"
+                title="Informational content—not medical advice"
+              >
                 <p className={body}>
                   Materials on this website—including articles, stories,
                   research summaries, and program descriptions—are provided for
@@ -136,11 +171,13 @@ export default function Content() {
                   local emergency services immediately. Do not rely on email,
                   contact forms, or website content for urgent care.
                 </p>
-              </div>
+              </LegalSection>
 
-              <div className={section} id="healthcare-limitations">
-                <LegalSectionRule variant="amber" />
-                <h2 className={h2}>Healthcare information and relationships</h2>
+              <LegalSection
+                id="healthcare-limitations"
+                ruleVariant="amber"
+                title="Healthcare information and relationships"
+              >
                 <p className={body}>
                   Browsing our website or signing up for newsletters{" "}
                   <strong>does not create</strong> a clinician–patient or other
@@ -149,11 +186,13 @@ export default function Content() {
                   partner policies, professional ethics, and privacy rules such
                   as HIPAA where they apply.
                 </p>
-              </div>
+              </LegalSection>
 
-              <div className={section} id="research">
-                <LegalSectionRule variant="teal" />
-                <h2 className={h2}>Research and innovation content</h2>
+              <LegalSection
+                id="research"
+                ruleVariant="teal"
+                title="Research and innovation content"
+              >
                 <p className={body}>
                   We may describe pilots, partnerships, or learning agendas on
                   our site. Those descriptions are illustrative and may change as
@@ -162,11 +201,13 @@ export default function Content() {
                   <strong>does not constitute an offer</strong> to enroll you in a
                   research study or clinical trial.
                 </p>
-              </div>
+              </LegalSection>
 
-              <div className={section} id="applications">
-                <LegalSectionRule variant="amber" />
-                <h2 className={h2}>Applications and eligibility</h2>
+              <LegalSection
+                id="applications"
+                ruleVariant="amber"
+                title="Applications and eligibility"
+              >
                 <p className={body}>
                   When you apply to volunteer, join leadership programs, or
                   participate in selective offerings, you agree that:
@@ -190,11 +231,13 @@ export default function Content() {
                     capacity, conduct, or compliance reasons
                   </li>
                 </ul>
-              </div>
+              </LegalSection>
 
-              <div className={section} id="donations">
-                <LegalSectionRule variant="teal" />
-                <h2 className={h2}>Donations and payments</h2>
+              <LegalSection
+                id="donations"
+                ruleVariant="teal"
+                title="Donations and payments"
+              >
                 <p className={body}>
                   Donations and certain partnership payments are processed
                   through a certified payment processor. You authorize charges you
@@ -210,11 +253,13 @@ export default function Content() {
                   promptly. Refunds, if any, are handled case by case and may
                   depend on processor policies and banking timelines.
                 </p>
-              </div>
+              </LegalSection>
 
-              <div className={section} id="volunteer-conduct">
-                <LegalSectionRule variant="amber" />
-                <h2 className={h2}>Volunteer responsibilities</h2>
+              <LegalSection
+                id="volunteer-conduct"
+                ruleVariant="amber"
+                title="Volunteer responsibilities"
+              >
                 <p className={body}>As a volunteer, you agree to:</p>
                 <ul className={list}>
                   <li>
@@ -233,22 +278,26 @@ export default function Content() {
                   </li>
                   <li>Report concerns or policy violations through proper channels</li>
                 </ul>
-              </div>
+              </LegalSection>
 
-              <div className={section} id="code-of-conduct">
-                <LegalSectionRule variant="teal" />
-                <h2 className={h2}>Code of conduct</h2>
+              <LegalSection
+                id="code-of-conduct"
+                ruleVariant="teal"
+                title="Code of conduct"
+              >
                 <p className={body}>
                   Participants are expected to behave professionally and respect
                   everyone&apos;s dignity—especially patients and community
                   members. Harassment, discrimination, or disruptive conduct may
                   result in removal from programs or sites.
                 </p>
-              </div>
+              </LegalSection>
 
-              <div className={section} id="intellectual-property">
-                <LegalSectionRule variant="amber" />
-                <h2 className={h2}>Intellectual property</h2>
+              <LegalSection
+                id="intellectual-property"
+                ruleVariant="amber"
+                title="Intellectual property"
+              >
                 <p className={body}>
                   The website, trademarks (including Akomapa and Nkwapa
                   branding where applicable), curriculum materials, documentation,
@@ -262,11 +311,13 @@ export default function Content() {
                   reverse engineer our materials or applications except where law
                   permits or we give written permission.
                 </p>
-              </div>
+              </LegalSection>
 
-              <div className={section} id="liability">
-                <LegalSectionRule variant="teal" />
-                <h2 className={h2}>Limitation of liability</h2>
+              <LegalSection
+                id="liability"
+                ruleVariant="teal"
+                title="Limitation of liability"
+              >
                 <p className={body}>
                   To the fullest extent permitted by law, Akomapa Health
                   Foundation and its directors, officers, volunteers, and
@@ -282,35 +333,34 @@ export default function Content() {
                   paid us in the twelve months before the claim or (b) one
                   hundred U.S. dollars, except where prohibited.
                 </p>
-              </div>
+              </LegalSection>
 
-              <div className={section} id="termination">
-                <LegalSectionRule variant="amber" />
-                <h2 className={h2}>Suspension and termination</h2>
+              <LegalSection
+                id="termination"
+                ruleVariant="amber"
+                title="Suspension and termination"
+              >
                 <p className={body}>
                   We may suspend or terminate access to our website, applications,
                   or programs when we reasonably believe there is a violation of
                   these Terms, risk to participants, or legal obligation.
                 </p>
-              </div>
+              </LegalSection>
 
-              <div className={section} id="changes">
-                <LegalSectionRule variant="teal" />
-                <h2 className={h2}>Changes to these Terms</h2>
+              <LegalSection
+                id="changes"
+                ruleVariant="teal"
+                title="Changes to these Terms"
+              >
                 <p className={body}>
                   We may update these Terms as our services grow. We will post
                   revisions on this page and update the &quot;Last updated&quot;
                   date. Continued use after changes become effective constitutes
                   acceptance unless applicable law requires additional steps.
                 </p>
-              </div>
+              </LegalSection>
 
-              <div
-                className="space-y-4 border-t border-[#E6E7E7] pt-6 sm:space-y-6 dark:border-[#4F5554]"
-                id="contact"
-              >
-                <LegalSectionRule variant="amber" />
-                <h2 className={h2}>Contact</h2>
+              <LegalSection id="contact" ruleVariant="amber" title="Contact">
                 <p className={body}>
                   Questions about these Terms? Email{" "}
                   <a href="mailto:akomapahealth@gmail.com" className={link}>
@@ -322,7 +372,7 @@ export default function Content() {
                   </Link>
                   .
                 </p>
-              </div>
+              </LegalSection>
 
               <LegalLastUpdated date={LAST_UPDATED} />
             </LegalProseArticle>

--- a/src/app/(main)/terms/Content.tsx
+++ b/src/app/(main)/terms/Content.tsx
@@ -1,393 +1,334 @@
 import { FadeIn } from "@/components/animations";
-import { HeroEntranceH1, HeroEntranceP } from "@/components/motion/HeroEntrance";
 import Breadcrumb from "@/components/layout/Breadcrumb";
+import {
+  LegalLastUpdated,
+  LegalProseArticle,
+  LegalSectionRule,
+  legalBodyClassName as body,
+  legalHeadingClassName as h2,
+  legalLinkClassName as link,
+  legalListClassName as list,
+  legalSectionClassName as section,
+} from "@/components/legal/LegalDocumentPrimitives";
+import { PublicationArticleMeasure } from "@/components/publication";
+import {
+  EditorialBand,
+  EditorialEyebrow,
+  EditorialHeading,
+  EditorialLead,
+} from "@/components/shared/EditorialPrimitives";
 import Link from "next/link";
 
 const LAST_UPDATED = "May 9, 2026";
 
-const body =
-  "text-base sm:text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed";
-const h2 =
-  "text-xl sm:text-2xl md:text-3xl font-bold text-[#1C1F1E] dark:text-[#FCFAEF]";
-const list =
-  `${body} list-disc list-outside space-y-2 pl-6 sm:pl-7 [&_strong]:text-[#1C1F1E] dark:[&_strong]:text-[#FCFAEF]`;
-
-function SectionRule({ variant }: { variant: "teal" | "amber" }) {
-  const bg = variant === "teal" ? "bg-[#0097b2]" : "bg-[#eeba2b]";
-  return (
-    <div className="flex items-center gap-2 mb-4" aria-hidden>
-      <div className={`h-1 w-8 ${bg} rounded-full`} />
-      <div className={`h-1 w-1 ${bg} rounded-full`} />
-    </div>
-  );
-}
-
 export default function Content() {
   return (
-    <>
+    <div data-rebrand-page className="bg-background text-foreground">
       <div className="site-container mx-auto">
         <Breadcrumb />
       </div>
 
-      <section
-        className="relative py-16 sm:py-20 md:py-28 bg-gradient-to-r from-[#0097b2] to-[#0F4C5C] overflow-hidden"
+      <EditorialBand
+        tone="teal"
+        aria-labelledby="terms-of-service-title"
+        className="border-b border-[#FCFAEF]/20 bg-[#0F4C5C]"
+        containerClassName="py-14 sm:py-16 md:py-20 lg:py-24"
+      >
+        <FadeIn>
+          <EditorialEyebrow tone="gold" className="text-[#F5C94D]">
+            Legal
+          </EditorialEyebrow>
+          <EditorialHeading
+            as="h1"
+            id="terms-of-service-title"
+            className="mt-5 max-w-4xl text-[2.35rem] text-[#FCFAEF] sm:text-[3rem] md:text-[3.7rem] lg:text-[4.35rem]"
+          >
+            Terms of Service
+          </EditorialHeading>
+          <EditorialLead className="mt-6 max-w-3xl text-[#FCFAEF]/88 dark:text-[#FCFAEF]/88">
+            These terms govern your use of our website, digital services,
+            donations, and applications to participate in Akomapa programs.
+          </EditorialLead>
+        </FadeIn>
+      </EditorialBand>
+
+      <EditorialBand
+        tone="cream"
+        marker="01"
         aria-labelledby="terms-of-service-title"
       >
-        <div className="absolute top-0 right-0 w-64 h-64 bg-[#FCFAEF]/10 rounded-full -translate-y-1/2 translate-x-1/2 blur-3xl" />
-        <div className="absolute bottom-0 left-0 w-96 h-96 bg-[#FCFAEF]/10 rounded-full translate-y-1/2 -translate-x-1/2 blur-3xl" />
+        <FadeIn amount="some">
+          <PublicationArticleMeasure>
+            <LegalProseArticle labelledBy="terms-of-service-title">
+              <div className="space-y-4 sm:space-y-6" id="acceptance">
+                <LegalSectionRule variant="teal" />
+                <h2 className={h2}>Agreement to these terms</h2>
+                <p className={body}>
+                  By accessing{" "}
+                  <strong>www.akomapahealth.org</strong> or related sites we
+                  operate, donating, submitting forms, or applying to volunteer
+                  or participate in our programs, you agree to these Terms of
+                  Service and our{" "}
+                  <Link href="/privacy" className={link}>
+                    Privacy Policy
+                  </Link>
+                  . If you do not agree, please discontinue use of our digital
+                  services.
+                </p>
+                <p className={body}>
+                  <strong>Nkwapa EMR:</strong> Nkwapa is an electronic medical
+                  records platform we develop for clinical environments. It may
+                  be offered in beta or evolving releases. When you access
+                  Nkwapa or other regulated clinical tools, supplemental terms,
+                  privacy notices, or institutional agreements may apply in
+                  addition to these Terms.
+                </p>
+              </div>
 
-        <div className="site-container mx-auto px-4 sm:px-6 relative z-10">
-          <div className="max-w-5xl pt-4 sm:pt-8">
-            <HeroEntranceH1
-              id="terms-of-service-title"
-              className="text-3xl sm:text-4xl md:text-6xl lg:text-7xl font-light text-[#FCFAEF] mb-6 leading-tight"
-            >
-              Terms of Service
-            </HeroEntranceH1>
-            <HeroEntranceP
-              delay={0.1}
-              className="text-base sm:text-lg md:text-2xl text-[#FCFAEF]/80 font-light max-w-3xl"
-            >
-              These terms govern your use of our website, digital services,
-              donations, and applications to participate in Akomapa programs.
-            </HeroEntranceP>
-          </div>
-        </div>
-      </section>
+              <div className={section} id="acceptable-use">
+                <LegalSectionRule variant="amber" />
+                <h2 className={h2}>Acceptable use</h2>
+                <p className={body}>
+                  You may use our digital services only for lawful, respectful
+                  purposes. Without limiting other obligations, you agree not to:
+                </p>
+                <ul className={list}>
+                  <li>
+                    Violate applicable laws or infringe anyone&apos;s rights
+                  </li>
+                  <li>
+                    Attempt to disrupt, scrape, overload, or probe our systems,
+                    APIs, or forms beyond ordinary browsing or legitimate
+                    submissions
+                  </li>
+                  <li>
+                    Misrepresent your identity, affiliation, or qualifications
+                  </li>
+                  <li>
+                    Collect personal information about volunteers, patients, or
+                    staff without authorization
+                  </li>
+                  <li>
+                    Use Akomapa or Nkwapa names, logos, or messaging in a way
+                    that implies endorsement you do not have
+                  </li>
+                  <li>
+                    Interfere with clinics, partner institutions, or community
+                    events coordinated through our programs
+                  </li>
+                </ul>
+              </div>
 
-      <section className="py-16 md:py-24 bg-[#FCFAEF] dark:bg-[#1C1F1E]">
-        <div className="site-container mx-auto px-4 sm:px-6">
-          <div className="max-w-4xl mx-auto">
-            <FadeIn
-              amount="some"
-              className="bg-white dark:bg-[#2F3332] rounded-2xl shadow-xl p-6 sm:p-8 md:p-10"
-            >
-              <article
-                className="max-w-prose mx-auto space-y-8 sm:space-y-10"
-                aria-labelledby="terms-of-service-title"
+              <div className={section} id="informational-disclaimer">
+                <LegalSectionRule variant="teal" />
+                <h2 className={h2}>Informational content—not medical advice</h2>
+                <p className={body}>
+                  Materials on this website—including articles, stories,
+                  research summaries, and program descriptions—are provided for
+                  general information and inspiration. They are{" "}
+                  <strong>not medical advice, diagnosis, or treatment</strong>.
+                  Always seek guidance from a qualified clinician for personal
+                  health decisions.
+                </p>
+                <p className={body}>
+                  <strong>Not for emergencies.</strong> If you believe you or
+                  someone else is experiencing a medical emergency, contact
+                  local emergency services immediately. Do not rely on email,
+                  contact forms, or website content for urgent care.
+                </p>
+              </div>
+
+              <div className={section} id="healthcare-limitations">
+                <LegalSectionRule variant="amber" />
+                <h2 className={h2}>Healthcare information and relationships</h2>
+                <p className={body}>
+                  Browsing our website or signing up for newsletters{" "}
+                  <strong>does not create</strong> a clinician–patient or other
+                  treatment relationship with Akomapa Health Foundation.
+                  Volunteers and staff who participate in programs must follow
+                  partner policies, professional ethics, and privacy rules such
+                  as HIPAA where they apply.
+                </p>
+              </div>
+
+              <div className={section} id="research">
+                <LegalSectionRule variant="teal" />
+                <h2 className={h2}>Research and innovation content</h2>
+                <p className={body}>
+                  We may describe pilots, partnerships, or learning agendas on
+                  our site. Those descriptions are illustrative and may change as
+                  work evolves. Unless we provide a separate informed consent or
+                  enrollment process, website content{" "}
+                  <strong>does not constitute an offer</strong> to enroll you in a
+                  research study or clinical trial.
+                </p>
+              </div>
+
+              <div className={section} id="applications">
+                <LegalSectionRule variant="amber" />
+                <h2 className={h2}>Applications and eligibility</h2>
+                <p className={body}>
+                  When you apply to volunteer, join leadership programs, or
+                  participate in selective offerings, you agree that:
+                </p>
+                <ul className={list}>
+                  <li>
+                    Information you submit is accurate to the best of your
+                    knowledge
+                  </li>
+                  <li>
+                    Selection is competitive and operational;{" "}
+                    <strong>we do not guarantee acceptance</strong>
+                  </li>
+                  <li>
+                    Partner schools, hospitals, or governments may impose
+                    additional requirements (immunizations, background checks,
+                    credentialing)
+                  </li>
+                  <li>
+                    We may defer or withdraw participation for safety,
+                    capacity, conduct, or compliance reasons
+                  </li>
+                </ul>
+              </div>
+
+              <div className={section} id="donations">
+                <LegalSectionRule variant="teal" />
+                <h2 className={h2}>Donations and payments</h2>
+                <p className={body}>
+                  Donations and certain partnership payments are processed
+                  through a certified payment processor. You authorize charges you
+                  initiate and agree to provide accurate billing information.
+                  Recurring donations continue until canceled according to the
+                  flow presented at checkout or by contacting us.
+                </p>
+                <p className={body}>
+                  If you believe a charge is incorrect, reach out to{" "}
+                  <a href="mailto:akomapahealth@gmail.com" className={link}>
+                    akomapahealth@gmail.com
+                  </a>{" "}
+                  promptly. Refunds, if any, are handled case by case and may
+                  depend on processor policies and banking timelines.
+                </p>
+              </div>
+
+              <div className={section} id="volunteer-conduct">
+                <LegalSectionRule variant="amber" />
+                <h2 className={h2}>Volunteer responsibilities</h2>
+                <p className={body}>As a volunteer, you agree to:</p>
+                <ul className={list}>
+                  <li>
+                    Provide truthful information in applications and updates
+                  </li>
+                  <li>
+                    Protect confidential patient and operations information
+                  </li>
+                  <li>
+                    Follow ethical, clinical, and safety guidelines from Akomapa
+                    and partner institutions
+                  </li>
+                  <li>
+                    Honor commitments or give timely notice when you cannot
+                    participate
+                  </li>
+                  <li>Report concerns or policy violations through proper channels</li>
+                </ul>
+              </div>
+
+              <div className={section} id="code-of-conduct">
+                <LegalSectionRule variant="teal" />
+                <h2 className={h2}>Code of conduct</h2>
+                <p className={body}>
+                  Participants are expected to behave professionally and respect
+                  everyone&apos;s dignity—especially patients and community
+                  members. Harassment, discrimination, or disruptive conduct may
+                  result in removal from programs or sites.
+                </p>
+              </div>
+
+              <div className={section} id="intellectual-property">
+                <LegalSectionRule variant="amber" />
+                <h2 className={h2}>Intellectual property</h2>
+                <p className={body}>
+                  The website, trademarks (including Akomapa and Nkwapa
+                  branding where applicable), curriculum materials, documentation,
+                  graphics, videos, software, and other content we provide are
+                  owned by Akomapa Health Foundation or our licensors. We grant
+                  you a limited, revocable license to view and download content
+                  for personal, non-commercial use consistent with these Terms.
+                </p>
+                <p className={body}>
+                  You may not copy, modify, distribute, publicly perform, or
+                  reverse engineer our materials or applications except where law
+                  permits or we give written permission.
+                </p>
+              </div>
+
+              <div className={section} id="liability">
+                <LegalSectionRule variant="teal" />
+                <h2 className={h2}>Limitation of liability</h2>
+                <p className={body}>
+                  To the fullest extent permitted by law, Akomapa Health
+                  Foundation and its directors, officers, volunteers, and
+                  partners are not liable for indirect, incidental, special,
+                  consequential, or punitive damages, or for loss of profits, data,
+                  or goodwill arising from your use of the website, donations,
+                  applications, or participation in programs—except where
+                  liability cannot be excluded under applicable law.
+                </p>
+                <p className={body}>
+                  Our total liability for any claim relating to these Terms or
+                  the website is limited to the greater of (a) the amount you
+                  paid us in the twelve months before the claim or (b) one
+                  hundred U.S. dollars, except where prohibited.
+                </p>
+              </div>
+
+              <div className={section} id="termination">
+                <LegalSectionRule variant="amber" />
+                <h2 className={h2}>Suspension and termination</h2>
+                <p className={body}>
+                  We may suspend or terminate access to our website, applications,
+                  or programs when we reasonably believe there is a violation of
+                  these Terms, risk to participants, or legal obligation.
+                </p>
+              </div>
+
+              <div className={section} id="changes">
+                <LegalSectionRule variant="teal" />
+                <h2 className={h2}>Changes to these Terms</h2>
+                <p className={body}>
+                  We may update these Terms as our services grow. We will post
+                  revisions on this page and update the &quot;Last updated&quot;
+                  date. Continued use after changes become effective constitutes
+                  acceptance unless applicable law requires additional steps.
+                </p>
+              </div>
+
+              <div
+                className="space-y-4 border-t border-[#E6E7E7] pt-6 sm:space-y-6 dark:border-[#4F5554]"
+                id="contact"
               >
-                <div className="space-y-4 sm:space-y-6" id="acceptance">
-                  <SectionRule variant="teal" />
-                  <h2 className={h2}>Agreement to these terms</h2>
-                  <p className={body}>
-                    By accessing{" "}
-                    <strong>www.akomapahealth.org</strong> or related sites we
-                    operate, donating, submitting forms, or applying to volunteer
-                    or participate in our programs, you agree to these Terms of
-                    Service and our{" "}
-                    <Link
-                      href="/privacy"
-                      className="text-[#0097b2] dark:text-[#66C4DC] hover:text-[#eeba2b] dark:hover:text-[#F5C94D] transition-colors font-medium underline-offset-2 hover:underline"
-                    >
-                      Privacy Policy
-                    </Link>
-                    . If you do not agree, please discontinue use of our digital
-                    services.
-                  </p>
-                  <p className={body}>
-                    <strong>Nkwapa EMR:</strong> Nkwapa is an electronic medical
-                    records platform we develop for clinical environments. It may
-                    be offered in beta or evolving releases. When you access
-                    Nkwapa or other regulated clinical tools, supplemental terms,
-                    privacy notices, or institutional agreements may apply in
-                    addition to these Terms.
-                  </p>
-                </div>
+                <LegalSectionRule variant="amber" />
+                <h2 className={h2}>Contact</h2>
+                <p className={body}>
+                  Questions about these Terms? Email{" "}
+                  <a href="mailto:akomapahealth@gmail.com" className={link}>
+                    akomapahealth@gmail.com
+                  </a>{" "}
+                  or visit our{" "}
+                  <Link href="/contact" className={link}>
+                    contact page
+                  </Link>
+                  .
+                </p>
+              </div>
 
-                <div
-                  className="space-y-4 sm:space-y-6 pt-6 border-t border-[#E6E7E7]/40 dark:border-[#4F5554]/40"
-                  id="acceptable-use"
-                >
-                  <SectionRule variant="amber" />
-                  <h2 className={h2}>Acceptable use</h2>
-                  <p className={body}>
-                    You may use our digital services only for lawful, respectful
-                    purposes. Without limiting other obligations, you agree not to:
-                  </p>
-                  <ul className={list}>
-                    <li>
-                      Violate applicable laws or infringe anyone&apos;s rights
-                    </li>
-                    <li>
-                      Attempt to disrupt, scrape, overload, or probe our systems,
-                      APIs, or forms beyond ordinary browsing or legitimate
-                      submissions
-                    </li>
-                    <li>
-                      Misrepresent your identity, affiliation, or qualifications
-                    </li>
-                    <li>
-                      Collect personal information about volunteers, patients, or
-                      staff without authorization
-                    </li>
-                    <li>
-                      Use Akomapa or Nkwapa names, logos, or messaging in a way
-                      that implies endorsement you do not have
-                    </li>
-                    <li>
-                      Interfere with clinics, partner institutions, or community
-                      events coordinated through our programs
-                    </li>
-                  </ul>
-                </div>
-
-                <div
-                  className="space-y-4 sm:space-y-6 pt-6 border-t border-[#E6E7E7]/40 dark:border-[#4F5554]/40"
-                  id="informational-disclaimer"
-                >
-                  <SectionRule variant="teal" />
-                  <h2 className={h2}>Informational content—not medical advice</h2>
-                  <p className={body}>
-                    Materials on this website—including articles, stories,
-                    research summaries, and program descriptions—are provided for
-                    general information and inspiration. They are{" "}
-                    <strong>not medical advice, diagnosis, or treatment</strong>.
-                    Always seek guidance from a qualified clinician for personal
-                    health decisions.
-                  </p>
-                  <p className={body}>
-                    <strong>Not for emergencies.</strong> If you believe you or
-                    someone else is experiencing a medical emergency, contact
-                    local emergency services immediately. Do not rely on email,
-                    contact forms, or website content for urgent care.
-                  </p>
-                </div>
-
-                <div
-                  className="space-y-4 sm:space-y-6 pt-6 border-t border-[#E6E7E7]/40 dark:border-[#4F5554]/40"
-                  id="healthcare-limitations"
-                >
-                  <SectionRule variant="amber" />
-                  <h2 className={h2}>Healthcare information and relationships</h2>
-                  <p className={body}>
-                    Browsing our website or signing up for newsletters{" "}
-                    <strong>does not create</strong> a clinician–patient or other
-                    treatment relationship with Akomapa Health Foundation.
-                    Volunteers and staff who participate in programs must follow
-                    partner policies, professional ethics, and privacy rules such
-                    as HIPAA where they apply.
-                  </p>
-                </div>
-
-                <div
-                  className="space-y-4 sm:space-y-6 pt-6 border-t border-[#E6E7E7]/40 dark:border-[#4F5554]/40"
-                  id="research"
-                >
-                  <SectionRule variant="teal" />
-                  <h2 className={h2}>Research and innovation content</h2>
-                  <p className={body}>
-                    We may describe pilots, partnerships, or learning agendas on
-                    our site. Those descriptions are illustrative and may change as
-                    work evolves. Unless we provide a separate informed consent or
-                    enrollment process, website content{" "}
-                    <strong>does not constitute an offer</strong> to enroll you in a
-                    research study or clinical trial.
-                  </p>
-                </div>
-
-                <div
-                  className="space-y-4 sm:space-y-6 pt-6 border-t border-[#E6E7E7]/40 dark:border-[#4F5554]/40"
-                  id="applications"
-                >
-                  <SectionRule variant="amber" />
-                  <h2 className={h2}>Applications and eligibility</h2>
-                  <p className={body}>
-                    When you apply to volunteer, join leadership programs, or
-                    participate in selective offerings, you agree that:
-                  </p>
-                  <ul className={list}>
-                    <li>
-                      Information you submit is accurate to the best of your
-                      knowledge
-                    </li>
-                    <li>
-                      Selection is competitive and operational;{" "}
-                      <strong>we do not guarantee acceptance</strong>
-                    </li>
-                    <li>
-                      Partner schools, hospitals, or governments may impose
-                      additional requirements (immunizations, background checks,
-                      credentialing)
-                    </li>
-                    <li>
-                      We may defer or withdraw participation for safety,
-                      capacity, conduct, or compliance reasons
-                    </li>
-                  </ul>
-                </div>
-
-                <div
-                  className="space-y-4 sm:space-y-6 pt-6 border-t border-[#E6E7E7]/40 dark:border-[#4F5554]/40"
-                  id="donations"
-                >
-                  <SectionRule variant="teal" />
-                  <h2 className={h2}>Donations and payments</h2>
-                  <p className={body}>
-                    Donations and certain partnership payments are processed
-                    through a certified payment processor. You authorize charges you
-                    initiate and agree to provide accurate billing information.
-                    Recurring donations continue until canceled according to the
-                    flow presented at checkout or by contacting us.
-                  </p>
-                  <p className={body}>
-                    If you believe a charge is incorrect, reach out to{" "}
-                    <a
-                      href="mailto:akomapahealth@gmail.com"
-                      className="text-[#0097b2] dark:text-[#66C4DC] hover:text-[#eeba2b] dark:hover:text-[#F5C94D] transition-colors font-medium underline-offset-2 hover:underline"
-                    >
-                      akomapahealth@gmail.com
-                    </a>{" "}
-                    promptly. Refunds, if any, are handled case by case and may
-                    depend on processor policies and banking timelines.
-                  </p>
-                </div>
-
-                <div
-                  className="space-y-4 sm:space-y-6 pt-6 border-t border-[#E6E7E7]/40 dark:border-[#4F5554]/40"
-                  id="volunteer-conduct"
-                >
-                  <SectionRule variant="amber" />
-                  <h2 className={h2}>Volunteer responsibilities</h2>
-                  <p className={body}>As a volunteer, you agree to:</p>
-                  <ul className={list}>
-                    <li>
-                      Provide truthful information in applications and updates
-                    </li>
-                    <li>
-                      Protect confidential patient and operations information
-                    </li>
-                    <li>
-                      Follow ethical, clinical, and safety guidelines from Akomapa
-                      and partner institutions
-                    </li>
-                    <li>
-                      Honor commitments or give timely notice when you cannot
-                      participate
-                    </li>
-                    <li>Report concerns or policy violations through proper channels</li>
-                  </ul>
-                </div>
-
-                <div
-                  className="space-y-4 sm:space-y-6 pt-6 border-t border-[#E6E7E7]/40 dark:border-[#4F5554]/40"
-                  id="code-of-conduct"
-                >
-                  <SectionRule variant="teal" />
-                  <h2 className={h2}>Code of conduct</h2>
-                  <p className={body}>
-                    Participants are expected to behave professionally and respect
-                    everyone&apos;s dignity—especially patients and community
-                    members. Harassment, discrimination, or disruptive conduct may
-                    result in removal from programs or sites.
-                  </p>
-                </div>
-
-                <div
-                  className="space-y-4 sm:space-y-6 pt-6 border-t border-[#E6E7E7]/40 dark:border-[#4F5554]/40"
-                  id="intellectual-property"
-                >
-                  <SectionRule variant="amber" />
-                  <h2 className={h2}>Intellectual property</h2>
-                  <p className={body}>
-                    The website, trademarks (including Akomapa and Nkwapa
-                    branding where applicable), curriculum materials, documentation,
-                    graphics, videos, software, and other content we provide are
-                    owned by Akomapa Health Foundation or our licensors. We grant
-                    you a limited, revocable license to view and download content
-                    for personal, non-commercial use consistent with these Terms.
-                  </p>
-                  <p className={body}>
-                    You may not copy, modify, distribute, publicly perform, or
-                    reverse engineer our materials or applications except where law
-                    permits or we give written permission.
-                  </p>
-                </div>
-
-                <div
-                  className="space-y-4 sm:space-y-6 pt-6 border-t border-[#E6E7E7]/40 dark:border-[#4F5554]/40"
-                  id="liability"
-                >
-                  <SectionRule variant="teal" />
-                  <h2 className={h2}>Limitation of liability</h2>
-                  <p className={body}>
-                    To the fullest extent permitted by law, Akomapa Health
-                    Foundation and its directors, officers, volunteers, and
-                    partners are not liable for indirect, incidental, special,
-                    consequential, or punitive damages, or for loss of profits, data,
-                    or goodwill arising from your use of the website, donations,
-                    applications, or participation in programs—except where
-                    liability cannot be excluded under applicable law.
-                  </p>
-                  <p className={body}>
-                    Our total liability for any claim relating to these Terms or
-                    the website is limited to the greater of (a) the amount you
-                    paid us in the twelve months before the claim or (b) one
-                    hundred U.S. dollars, except where prohibited.
-                  </p>
-                </div>
-
-                <div
-                  className="space-y-4 sm:space-y-6 pt-6 border-t border-[#E6E7E7]/40 dark:border-[#4F5554]/40"
-                  id="termination"
-                >
-                  <SectionRule variant="amber" />
-                  <h2 className={h2}>Suspension and termination</h2>
-                  <p className={body}>
-                    We may suspend or terminate access to our website, applications,
-                    or programs when we reasonably believe there is a violation of
-                    these Terms, risk to participants, or legal obligation.
-                  </p>
-                </div>
-
-                <div
-                  className="space-y-4 sm:space-y-6 pt-6 border-t border-[#E6E7E7]/40 dark:border-[#4F5554]/40"
-                  id="changes"
-                >
-                  <SectionRule variant="teal" />
-                  <h2 className={h2}>Changes to these Terms</h2>
-                  <p className={body}>
-                    We may update these Terms as our services grow. We will post
-                    revisions on this page and update the &quot;Last updated&quot;
-                    date. Continued use after changes become effective constitutes
-                    acceptance unless applicable law requires additional steps.
-                  </p>
-                </div>
-
-                <div
-                  className="space-y-4 sm:space-y-6 pt-6 border-t border-[#E6E7E7] dark:border-[#4F5554]"
-                  id="contact"
-                >
-                  <SectionRule variant="amber" />
-                  <h2 className={h2}>Contact</h2>
-                  <p className={body}>
-                    Questions about these Terms? Email{" "}
-                    <a
-                      href="mailto:akomapahealth@gmail.com"
-                      className="text-[#0097b2] dark:text-[#66C4DC] hover:text-[#eeba2b] dark:hover:text-[#F5C94D] transition-colors font-medium underline-offset-2 hover:underline"
-                    >
-                      akomapahealth@gmail.com
-                    </a>{" "}
-                    or visit our{" "}
-                    <Link
-                      href="/contact"
-                      className="text-[#0097b2] dark:text-[#66C4DC] hover:text-[#eeba2b] dark:hover:text-[#F5C94D] transition-colors font-medium underline-offset-2 hover:underline"
-                    >
-                      contact page
-                    </Link>
-                    .
-                  </p>
-                </div>
-
-                <div className="pt-6 border-t border-[#E6E7E7] dark:border-[#4F5554]">
-                  <p className="text-sm sm:text-base text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
-                    Last updated: {LAST_UPDATED}
-                  </p>
-                </div>
-              </article>
-            </FadeIn>
-          </div>
-        </div>
-      </section>
-    </>
+              <LegalLastUpdated date={LAST_UPDATED} />
+            </LegalProseArticle>
+          </PublicationArticleMeasure>
+        </FadeIn>
+      </EditorialBand>
+    </div>
   );
 }

--- a/src/app/(main)/terms/__tests__/TermsContentEditorial.test.tsx
+++ b/src/app/(main)/terms/__tests__/TermsContentEditorial.test.tsx
@@ -70,10 +70,15 @@ describe("Terms Content editorial contracts", () => {
       expect(document.getElementById(id)).toBeTruthy();
     }
 
-    expect(screen.getByText("Last updated: May 9, 2026")).toBeInTheDocument();
+    expect(
+      screen.getAllByText("Last updated: May 9, 2026").length,
+    ).toBeGreaterThanOrEqual(1);
 
     expect(
-      screen.getByRole("link", { name: "Privacy Policy" }),
+      screen
+        .getByRole("heading", { level: 2, name: "Agreement to these terms" })
+        .closest("section")
+        ?.querySelector('a[href="/privacy"]'),
     ).toHaveAttribute("href", "/privacy");
 
     const mailLinks = screen.getAllByRole("link", {
@@ -89,15 +94,22 @@ describe("Terms Content editorial contracts", () => {
     ).toHaveAttribute("href", "/contact");
 
     expect(screen.getByText("www.akomapahealth.org")).toBeInTheDocument();
+    expect(
+      screen.getByRole("navigation", { name: "On this page" }),
+    ).toBeInTheDocument();
   });
 
-  it("uses a cream body band with restrained section rules", () => {
+  it("uses a cream body band with semantic legal sections and restrained rules", () => {
     render(<Content />);
 
     const bodyBand = document.querySelector(
       '[data-editorial-band][data-editorial-tone="cream"]',
     );
     expect(bodyBand).toBeTruthy();
+
+    expect(document.querySelectorAll("[data-legal-section]").length).toBe(
+      termsHeadings.length,
+    );
 
     const rules = document.querySelectorAll("[data-legal-section-rule]");
     expect(rules.length).toBeGreaterThanOrEqual(termsHeadings.length);

--- a/src/app/(main)/terms/__tests__/TermsContentEditorial.test.tsx
+++ b/src/app/(main)/terms/__tests__/TermsContentEditorial.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import Content from "../Content";
+
+const termsHeadings = [
+  "Agreement to these terms",
+  "Acceptable use",
+  "Informational content—not medical advice",
+  "Healthcare information and relationships",
+  "Research and innovation content",
+  "Applications and eligibility",
+  "Donations and payments",
+  "Volunteer responsibilities",
+  "Code of conduct",
+  "Intellectual property",
+  "Limitation of liability",
+  "Suspension and termination",
+  "Changes to these Terms",
+  "Contact",
+] as const;
+
+const termsSectionIds = [
+  "acceptance",
+  "acceptable-use",
+  "informational-disclaimer",
+  "healthcare-limitations",
+  "research",
+  "applications",
+  "donations",
+  "volunteer-conduct",
+  "code-of-conduct",
+  "intellectual-property",
+  "liability",
+  "termination",
+  "changes",
+  "contact",
+] as const;
+
+describe("Terms Content editorial contracts", () => {
+  it("renders one h1 on a flat deep-teal editorial hero without gradient or card chrome", () => {
+    const { container } = render(<Content />);
+
+    const heading = screen.getByRole("heading", {
+      level: 1,
+      name: "Terms of Service",
+    });
+    expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
+
+    const hero = heading.closest("[data-editorial-band]");
+    expect(hero).toHaveAttribute("data-editorial-tone", "teal");
+    expect(hero?.className).toContain("bg-[#0F4C5C]");
+    expect(hero?.className).not.toContain("gradient");
+    expect(hero?.className).not.toContain("blur-3xl");
+
+    expect(container.innerHTML).not.toContain("shadow-xl");
+    expect(container.querySelector("[data-publication-article-measure]")).toBeTruthy();
+    expect(container.querySelector("[data-legal-prose-article]")).toBeTruthy();
+  });
+
+  it("preserves approved terms headings, section anchors, date, and links", () => {
+    render(<Content />);
+
+    for (const title of termsHeadings) {
+      expect(
+        screen.getByRole("heading", { level: 2, name: title }),
+      ).toBeInTheDocument();
+    }
+
+    for (const id of termsSectionIds) {
+      expect(document.getElementById(id)).toBeTruthy();
+    }
+
+    expect(screen.getByText("Last updated: May 9, 2026")).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("link", { name: "Privacy Policy" }),
+    ).toHaveAttribute("href", "/privacy");
+
+    const mailLinks = screen.getAllByRole("link", {
+      name: "akomapahealth@gmail.com",
+    });
+    expect(mailLinks.length).toBeGreaterThanOrEqual(2);
+    for (const link of mailLinks) {
+      expect(link).toHaveAttribute("href", "mailto:akomapahealth@gmail.com");
+    }
+
+    expect(
+      screen.getByRole("link", { name: "contact page" }),
+    ).toHaveAttribute("href", "/contact");
+
+    expect(screen.getByText("www.akomapahealth.org")).toBeInTheDocument();
+  });
+
+  it("uses a cream body band with restrained section rules", () => {
+    render(<Content />);
+
+    const bodyBand = document.querySelector(
+      '[data-editorial-band][data-editorial-tone="cream"]',
+    );
+    expect(bodyBand).toBeTruthy();
+
+    const rules = document.querySelectorAll("[data-legal-section-rule]");
+    expect(rules.length).toBeGreaterThanOrEqual(termsHeadings.length);
+    for (const rule of rules) {
+      expect(rule).toHaveAttribute("aria-hidden", "true");
+    }
+  });
+});

--- a/src/app/__tests__/not-found.test.tsx
+++ b/src/app/__tests__/not-found.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("framer-motion", async () => {
+  const actual = await vi.importActual<typeof import("framer-motion")>(
+    "framer-motion",
+  );
+  return {
+    ...actual,
+    useReducedMotion: () => true,
+  };
+});
+
+vi.mock("next/dynamic", () => ({
+  __esModule: true,
+  default: () => () => null,
+}));
+
+vi.mock("@/components/layout/Header", () => ({
+  __esModule: true,
+  default: () => <header>Header</header>,
+}));
+
+vi.mock("@/components/layout/Footer", () => ({
+  __esModule: true,
+  default: () => <footer>Footer</footer>,
+}));
+
+vi.mock("@/components/layout/SkipToMainContent", () => ({
+  __esModule: true,
+  default: () => <a href="#main-content">Skip to main content</a>,
+}));
+
+import NotFound from "../not-found";
+
+describe("NotFound page", () => {
+  it("renders accessible not-found recovery without loading Lottie under reduced motion", () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    render(<NotFound />);
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Page Not Found" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Back to Homepage" }),
+    ).toHaveAttribute("href", "/");
+    expect(
+      screen.getByRole("navigation", { name: "Helpful links" }),
+    ).toBeInTheDocument();
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    fetchSpy.mockRestore();
+  });
+});

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -2,32 +2,63 @@
 
 import { useEffect, useState } from "react";
 import dynamic from "next/dynamic";
-import Link from "next/link";
+import { useReducedMotion } from "framer-motion";
 import Header from "@/components/layout/Header";
 import Footer from "@/components/layout/Footer";
 import SkipToMainContent from "@/components/layout/SkipToMainContent";
-import { PublicCta } from "@/components/shared/PublicPagePrimitives";
+import { RouteNotFoundState } from "@/components/shared/RouteBoundaryPrimitives";
 
 // Lottie ships ~30kB of runtime. Defer it so a hard-404 doesn't pay the cost
 // upfront from any other route's chunk graph.
 const Lottie = dynamic(() => import("lottie-react"), { ssr: false });
 
-const recoveryLinks = [
-  { href: "/get-involved", label: "Get Involved" },
-  { href: "/community-hubs", label: "Community Health Hubs" },
-  { href: "/programs", label: "Programs" },
-  { href: "/contact", label: "Contact" },
-] as const;
-
 export default function NotFound() {
   const [animationData, setAnimationData] = useState<unknown>(null);
+  const shouldReduceMotion = useReducedMotion();
 
   useEffect(() => {
+    if (shouldReduceMotion) {
+      setAnimationData(null);
+      return;
+    }
+
+    let cancelled = false;
+
     fetch("/Error 404.json")
       .then((res) => res.json())
-      .then((data) => setAnimationData(data))
+      .then((data) => {
+        if (!cancelled) {
+          setAnimationData(data);
+        }
+      })
       .catch((err) => console.error("Failed to load animation:", err));
-  }, []);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [shouldReduceMotion]);
+
+  const media =
+    shouldReduceMotion === true ? (
+      <div
+        className="mx-auto mb-8 aspect-[4/3] max-w-md rounded-md border border-[#E6E7E7]/50 bg-[#FCFAEF] dark:border-[#4F5554]/50 dark:bg-[#1C1F1E]"
+        aria-hidden="true"
+      />
+    ) : animationData !== null ? (
+      <div className="mx-auto mb-8 max-w-md" aria-hidden="true">
+        <Lottie
+          animationData={animationData as object}
+          loop
+          className="h-auto w-full"
+          aria-hidden="true"
+        />
+      </div>
+    ) : (
+      <div
+        className="mx-auto mb-8 aspect-[4/3] max-w-md rounded-md bg-muted/40"
+        aria-hidden="true"
+      />
+    );
 
   return (
     <div className="flex min-h-screen flex-col bg-background text-foreground">
@@ -36,60 +67,9 @@ export default function NotFound() {
       <main
         id="main-content"
         tabIndex={-1}
-        className="flex flex-1 items-center justify-center px-4 py-16 sm:py-24 outline-none"
+        className="flex flex-1 items-center justify-center px-4 py-16 outline-none sm:py-24"
       >
-        <div className="mx-auto max-w-lg text-center">
-          {animationData !== null ? (
-            <div className="mx-auto mb-8 max-w-md">
-              <Lottie
-                animationData={animationData as object}
-                loop
-                className="h-auto w-full"
-                aria-hidden="true"
-              />
-            </div>
-          ) : (
-            <div
-              className="mx-auto mb-8 max-w-md aspect-[4/3] animate-pulse rounded-2xl bg-muted/40"
-              aria-hidden="true"
-            />
-          )}
-
-          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-            404
-          </p>
-          <h1 className="mt-3 font-heading text-3xl font-bold text-foreground sm:text-4xl">
-            Page Not Found
-          </h1>
-          <p className="mt-4 text-base leading-relaxed text-muted-foreground">
-            We couldn&apos;t find the page you&apos;re looking for. It may have
-            been moved, renamed, or the URL might be mistyped.
-          </p>
-
-          <div className="mt-8 flex justify-center">
-            <PublicCta href="/" variant="teal" icon={false}>
-              Back to Homepage
-            </PublicCta>
-          </div>
-
-          <nav className="mt-10" aria-label="Helpful links">
-            <p className="text-sm font-medium text-foreground">
-              Try one of these instead
-            </p>
-            <ul className="mt-4 flex flex-wrap justify-center gap-x-6 gap-y-3">
-              {recoveryLinks.map(({ href, label }) => (
-                <li key={href}>
-                  <Link
-                    href={href}
-                    className="text-sm font-medium text-[#0097b2] underline-offset-4 transition-colors hover:text-[#eeba2b] hover:underline dark:text-[#66C4DC] dark:hover:text-[#F5C94D]"
-                  >
-                    {label}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </nav>
-        </div>
+        <RouteNotFoundState media={media} />
       </main>
       <Footer />
     </div>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -41,11 +41,11 @@ export default function NotFound() {
   const media =
     shouldReduceMotion === true ? (
       <div
-        className="mx-auto mb-8 aspect-[4/3] max-w-md rounded-md border border-[#E6E7E7]/50 bg-[#FCFAEF] dark:border-[#4F5554]/50 dark:bg-[#1C1F1E]"
+        className="mx-auto mb-8 aspect-[4/3] max-w-sm rounded-md border border-[#E6E7E7]/50 bg-white dark:border-[#4F5554]/50 dark:bg-[#1C1F1E]"
         aria-hidden="true"
       />
     ) : animationData !== null ? (
-      <div className="mx-auto mb-8 max-w-md" aria-hidden="true">
+      <div className="mx-auto mb-2 max-w-md" aria-hidden="true">
         <Lottie
           animationData={animationData as object}
           loop
@@ -55,19 +55,19 @@ export default function NotFound() {
       </div>
     ) : (
       <div
-        className="mx-auto mb-8 aspect-[4/3] max-w-md rounded-md bg-muted/40"
+        className="mx-auto mb-8 aspect-[4/3] max-w-sm rounded-md bg-[#E6E7E7]/40 dark:bg-[#4F5554]/30"
         aria-hidden="true"
       />
     );
 
   return (
-    <div className="flex min-h-screen flex-col bg-background text-foreground">
+    <div className="flex min-h-screen flex-col bg-[#FCFAEF] text-foreground dark:bg-[#121514]">
       <SkipToMainContent />
       <Header />
       <main
         id="main-content"
         tabIndex={-1}
-        className="flex flex-1 items-center justify-center px-4 py-16 outline-none sm:py-24"
+        className="flex flex-1 items-center justify-center px-4 py-16 outline-none sm:px-6 sm:py-24"
       >
         <RouteNotFoundState media={media} />
       </main>

--- a/src/components/legal/LegalDocumentPrimitives.tsx
+++ b/src/components/legal/LegalDocumentPrimitives.tsx
@@ -1,0 +1,93 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Shared long-form prose helpers for Privacy and Terms.
+ * Visual-only: approved legal copy stays inline in each route Content file.
+ */
+
+export const legalBodyClassName =
+  "text-base sm:text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed break-words";
+
+export const legalHeadingClassName =
+  "font-heading text-xl sm:text-2xl md:text-3xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]";
+
+export const legalSubheadingClassName =
+  "text-lg sm:text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]";
+
+export const legalListClassName = cn(
+  legalBodyClassName,
+  "list-disc list-outside space-y-2 pl-6 sm:pl-7 [&_strong]:text-[#1C1F1E] dark:[&_strong]:text-[#FCFAEF]",
+);
+
+export const legalLinkClassName =
+  "font-medium text-[#0097b2] underline-offset-2 transition-colors hover:text-[#eeba2b] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] focus-visible:ring-offset-2 dark:text-[#66C4DC] dark:hover:text-[#F5C94D]";
+
+export const legalSectionClassName =
+  "space-y-4 sm:space-y-6 pt-6 border-t border-[#E6E7E7]/40 dark:border-[#4F5554]/40 first:border-t-0 first:pt-0";
+
+export type LegalSectionRuleVariant = "teal" | "amber";
+
+export function LegalSectionRule({
+  variant,
+  className,
+}: {
+  variant: LegalSectionRuleVariant;
+  className?: string;
+}) {
+  const bg = variant === "teal" ? "bg-[#0097b2]" : "bg-[#eeba2b]";
+
+  return (
+    <div
+      data-legal-section-rule
+      data-legal-section-rule-variant={variant}
+      className={cn("mb-4 flex items-center gap-2", className)}
+      aria-hidden="true"
+    >
+      <div className={cn("h-1 w-8 rounded-full", bg)} />
+      <div className={cn("h-1 w-1 rounded-full", bg)} />
+    </div>
+  );
+}
+
+export function LegalLastUpdated({
+  date,
+  className,
+}: {
+  date: string;
+  className?: string;
+}) {
+  return (
+    <div
+      data-legal-last-updated
+      className={cn(
+        "border-t border-[#E6E7E7] pt-6 dark:border-[#4F5554]",
+        className,
+      )}
+    >
+      <p className="text-sm text-[#2F3332]/80 sm:text-base dark:text-[#E6E7E7]/80">
+        Last updated: {date}
+      </p>
+    </div>
+  );
+}
+
+export function LegalProseArticle({
+  children,
+  labelledBy,
+  className,
+}: {
+  children: ReactNode;
+  labelledBy: string;
+  className?: string;
+}) {
+  return (
+    <article
+      data-legal-prose-article
+      aria-labelledby={labelledBy}
+      className={cn("space-y-8 sm:space-y-10", className)}
+    >
+      {children}
+    </article>
+  );
+}

--- a/src/components/legal/LegalDocumentPrimitives.tsx
+++ b/src/components/legal/LegalDocumentPrimitives.tsx
@@ -10,21 +10,21 @@ export const legalBodyClassName =
   "text-base sm:text-lg text-[#2F3332] dark:text-[#E6E7E7] leading-relaxed break-words";
 
 export const legalHeadingClassName =
-  "font-heading text-xl sm:text-2xl md:text-3xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]";
+  "font-heading text-xl sm:text-2xl md:text-[1.85rem] lg:text-[2.1rem] font-semibold leading-snug tracking-tight text-[#1C1F1E] dark:text-[#FCFAEF]";
 
 export const legalSubheadingClassName =
   "text-lg sm:text-xl font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]";
 
 export const legalListClassName = cn(
   legalBodyClassName,
-  "list-disc list-outside space-y-2 pl-6 sm:pl-7 [&_strong]:text-[#1C1F1E] dark:[&_strong]:text-[#FCFAEF]",
+  "list-disc list-outside space-y-2.5 pl-6 sm:pl-7 marker:text-[#0097b2] dark:marker:text-[#66C4DC] [&_strong]:text-[#1C1F1E] dark:[&_strong]:text-[#FCFAEF]",
 );
 
 export const legalLinkClassName =
   "font-medium text-[#0097b2] underline-offset-2 transition-colors hover:text-[#eeba2b] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] focus-visible:ring-offset-2 dark:text-[#66C4DC] dark:hover:text-[#F5C94D]";
 
 export const legalSectionClassName =
-  "space-y-4 sm:space-y-6 pt-6 border-t border-[#E6E7E7]/40 dark:border-[#4F5554]/40 first:border-t-0 first:pt-0";
+  "space-y-5 sm:space-y-6 border-t border-[#E6E7E7]/55 py-8 first:border-t-0 first:pt-2 sm:py-10 dark:border-[#4F5554]/55";
 
 export type LegalSectionRuleVariant = "teal" | "amber";
 
@@ -44,9 +44,94 @@ export function LegalSectionRule({
       className={cn("mb-4 flex items-center gap-2", className)}
       aria-hidden="true"
     >
-      <div className={cn("h-1 w-8 rounded-full", bg)} />
-      <div className={cn("h-1 w-1 rounded-full", bg)} />
+      <div className={cn("h-1 w-10 rounded-full", bg)} />
+      <div className={cn("h-1 w-1.5 rounded-full", bg)} />
+      <div className={cn("h-px flex-1 max-w-16 opacity-40", bg)} />
     </div>
+  );
+}
+
+export function LegalSection({
+  id,
+  title,
+  ruleVariant,
+  children,
+  className,
+}: {
+  id: string;
+  title: string;
+  ruleVariant: LegalSectionRuleVariant;
+  children: ReactNode;
+  className?: string;
+}) {
+  const headingId = `${id}-heading`;
+
+  return (
+    <section
+      id={id}
+      data-legal-section
+      aria-labelledby={headingId}
+      className={cn(legalSectionClassName, "scroll-mt-28", className)}
+    >
+      <header className="space-y-3">
+        <LegalSectionRule variant={ruleVariant} className="mb-0" />
+        <h2 id={headingId} className={legalHeadingClassName}>
+          {title}
+        </h2>
+      </header>
+      <div className="space-y-4 sm:space-y-5">{children}</div>
+    </section>
+  );
+}
+
+export type LegalContentsItem = {
+  href: `#${string}`;
+  label: string;
+};
+
+export function LegalContentsNav({
+  items,
+  className,
+}: {
+  items: readonly LegalContentsItem[];
+  className?: string;
+}) {
+  return (
+    <nav
+      data-legal-contents
+      aria-label="On this page"
+      className={cn(
+        "mb-2 border-y border-[#E6E7E7]/60 py-7 dark:border-[#4F5554]/60",
+        className,
+      )}
+    >
+      <p className="font-subheading text-xs font-bold uppercase tracking-[0.2em] text-[#0097b2] dark:text-[#66C4DC]">
+        On this page
+      </p>
+      <ol className="mt-5 grid list-none gap-x-8 gap-y-1 p-0 sm:grid-cols-2">
+        {items.map((item, index) => (
+          <li key={item.href}>
+            <a
+              href={item.href}
+              className={cn(
+                "group inline-flex min-h-11 w-full items-baseline gap-3 py-1 text-sm sm:text-base",
+                "text-[#2F3332] transition-colors hover:text-[#0097b2] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] focus-visible:ring-offset-2 dark:text-[#E6E7E7] dark:hover:text-[#66C4DC]",
+              )}
+            >
+              <span
+                className="shrink-0 font-subheading text-xs font-bold tabular-nums tracking-wider text-[#C9920F] dark:text-[#F5C94D]"
+                aria-hidden="true"
+              >
+                {String(index + 1).padStart(2, "0")}
+              </span>
+              <span className="text-left leading-snug underline-offset-4 group-hover:underline">
+                {item.label}
+              </span>
+            </a>
+          </li>
+        ))}
+      </ol>
+    </nav>
   );
 }
 
@@ -61,11 +146,14 @@ export function LegalLastUpdated({
     <div
       data-legal-last-updated
       className={cn(
-        "border-t border-[#E6E7E7] pt-6 dark:border-[#4F5554]",
+        "mt-2 border-t border-[#E6E7E7] pt-8 dark:border-[#4F5554]",
         className,
       )}
     >
-      <p className="text-sm text-[#2F3332]/80 sm:text-base dark:text-[#E6E7E7]/80">
+      <p className="font-subheading text-xs font-bold uppercase tracking-[0.18em] text-[#0097b2] dark:text-[#66C4DC]">
+        Document status
+      </p>
+      <p className="mt-2 text-sm text-[#2F3332]/80 sm:text-base dark:text-[#E6E7E7]/80">
         Last updated: {date}
       </p>
     </div>
@@ -85,7 +173,7 @@ export function LegalProseArticle({
     <article
       data-legal-prose-article
       aria-labelledby={labelledBy}
-      className={cn("space-y-8 sm:space-y-10", className)}
+      className={cn("space-y-0", className)}
     >
       {children}
     </article>

--- a/src/components/legal/__tests__/LegalDocumentPrimitives.test.tsx
+++ b/src/components/legal/__tests__/LegalDocumentPrimitives.test.tsx
@@ -1,8 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import {
+  LegalContentsNav,
   LegalLastUpdated,
   LegalProseArticle,
+  LegalSection,
   LegalSectionRule,
   legalBodyClassName,
   legalLinkClassName,
@@ -18,6 +20,44 @@ describe("LegalDocumentPrimitives", () => {
     expect(rule).toHaveAttribute("data-legal-section-rule-variant", "amber");
     expect(rule?.className).not.toContain("gradient");
     expect(rule?.className).not.toContain("shadow");
+  });
+
+  it("renders semantic legal sections with headings and section rules", () => {
+    render(
+      <LegalSection id="scope" ruleVariant="teal" title="Who we are">
+        <p className={legalBodyClassName}>Body copy</p>
+      </LegalSection>,
+    );
+
+    const section = document.getElementById("scope");
+    expect(section?.tagName).toBe("SECTION");
+    expect(section).toHaveAttribute("data-legal-section");
+    expect(
+      screen.getByRole("heading", { level: 2, name: "Who we are" }),
+    ).toHaveAttribute("id", "scope-heading");
+    expect(section?.querySelector("[data-legal-section-rule]")).toBeTruthy();
+  });
+
+  it("renders an on-this-page contents nav with numbered anchors", () => {
+    render(
+      <LegalContentsNav
+        items={[
+          { href: "#scope", label: "Who we are" },
+          { href: "#contact", label: "Contact us" },
+        ]}
+      />,
+    );
+
+    const nav = screen.getByRole("navigation", { name: "On this page" });
+    expect(nav).toHaveAttribute("data-legal-contents");
+    expect(screen.getByRole("link", { name: /Who we are/i })).toHaveAttribute(
+      "href",
+      "#scope",
+    );
+    expect(screen.getByRole("link", { name: /Contact us/i })).toHaveAttribute(
+      "href",
+      "#contact",
+    );
   });
 
   it("renders the last-updated line with the provided date", () => {

--- a/src/components/legal/__tests__/LegalDocumentPrimitives.test.tsx
+++ b/src/components/legal/__tests__/LegalDocumentPrimitives.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  LegalLastUpdated,
+  LegalProseArticle,
+  LegalSectionRule,
+  legalBodyClassName,
+  legalLinkClassName,
+} from "@/components/legal/LegalDocumentPrimitives";
+
+describe("LegalDocumentPrimitives", () => {
+  it("renders a decorative section rule that is hidden from assistive technology", () => {
+    const { container } = render(<LegalSectionRule variant="amber" />);
+
+    const rule = container.querySelector("[data-legal-section-rule]");
+    expect(rule).toBeTruthy();
+    expect(rule).toHaveAttribute("aria-hidden", "true");
+    expect(rule).toHaveAttribute("data-legal-section-rule-variant", "amber");
+    expect(rule?.className).not.toContain("gradient");
+    expect(rule?.className).not.toContain("shadow");
+  });
+
+  it("renders the last-updated line with the provided date", () => {
+    render(<LegalLastUpdated date="May 9, 2026" />);
+
+    expect(screen.getByText("Last updated: May 9, 2026")).toBeInTheDocument();
+    expect(
+      document.querySelector("[data-legal-last-updated]"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a semantic prose article without card or gradient chrome", () => {
+    render(
+      <LegalProseArticle labelledBy="privacy-policy-title">
+        <h2 id="privacy-policy-title">Privacy Policy</h2>
+        <p className={legalBodyClassName}>Body copy</p>
+        <a className={legalLinkClassName} href="mailto:akomapahealth@gmail.com">
+          akomapahealth@gmail.com
+        </a>
+      </LegalProseArticle>,
+    );
+
+    const article = document.querySelector("[data-legal-prose-article]");
+    expect(article).toBeTruthy();
+    expect(article).toHaveAttribute("aria-labelledby", "privacy-policy-title");
+    expect(article?.className).not.toContain("rounded-2xl");
+    expect(article?.className).not.toContain("shadow-xl");
+    expect(article?.className).not.toContain("gradient");
+    expect(
+      screen.getByRole("link", { name: "akomapahealth@gmail.com" }),
+    ).toHaveAttribute("href", "mailto:akomapahealth@gmail.com");
+  });
+});

--- a/src/components/shared/RouteBoundaryPrimitives.tsx
+++ b/src/components/shared/RouteBoundaryPrimitives.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { ReactNode } from "react";
 import {
+  EditorialArrow,
   EditorialButton,
   EditorialHeading,
   EditorialLead,
@@ -24,17 +25,21 @@ function RouteRecoveryNav({ className }: { className?: string }) {
       aria-label="Helpful links"
       data-route-recovery-nav
     >
-      <p className="text-sm font-medium text-[#1C1F1E] dark:text-[#FCFAEF]">
+      <p className="font-subheading text-xs font-bold uppercase tracking-[0.18em] text-[#C9920F] dark:text-[#F5C94D]">
+        Helpful destinations
+      </p>
+      <p className="mt-2 text-sm font-medium text-[#1C1F1E] dark:text-[#FCFAEF]">
         Try one of these instead
       </p>
-      <ul className="mt-4 flex flex-wrap justify-center gap-x-6 gap-y-3">
+      <ul className="mt-5 grid gap-2 sm:grid-cols-2">
         {recoveryLinks.map(({ href, label }) => (
           <li key={href}>
             <Link
               href={href}
-              className="inline-flex min-h-11 items-center text-sm font-medium text-[#0097b2] underline-offset-4 transition-colors hover:text-[#eeba2b] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] focus-visible:ring-offset-2 dark:text-[#66C4DC] dark:hover:text-[#F5C94D]"
+              className="group inline-flex min-h-11 w-full items-center justify-between gap-3 border border-[#1C1F1E]/10 bg-white/70 px-4 py-3 text-sm font-medium text-[#0097b2] transition-colors hover:border-[#0097b2]/40 hover:text-[#0F4C5C] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] focus-visible:ring-offset-2 dark:border-[#FCFAEF]/15 dark:bg-[#1C1F1E]/50 dark:text-[#66C4DC] dark:hover:border-[#66C4DC]/40 dark:hover:text-[#F5C94D]"
             >
-              {label}
+              <span>{label}</span>
+              <EditorialArrow className="opacity-70 transition-transform group-hover:translate-x-0.5" />
             </Link>
           </li>
         ))}
@@ -73,11 +78,7 @@ export function RouteLoadingState({
       </div>
 
       <div className="flex flex-1 flex-col items-center px-4 py-16 sm:py-20">
-        <div
-          role="status"
-          aria-live="polite"
-          className="text-center"
-        >
+        <div role="status" aria-live="polite" className="text-center">
           <div
             data-route-loading-spinner
             className="mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-b-2 border-[#0097b2] motion-reduce:animate-none"
@@ -111,9 +112,13 @@ export function RouteErrorState({ error, onRetry }: RouteErrorStateProps) {
   return (
     <div
       data-route-error-state
-      className="flex flex-1 items-center justify-center px-4 py-16 sm:py-24"
+      className="flex flex-1 items-center justify-center bg-[#FCFAEF] px-4 py-16 dark:bg-[#121514] sm:py-24"
     >
-      <div className="mx-auto w-full max-w-lg border-l-2 border-[#eeba2b] py-2 pl-6 text-left sm:pl-8">
+      <div className="mx-auto w-full max-w-xl border border-[#E6E7E7]/70 bg-white px-6 py-10 dark:border-[#4F5554]/50 dark:bg-[#1C1F1E] sm:px-10 sm:py-12">
+        <div
+          className="mb-6 h-1 w-12 bg-[#eeba2b]"
+          aria-hidden="true"
+        />
         <p className="font-subheading text-xs font-bold uppercase tracking-[0.2em] text-[#C9920F] dark:text-[#F5C94D]">
           Something went wrong
         </p>
@@ -139,7 +144,7 @@ export function RouteErrorState({ error, onRetry }: RouteErrorStateProps) {
           </div>
         ) : null}
 
-        <div className="mt-8 flex flex-wrap gap-4">
+        <div className="mt-8 flex flex-wrap gap-3">
           {onRetry ? (
             <button
               type="button"
@@ -149,13 +154,16 @@ export function RouteErrorState({ error, onRetry }: RouteErrorStateProps) {
               Try again
             </button>
           ) : (
-            <EditorialButton href="/" variant="solid" icon={false}>
+            <EditorialButton href="/" variant="solid">
               Back to Homepage
             </EditorialButton>
           )}
+          <EditorialButton href="/contact" variant="outline" icon={false}>
+            Contact us
+          </EditorialButton>
         </div>
 
-        <RouteRecoveryNav className="text-left [&_ul]:justify-start" />
+        <RouteRecoveryNav />
       </div>
     </div>
   );
@@ -169,31 +177,47 @@ export function RouteNotFoundState({ media }: RouteNotFoundStateProps) {
   return (
     <div
       data-route-not-found-state
-      className="mx-auto w-full max-w-lg text-center"
+      className="mx-auto w-full max-w-2xl border border-[#E6E7E7]/70 bg-white dark:border-[#4F5554]/50 dark:bg-[#1C1F1E]"
     >
-      {media}
+      {media ? (
+        <div
+          data-route-not-found-media
+          className="border-b border-[#E6E7E7]/50 bg-[#FCFAEF]/80 px-6 pt-8 dark:border-[#4F5554]/40 dark:bg-[#121514]/80 sm:px-10"
+        >
+          {media}
+        </div>
+      ) : null}
 
-      <p className="font-subheading text-xs font-bold uppercase tracking-[0.2em] text-[#C9920F] dark:text-[#F5C94D]">
-        404
-      </p>
-      <EditorialHeading
-        as="h1"
-        className="mt-3 text-[1.85rem] md:text-[2.25rem] lg:text-[2.5rem]"
-      >
-        Page Not Found
-      </EditorialHeading>
-      <EditorialLead className="mt-4">
-        We couldn&apos;t find the page you&apos;re looking for. It may have
-        been moved, renamed, or the URL might be mistyped.
-      </EditorialLead>
+      <div className="px-6 py-10 text-center sm:px-10 sm:py-12">
+        <div
+          className="mx-auto mb-6 h-1 w-12 bg-[#eeba2b]"
+          aria-hidden="true"
+        />
+        <p className="font-subheading text-xs font-bold uppercase tracking-[0.2em] text-[#C9920F] dark:text-[#F5C94D]">
+          404
+        </p>
+        <EditorialHeading
+          as="h1"
+          className="mt-3 text-[1.85rem] md:text-[2.25rem] lg:text-[2.5rem]"
+        >
+          Page Not Found
+        </EditorialHeading>
+        <EditorialLead className="mx-auto mt-4 max-w-md">
+          We couldn&apos;t find the page you&apos;re looking for. It may have
+          been moved, renamed, or the URL might be mistyped.
+        </EditorialLead>
 
-      <div className="mt-8 flex justify-center">
-        <EditorialButton href="/" variant="solid" icon={false}>
-          Back to Homepage
-        </EditorialButton>
+        <div className="mt-8 flex flex-col items-stretch justify-center gap-3 sm:flex-row sm:items-center">
+          <EditorialButton href="/" variant="solid">
+            Back to Homepage
+          </EditorialButton>
+          <EditorialButton href="/contact" variant="outline" icon={false}>
+            Contact us
+          </EditorialButton>
+        </div>
+
+        <RouteRecoveryNav className="text-left" />
       </div>
-
-      <RouteRecoveryNav />
     </div>
   );
 }

--- a/src/components/shared/RouteBoundaryPrimitives.tsx
+++ b/src/components/shared/RouteBoundaryPrimitives.tsx
@@ -1,7 +1,11 @@
 import Link from "next/link";
-import { AlertCircle } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { PublicCta } from "@/components/shared/PublicPagePrimitives";
+import type { ReactNode } from "react";
+import {
+  EditorialButton,
+  EditorialHeading,
+  EditorialLead,
+} from "@/components/shared/EditorialPrimitives";
+import { cn } from "@/lib/utils";
 
 export const recoveryLinks = [
   { href: "/get-involved", label: "Get Involved" },
@@ -10,16 +14,87 @@ export const recoveryLinks = [
   { href: "/contact", label: "Contact" },
 ] as const;
 
-export function RouteLoadingState({ message = "Loading page…" }: { message?: string }) {
+const recoveryActionClassName =
+  "group inline-flex min-h-11 items-center justify-center gap-2 rounded-md bg-[#0097b2] px-6 py-3 text-sm font-semibold text-[#FCFAEF] transition-colors hover:bg-[#eeba2b] hover:text-[#1C1F1E] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] focus-visible:ring-offset-2 md:text-base";
+
+function RouteRecoveryNav({ className }: { className?: string }) {
   return (
-    <div className="flex flex-1 items-center justify-center px-4 py-24">
-      <div className="text-center">
+    <nav
+      className={cn("mt-10", className)}
+      aria-label="Helpful links"
+      data-route-recovery-nav
+    >
+      <p className="text-sm font-medium text-[#1C1F1E] dark:text-[#FCFAEF]">
+        Try one of these instead
+      </p>
+      <ul className="mt-4 flex flex-wrap justify-center gap-x-6 gap-y-3">
+        {recoveryLinks.map(({ href, label }) => (
+          <li key={href}>
+            <Link
+              href={href}
+              className="inline-flex min-h-11 items-center text-sm font-medium text-[#0097b2] underline-offset-4 transition-colors hover:text-[#eeba2b] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] focus-visible:ring-offset-2 dark:text-[#66C4DC] dark:hover:text-[#F5C94D]"
+            >
+              {label}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}
+
+export function RouteLoadingState({
+  message = "Loading page…",
+}: {
+  message?: string;
+}) {
+  return (
+    <div
+      data-route-loading-state
+      className="flex flex-1 flex-col bg-background"
+      aria-busy="true"
+    >
+      <div className="site-container mx-auto w-full px-4 py-4">
         <div
-          className="mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-b-2 border-[#0097b2]"
-          role="status"
-          aria-label="Loading"
+          className="h-4 w-40 max-w-full rounded-sm bg-[#1C1F1E]/10 dark:bg-[#FCFAEF]/10"
+          aria-hidden="true"
         />
-        <p className="text-sm text-muted-foreground">{message}</p>
+      </div>
+
+      <div
+        className="border-b border-[#FCFAEF]/20 bg-[#0F4C5C]"
+        aria-hidden="true"
+      >
+        <div className="site-container mx-auto space-y-4 px-4 py-14 sm:py-16 md:py-20">
+          <div className="h-3 w-16 rounded-sm bg-[#FCFAEF]/25" />
+          <div className="h-10 w-3/4 max-w-xl rounded-sm bg-[#FCFAEF]/20" />
+          <div className="h-4 w-1/2 max-w-md rounded-sm bg-[#FCFAEF]/15" />
+        </div>
+      </div>
+
+      <div className="flex flex-1 flex-col items-center px-4 py-16 sm:py-20">
+        <div
+          role="status"
+          aria-live="polite"
+          className="text-center"
+        >
+          <div
+            data-route-loading-spinner
+            className="mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-b-2 border-[#0097b2] motion-reduce:animate-none"
+            aria-hidden="true"
+          />
+          <p className="text-sm text-muted-foreground">{message}</p>
+        </div>
+
+        <div
+          className="mt-12 w-full max-w-[65ch] space-y-3"
+          aria-hidden="true"
+        >
+          <div className="h-3 w-full rounded-sm bg-[#1C1F1E]/8 dark:bg-[#FCFAEF]/10" />
+          <div className="h-3 w-11/12 rounded-sm bg-[#1C1F1E]/8 dark:bg-[#FCFAEF]/10" />
+          <div className="h-3 w-4/5 rounded-sm bg-[#1C1F1E]/8 dark:bg-[#FCFAEF]/10" />
+          <div className="h-3 w-10/12 rounded-sm bg-[#1C1F1E]/8 dark:bg-[#FCFAEF]/10" />
+        </div>
       </div>
     </div>
   );
@@ -34,68 +109,91 @@ export function RouteErrorState({ error, onRetry }: RouteErrorStateProps) {
   const isDev = process.env.NODE_ENV === "development";
 
   return (
-    <div className="flex flex-1 items-center justify-center px-4 py-16 sm:py-24">
-      <div className="mx-auto max-w-lg text-center">
-        <div className="mx-auto mb-8 flex h-24 w-24 items-center justify-center rounded-full bg-[#0097b2]/10 text-[#0097b2] dark:bg-[#66C4DC]/15 dark:text-[#66C4DC]">
-          <AlertCircle className="h-12 w-12" aria-hidden="true" />
-        </div>
-
-        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+    <div
+      data-route-error-state
+      className="flex flex-1 items-center justify-center px-4 py-16 sm:py-24"
+    >
+      <div className="mx-auto w-full max-w-lg border-l-2 border-[#eeba2b] py-2 pl-6 text-left sm:pl-8">
+        <p className="font-subheading text-xs font-bold uppercase tracking-[0.2em] text-[#C9920F] dark:text-[#F5C94D]">
           Something went wrong
         </p>
-        <h1 className="mt-3 font-heading text-3xl font-bold text-foreground sm:text-4xl">
+        <EditorialHeading
+          as="h1"
+          className="mt-3 text-[1.85rem] md:text-[2.25rem] lg:text-[2.5rem]"
+        >
           We hit a snag
-        </h1>
-        <p className="mt-4 text-base leading-relaxed text-muted-foreground">
+        </EditorialHeading>
+        <EditorialLead className="mt-4">
           This page ran into an unexpected problem. You can try again or head to
           one of the links below.
-        </p>
+        </EditorialLead>
 
-        {isDev && error && (
+        {isDev && error ? (
           <div className="mt-6 rounded-md border border-destructive/30 bg-destructive/5 px-4 py-3 text-left">
             <p className="text-sm font-medium text-destructive">{error.message}</p>
-            {error.digest && (
+            {error.digest ? (
               <p className="mt-1 font-mono text-xs text-muted-foreground">
                 Digest: {error.digest}
               </p>
-            )}
+            ) : null}
           </div>
-        )}
+        ) : null}
 
-        <div className="mt-8 flex flex-wrap justify-center gap-4">
+        <div className="mt-8 flex flex-wrap gap-4">
           {onRetry ? (
-            <Button
+            <button
               type="button"
               onClick={onRetry}
-              className="h-auto rounded-md bg-[#0097b2] px-7 py-4 text-base font-semibold text-[#FCFAEF] hover:bg-[#eeba2b] hover:text-[#1C1F1E] md:text-lg"
+              className={recoveryActionClassName}
             >
               Try again
-            </Button>
+            </button>
           ) : (
-            <PublicCta href="/" variant="teal" icon={false}>
+            <EditorialButton href="/" variant="solid" icon={false}>
               Back to Homepage
-            </PublicCta>
+            </EditorialButton>
           )}
         </div>
 
-        <nav className="mt-10" aria-label="Helpful links">
-          <p className="text-sm font-medium text-foreground">
-            Try one of these instead
-          </p>
-          <ul className="mt-4 flex flex-wrap justify-center gap-x-6 gap-y-3">
-            {recoveryLinks.map(({ href, label }) => (
-              <li key={href}>
-                <Link
-                  href={href}
-                  className="text-sm font-medium text-[#0097b2] underline-offset-4 transition-colors hover:text-[#eeba2b] hover:underline dark:text-[#66C4DC] dark:hover:text-[#F5C94D]"
-                >
-                  {label}
-                </Link>
-              </li>
-            ))}
-          </ul>
-        </nav>
+        <RouteRecoveryNav className="text-left [&_ul]:justify-start" />
       </div>
+    </div>
+  );
+}
+
+type RouteNotFoundStateProps = {
+  media?: ReactNode;
+};
+
+export function RouteNotFoundState({ media }: RouteNotFoundStateProps) {
+  return (
+    <div
+      data-route-not-found-state
+      className="mx-auto w-full max-w-lg text-center"
+    >
+      {media}
+
+      <p className="font-subheading text-xs font-bold uppercase tracking-[0.2em] text-[#C9920F] dark:text-[#F5C94D]">
+        404
+      </p>
+      <EditorialHeading
+        as="h1"
+        className="mt-3 text-[1.85rem] md:text-[2.25rem] lg:text-[2.5rem]"
+      >
+        Page Not Found
+      </EditorialHeading>
+      <EditorialLead className="mt-4">
+        We couldn&apos;t find the page you&apos;re looking for. It may have
+        been moved, renamed, or the URL might be mistyped.
+      </EditorialLead>
+
+      <div className="mt-8 flex justify-center">
+        <EditorialButton href="/" variant="solid" icon={false}>
+          Back to Homepage
+        </EditorialButton>
+      </div>
+
+      <RouteRecoveryNav />
     </div>
   );
 }

--- a/src/components/shared/__tests__/RouteBoundaryPrimitives.test.tsx
+++ b/src/components/shared/__tests__/RouteBoundaryPrimitives.test.tsx
@@ -36,8 +36,12 @@ describe("RouteBoundaryPrimitives", () => {
     expect(screen.getByText("Something went wrong")).toBeInTheDocument();
 
     const errorRoot = document.querySelector("[data-route-error-state]");
-    expect(errorRoot?.innerHTML).toContain("border-[#eeba2b]");
+    expect(errorRoot?.innerHTML).toContain("bg-[#eeba2b]");
     expect(errorRoot?.querySelector("svg.lucide-alert-circle")).toBeNull();
+    expect(screen.getByRole("link", { name: "Contact us" })).toHaveAttribute(
+      "href",
+      "/contact",
+    );
 
     await user.click(screen.getByRole("button", { name: "Try again" }));
     expect(onRetry).toHaveBeenCalledTimes(1);
@@ -69,7 +73,7 @@ describe("RouteBoundaryPrimitives", () => {
     vi.unstubAllEnvs();
   });
 
-  it("renders not-found recovery with accessible naming and homepage CTA", () => {
+  it("renders not-found recovery with accessible naming and cohesive CTAs", () => {
     render(
       <RouteNotFoundState
         media={<div data-testid="not-found-media" aria-hidden="true" />}
@@ -87,8 +91,15 @@ describe("RouteBoundaryPrimitives", () => {
     expect(
       screen.getByRole("link", { name: "Back to Homepage" }),
     ).toHaveAttribute("href", "/");
+    expect(screen.getByRole("link", { name: "Contact us" })).toHaveAttribute(
+      "href",
+      "/contact",
+    );
     expect(
       screen.getByRole("navigation", { name: "Helpful links" }),
     ).toBeInTheDocument();
+    expect(
+      document.querySelector("[data-route-not-found-media]"),
+    ).toBeTruthy();
   });
 });

--- a/src/components/shared/__tests__/RouteBoundaryPrimitives.test.tsx
+++ b/src/components/shared/__tests__/RouteBoundaryPrimitives.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import {
+  recoveryLinks,
+  RouteErrorState,
+  RouteLoadingState,
+  RouteNotFoundState,
+} from "@/components/shared/RouteBoundaryPrimitives";
+
+describe("RouteBoundaryPrimitives", () => {
+  it("renders a calm loading shell with status semantics and reduced-motion spinner", () => {
+    render(<RouteLoadingState />);
+
+    const root = document.querySelector("[data-route-loading-state]");
+    expect(root).toHaveAttribute("aria-busy", "true");
+
+    expect(screen.getByRole("status")).toHaveTextContent("Loading page…");
+
+    const spinner = document.querySelector("[data-route-loading-spinner]");
+    expect(spinner).toBeTruthy();
+    expect(spinner?.className).toContain("motion-reduce:animate-none");
+    expect(spinner?.className).not.toContain("animate-pulse");
+    expect(root?.className).not.toContain("gradient");
+  });
+
+  it("renders editorial error recovery with retry and shared recovery links", async () => {
+    const user = userEvent.setup();
+    const onRetry = vi.fn();
+
+    render(<RouteErrorState onRetry={onRetry} />);
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: "We hit a snag" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+
+    const errorRoot = document.querySelector("[data-route-error-state]");
+    expect(errorRoot?.innerHTML).toContain("border-[#eeba2b]");
+    expect(errorRoot?.querySelector("svg.lucide-alert-circle")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "Try again" }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+
+    const recovery = screen.getByRole("navigation", { name: "Helpful links" });
+    for (const { href, label } of recoveryLinks) {
+      expect(
+        screen.getByRole("link", { name: label }),
+      ).toHaveAttribute("href", href);
+    }
+    expect(recovery.querySelectorAll("a")).toHaveLength(recoveryLinks.length);
+  });
+
+  it("does not expose error diagnostics outside development", () => {
+    vi.stubEnv("NODE_ENV", "production");
+
+    render(
+      <RouteErrorState
+        error={Object.assign(new Error("secret stack"), {
+          digest: "abc123",
+          stack: "Error: secret stack",
+        })}
+      />,
+    );
+
+    expect(screen.queryByText("secret stack")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Digest:/)).not.toBeInTheDocument();
+
+    vi.unstubAllEnvs();
+  });
+
+  it("renders not-found recovery with accessible naming and homepage CTA", () => {
+    render(
+      <RouteNotFoundState
+        media={<div data-testid="not-found-media" aria-hidden="true" />}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Page Not Found" }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
+    expect(screen.getByTestId("not-found-media")).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
+    expect(
+      screen.getByRole("link", { name: "Back to Homepage" }),
+    ).toHaveAttribute("href", "/");
+    expect(
+      screen.getByRole("navigation", { name: "Helpful links" }),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Restyle `/privacy` and `/terms` onto the shared #179 editorial system (deep-teal hero, cream long-form body, restrained section rules) while preserving every approved legal statement, date, heading, list, link, section id, and metadata value.
- Align main-route loading/error and global not-found with the same quieter recovery language: shell-matched reduced-motion-safe loading, mustard-rule error recovery with `EditorialButton` CTAs, shared recovery links, and reduced-motion-aware 404 (skip decorative Lottie when `prefers-reduced-motion` is set).
- Add focused unit and Playwright contracts so legal copy, Sentry capture + retry, not-found naming, loading semantics, and responsive light/dark readability stay locked in.

Closes #186
Related to #179

## Test plan
- [x] `nvm use 22`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` (226 passing, including Privacy/Terms/RouteBoundary/not-found/error contracts)
- [x] `npm run build`
- [x] `npx playwright test e2e/legal-utility-editorial.spec.ts e2e/pages-render.spec.ts e2e/responsive-pages.spec.ts e2e/typography-regression.spec.ts` (440 passed)
- [x] Manual spot-check `/privacy`, `/terms`, a hard 404, and an error recovery path in light + dark at 390 and 1280
- [x] Confirm reduced-motion: loading spinner does not spin; 404 does not fetch/loop Lottie
- [x] Confirm production error UI never exposes stack/digest diagnostics