### PR TITLE
design: editorial form polish and announcement modal restyle

### DIFF
--- a/e2e/conversion-family-editorial.spec.ts
+++ b/e2e/conversion-family-editorial.spec.ts
@@ -125,26 +125,40 @@ test.describe("conversion family editorial contracts", () => {
   test("supports keyboard FAQ and donation tab switching", async ({ page }) => {
     await preparePage(page, "light");
     await page.goto("/get-involved", { waitUntil: "domcontentloaded" });
+    await page.waitForLoadState("networkidle");
 
     const firstFaq = page
       .locator('section[aria-labelledby="get-involved-faq-heading"]')
       .getByRole("button")
       .first();
+    await firstFaq.scrollIntoViewIfNeeded();
+    await expect(firstFaq).toHaveAttribute("aria-expanded", "false");
     await firstFaq.focus();
     await expect(firstFaq).toBeFocused();
-    const expanded = await firstFaq.getAttribute("aria-expanded");
-    await firstFaq.press("Enter");
-    await expect(firstFaq).toHaveAttribute(
-      "aria-expanded",
-      expanded === "true" ? "false" : "true",
-    );
+
+    // Retry until client hydration attaches the accordion handler.
+    await expect(async () => {
+      if ((await firstFaq.getAttribute("aria-expanded")) !== "true") {
+        await page.keyboard.press("Enter");
+      }
+      await expect(firstFaq).toHaveAttribute("aria-expanded", "true");
+    }).toPass({ timeout: 10_000 });
+
+    await page.keyboard.press("Enter");
+    await expect(firstFaq).toHaveAttribute("aria-expanded", "false");
 
     await page.goto("/donate", { waitUntil: "domcontentloaded" });
+    await page.waitForLoadState("networkidle");
     const oneTimeTab = page.getByRole("button", { name: /One-Time Gift/i });
+    await oneTimeTab.scrollIntoViewIfNeeded();
     await oneTimeTab.focus();
     await expect(oneTimeTab).toBeFocused();
-    await oneTimeTab.click();
-    await expect(oneTimeTab).toHaveAttribute("aria-pressed", "true");
+    await expect(async () => {
+      if ((await oneTimeTab.getAttribute("aria-pressed")) !== "true") {
+        await oneTimeTab.click();
+      }
+      await expect(oneTimeTab).toHaveAttribute("aria-pressed", "true");
+    }).toPass({ timeout: 10_000 });
     await expect(
       page.getByRole("heading", { name: "Make a One-Time Gift" }),
     ).toBeVisible();

--- a/src/components/announcement/AnnouncementModal.tsx
+++ b/src/components/announcement/AnnouncementModal.tsx
@@ -1,19 +1,33 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
-import Link from "next/link";
 import { motion, AnimatePresence } from "framer-motion";
-import { X, ChevronLeft, ChevronRight, ArrowRight, Play } from "lucide-react";
+import { X, ChevronLeft, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { MOTION_EASE, motionDurations } from "@/lib/motion/tokens";
 import { announcementCampaign } from "@/data/announcements";
 import Image from "@/components/common/Image";
-import { TAG_COLORS } from "@/data/announcement-colors";
+import {
+  EditorialArrowLink,
+  EditorialButton,
+  EditorialEyebrow,
+  EditorialPlay,
+  type EditorialEyebrowTone,
+} from "@/components/shared/EditorialPrimitives";
 import { getAnnouncementPosterSrc, parseVideoUrl } from "@/lib/video-utils";
 import { trackEvent } from "@/lib/analytics";
 
 const STORAGE_KEY = "akomapa-announcements-dismissed";
 const AUTO_ADVANCE_MS = 6000;
+
+const mediaControlClassName =
+  "inline-flex h-11 w-11 items-center justify-center rounded-md bg-[#FCFAEF] text-[#1C1F1E] shadow-sm transition-colors hover:bg-[#eeba2b] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] focus-visible:ring-offset-2 dark:bg-[#1C1F1E] dark:text-[#FCFAEF] dark:hover:bg-[#0F4C5C] dark:focus-visible:ring-[#F5C94D]";
+
+function tagEyebrowTone(
+  tagColor: "lapis" | "amber" | "skobeloff" | undefined,
+): EditorialEyebrowTone {
+  return tagColor === "amber" ? "gold" : "teal";
+}
 
 type AnnouncementModalProps = {
   isOpen: boolean;
@@ -206,7 +220,7 @@ export default function AnnouncementModal({
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           transition={{ duration: motionDurations.enter, ease: [...MOTION_EASE] }}
-          className="fixed inset-0 z-50 flex items-end sm:items-center justify-center sm:p-4 bg-black/60 backdrop-blur-sm"
+          className="fixed inset-0 z-50 flex items-end justify-center bg-[#121514]/75 sm:items-center sm:p-4"
           onClick={close}
           aria-hidden="true"
         >
@@ -220,7 +234,7 @@ export default function AnnouncementModal({
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.95, y: 20 }}
             transition={{ duration: motionDurations.enter, ease: [...MOTION_EASE] }}
-            className="relative w-full sm:max-w-[680px] max-h-[90vh] sm:max-h-[88vh] overflow-hidden rounded-t-2xl sm:rounded-2xl bg-white dark:bg-[#2F3332] shadow-2xl outline-none"
+            className="relative max-h-[90vh] w-full overflow-hidden rounded-t-md border border-[#1C1F1E]/10 bg-[#FCFAEF] shadow-2xl outline-none dark:border-[#FCFAEF]/12 dark:bg-[#1C1F1E] sm:max-h-[88vh] sm:max-w-[680px] sm:rounded-md"
             onClick={(e) => e.stopPropagation()}
             onMouseEnter={() => setIsPaused(true)}
             onMouseLeave={() => setIsPaused(false)}
@@ -236,29 +250,38 @@ export default function AnnouncementModal({
           >
             {/* Close Button — floats over the image */}
             <button
+              type="button"
               onClick={close}
-              className="absolute top-3 right-3 z-20 p-1.5 rounded-full bg-black/30 backdrop-blur-sm hover:bg-black/50 transition-colors focus:outline-none focus:ring-2 focus:ring-white/80 focus:ring-offset-2 focus:ring-offset-black/20"
+              className={cn(mediaControlClassName, "absolute top-3 right-3 z-20")}
               aria-label="Close announcements"
             >
-              <X size={18} className="text-white" />
+              <X className="h-5 w-5" aria-hidden="true" />
             </button>
 
             {/* Prev/Next overlays on image area */}
             {showNavigation && (
               <>
                 <button
+                  type="button"
                   onClick={goToPrevious}
-                  className="absolute left-2 top-[28vw] sm:top-[170px] -translate-y-1/2 z-20 p-1.5 rounded-full bg-black/30 backdrop-blur-sm hover:bg-black/50 text-white/80 hover:text-white transition-colors focus:outline-none focus:ring-2 focus:ring-white/80"
+                  className={cn(
+                    mediaControlClassName,
+                    "absolute left-2 top-[28vw] z-20 -translate-y-1/2 sm:top-[170px]",
+                  )}
                   aria-label="Previous announcement"
                 >
-                  <ChevronLeft className="w-5 h-5 sm:w-6 sm:h-6" />
+                  <ChevronLeft className="h-5 w-5 sm:h-6 sm:w-6" aria-hidden="true" />
                 </button>
                 <button
+                  type="button"
                   onClick={goToNext}
-                  className="absolute right-2 top-[28vw] sm:top-[170px] -translate-y-1/2 z-20 p-1.5 rounded-full bg-black/30 backdrop-blur-sm hover:bg-black/50 text-white/80 hover:text-white transition-colors focus:outline-none focus:ring-2 focus:ring-white/80"
+                  className={cn(
+                    mediaControlClassName,
+                    "absolute right-2 top-[28vw] z-20 -translate-y-1/2 sm:top-[170px]",
+                  )}
                   aria-label="Next announcement"
                 >
-                  <ChevronRight className="w-5 h-5 sm:w-6 sm:h-6" />
+                  <ChevronRight className="h-5 w-5 sm:h-6 sm:w-6" aria-hidden="true" />
                 </button>
               </>
             )}
@@ -277,11 +300,11 @@ export default function AnnouncementModal({
               >
                 {/* Media Section (Image or Video) */}
                 {(currentSlide.image || currentSlide.videoUrl) && (
-                  <div className="relative w-full aspect-[16/9] sm:aspect-[2/1] overflow-hidden">
+                  <div className="relative aspect-[16/9] w-full overflow-hidden sm:aspect-[2/1]">
                     {currentSlide.videoUrl && videoPlaying ? (
                       <iframe
                         src={parseVideoUrl(currentSlide.videoUrl)?.embedUrl}
-                        className="absolute inset-0 w-full h-full"
+                        className="absolute inset-0 h-full w-full"
                         allow="autoplay; encrypted-media; picture-in-picture"
                         allowFullScreen
                         title={currentSlide.title}
@@ -290,46 +313,45 @@ export default function AnnouncementModal({
                       <>
                         {/* Video/announcement poster — decorative — intentional empty alt (slide title above) */}
                         <Image
-                          src={
-                            getAnnouncementPosterSrc(currentSlide) ||
-                            ""
-                          }
+                          src={getAnnouncementPosterSrc(currentSlide) || ""}
                           alt=""
                           fill
                           className="object-cover"
                           sizes="(max-width: 640px) 100vw, 680px"
                         />
-                        <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-black/10" />
 
                         {currentSlide.videoUrl && (
                           <button
-                            onClick={() => { setVideoPlaying(true); setIsPaused(true); }}
-                            className="absolute inset-0 z-10 flex items-center justify-center group/play"
+                            type="button"
+                            onClick={() => {
+                              setVideoPlaying(true);
+                              setIsPaused(true);
+                            }}
+                            className="absolute inset-0 z-10 flex items-center justify-center"
                             aria-label="Play video"
                           >
-                            <span className="flex items-center justify-center w-16 h-16 sm:w-20 sm:h-20 rounded-full bg-white/90 shadow-xl group-hover/play:scale-110 transition-transform duration-200">
-                              <Play className="w-7 h-7 sm:w-8 sm:h-8 text-[#0097b2] ml-1" fill="currentColor" />
+                            <span className="inline-flex h-14 w-14 items-center justify-center rounded-md bg-[#FCFAEF] text-[#0097b2] shadow-sm transition-colors hover:bg-[#eeba2b] hover:text-[#1C1F1E] sm:h-16 sm:w-16">
+                              <EditorialPlay className="ml-0.5 h-5 w-5 sm:h-6 sm:w-6" />
                             </span>
                           </button>
                         )}
                       </>
                     )}
 
-                    {/* Tag badge overlaid on image */}
+                    {/* Tag eyebrow overlaid on image */}
                     {currentSlide.tag && !videoPlaying && (
-                      <span
-                        className={cn(
-                          "absolute top-3 left-3 z-10 inline-block rounded-full px-3 py-1 text-xs font-bold tracking-wide backdrop-blur-md shadow-sm",
-                          TAG_COLORS[currentSlide.tagColor ?? "lapis"]
-                        )}
-                      >
-                        {currentSlide.tag}
-                      </span>
+                      <div className="absolute top-3 left-3 z-10 rounded-md bg-[#FCFAEF]/95 px-3 py-2 dark:bg-[#1C1F1E]/95">
+                        <EditorialEyebrow
+                          tone={tagEyebrowTone(currentSlide.tagColor)}
+                        >
+                          {currentSlide.tag}
+                        </EditorialEyebrow>
+                      </div>
                     )}
 
                     {/* Slide counter on image */}
                     {showNavigation && !videoPlaying && (
-                      <span className="absolute bottom-3 right-3 text-xs font-medium text-white/80 bg-black/30 backdrop-blur-sm rounded-full px-2.5 py-0.5">
+                      <span className="absolute bottom-3 right-3 rounded-md bg-[#FCFAEF]/95 px-2.5 py-1 font-subheading text-xs font-semibold tracking-wide text-[#1C1F1E] dark:bg-[#1C1F1E]/95 dark:text-[#FCFAEF]">
                         {currentIndex + 1} / {slides.length}
                       </span>
                     )}
@@ -338,34 +360,32 @@ export default function AnnouncementModal({
 
                 {/* Text Content */}
                 <div className="p-5 sm:p-8">
-                  {/* Tag badge — only if no image */}
-                  {currentSlide.tag && !currentSlide.image && (
-                    <span
-                      className={cn(
-                        "inline-block rounded-full px-3 py-0.5 text-xs font-semibold mb-3",
-                        TAG_COLORS[currentSlide.tagColor ?? "lapis"]
-                      )}
+                  {currentSlide.tag &&
+                  !currentSlide.image &&
+                  !currentSlide.videoUrl ? (
+                    <EditorialEyebrow
+                      tone={tagEyebrowTone(currentSlide.tagColor)}
+                      className="mb-3"
                     >
                       {currentSlide.tag}
-                    </span>
-                  )}
+                    </EditorialEyebrow>
+                  ) : null}
 
-                  <h2 className="font-heading text-xl sm:text-2xl font-bold text-[#1C1F1E] dark:text-[#FCFAEF] mb-2 sm:mb-3">
+                  <h2 className="mb-2 font-heading text-xl font-semibold leading-tight text-[#1C1F1E] dark:text-[#FCFAEF] sm:mb-3 sm:text-2xl">
                     {currentSlide.title}
                   </h2>
 
-                  <p className="text-sm sm:text-base text-[#2F3332]/80 dark:text-[#E6E7E7]/80 leading-relaxed mb-5 sm:mb-6">
+                  <p className="mb-5 max-w-xl text-sm leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80 sm:mb-6 sm:text-base">
                     {currentSlide.description}
                   </p>
 
                   {/* CTA + Dismiss row */}
-                  <div className="flex items-center gap-3">
-                    {currentSlide.ctaText && currentSlide.ctaLink && (
+                  <div className="flex flex-wrap items-center gap-x-4 gap-y-3">
+                    {currentSlide.ctaText && currentSlide.ctaLink ? (
                       currentSlide.isExternal ? (
-                        <a
+                        <EditorialButton
                           href={currentSlide.ctaLink}
-                          target="_blank"
-                          rel="noopener noreferrer"
+                          external
                           onClick={() =>
                             trackEvent({
                               name: "announcement_cta_click",
@@ -374,13 +394,11 @@ export default function AnnouncementModal({
                               cta_link: currentSlide.ctaLink ?? "",
                             })
                           }
-                          className="group inline-flex items-center gap-2 px-6 py-3 bg-[#0097b2] text-[#FCFAEF] rounded-full hover:bg-[#005A55] transition-all duration-200 font-medium text-sm sm:text-base shadow-lg hover:shadow-xl hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-[#0097b2] focus:ring-offset-2"
                         >
                           {currentSlide.ctaText}
-                          <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
-                        </a>
+                        </EditorialButton>
                       ) : (
-                        <Link
+                        <EditorialButton
                           href={`/news/${currentSlide.id}`}
                           onClick={() => {
                             trackEvent({
@@ -391,25 +409,20 @@ export default function AnnouncementModal({
                             });
                             close();
                           }}
-                          className="group inline-flex items-center gap-2 px-6 py-3 bg-[#0097b2] text-[#FCFAEF] rounded-full hover:bg-[#005A55] transition-all duration-200 font-medium text-sm sm:text-base shadow-lg hover:shadow-xl hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-[#0097b2] focus:ring-offset-2"
                         >
                           {currentSlide.ctaText}
-                          <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
-                        </Link>
+                        </EditorialButton>
                       )
-                    )}
+                    ) : null}
 
-                    <Link
-                      href="/news"
-                      onClick={close}
-                      className="inline-flex items-center gap-1.5 text-sm font-medium text-[#0097b2] dark:text-[#66C4DC] hover:text-[#005A55] dark:hover:text-[#eeba2b] transition-colors focus:outline-none focus:ring-2 focus:ring-[#0097b2] focus:ring-offset-2 rounded px-2 py-1"
-                    >
+                    <EditorialArrowLink href="/news" onClick={close}>
                       View All Updates
-                    </Link>
+                    </EditorialArrowLink>
 
                     <button
+                      type="button"
                       onClick={close}
-                      className="text-sm text-[#2F3332]/50 dark:text-[#FCFAEF]/40 hover:text-[#2F3332] dark:hover:text-[#FCFAEF] transition-colors focus:outline-none focus:ring-2 focus:ring-[#0097b2] focus:ring-offset-2 rounded px-2 py-1"
+                      className="inline-flex min-h-11 items-center rounded-md px-3 text-sm text-[#2F3332]/55 transition-colors hover:text-[#1C1F1E] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] focus-visible:ring-offset-2 dark:text-[#FCFAEF]/45 dark:hover:text-[#FCFAEF]"
                     >
                       Dismiss
                     </button>
@@ -420,7 +433,7 @@ export default function AnnouncementModal({
 
             {/* Dot Indicators — fixed at bottom */}
             {showNavigation && (
-              <div className="pb-5 pt-1 flex justify-center">
+              <div className="flex justify-center pb-5 pt-1">
                 <div
                   className="flex items-center gap-2"
                   role="tablist"
@@ -429,15 +442,18 @@ export default function AnnouncementModal({
                   {slides.map((slide, index) => (
                     <button
                       key={slide.id}
-                      onClick={() => navigate(index, index > currentIndex ? 1 : -1)}
+                      type="button"
+                      onClick={() =>
+                        navigate(index, index > currentIndex ? 1 : -1)
+                      }
                       role="tab"
                       aria-selected={index === currentIndex}
                       aria-label={`Go to announcement ${index + 1}: ${slide.title}`}
                       className={cn(
-                        "h-2 rounded-full transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-[#0097b2] focus:ring-offset-2",
+                        "h-1.5 rounded-sm transition-[width,background-color] duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] focus-visible:ring-offset-2",
                         index === currentIndex
-                          ? "bg-[#0097b2] dark:bg-[#66C4DC] w-6"
-                          : "bg-[#2F3332]/15 dark:bg-[#FCFAEF]/15 hover:bg-[#2F3332]/30 dark:hover:bg-[#FCFAEF]/30 w-2"
+                          ? "w-6 bg-[#0097b2] dark:bg-[#66C4DC]"
+                          : "w-2 bg-[#1C1F1E]/15 hover:bg-[#1C1F1E]/30 dark:bg-[#FCFAEF]/15 dark:hover:bg-[#FCFAEF]/30",
                       )}
                     />
                   ))}

--- a/src/components/announcement/AnnouncementTrigger.tsx
+++ b/src/components/announcement/AnnouncementTrigger.tsx
@@ -71,17 +71,20 @@ export default function AnnouncementTrigger() {
             className="relative max-w-[min(17rem,calc(100vw-2rem))]"
             data-testid="announcement-trigger-tip"
           >
-            <div className="relative rounded-2xl bg-[#FCFAEF] p-3 pr-9 shadow-[0_8px_30px_rgba(0,0,0,0.12)] ring-1 ring-black/5 dark:bg-[#2F3332] dark:ring-white/10">
+            <div className="relative rounded-md border border-[#1C1F1E]/10 bg-[#FCFAEF] p-3 pr-9 shadow-sm dark:border-[#FCFAEF]/15 dark:bg-[#1C1F1E]">
               <button
                 type="button"
                 onClick={openAnnouncements}
-                className="flex w-full items-start gap-3 rounded-xl text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0097b2] focus-visible:ring-offset-2"
+                className="flex w-full items-start gap-3 rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] focus-visible:ring-offset-2"
               >
-                <span className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#0097b2]/10 text-[#0097b2] dark:bg-[#66C4DC]/15 dark:text-[#66C4DC]">
+                <span className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-[#0097b2]/30 bg-white text-[#0097b2] dark:border-[#66C4DC]/40 dark:bg-[#121514] dark:text-[#66C4DC]">
                   <Sparkles className="h-4 w-4" aria-hidden="true" />
                 </span>
-                <span className="flex flex-col gap-0.5">
-                  <span className="text-sm font-semibold leading-tight text-[#1C1F1E] dark:text-[#FCFAEF]">
+                <span className="flex flex-col gap-1">
+                  <span className="font-subheading text-[0.65rem] font-bold uppercase tracking-[0.16em] text-[#0F4C5C] dark:text-[#66C4DC]">
+                    Updates
+                  </span>
+                  <span className="font-heading text-sm font-semibold leading-tight text-[#1C1F1E] dark:text-[#FCFAEF]">
                     What&apos;s new at Akomapa
                   </span>
                   <span className="text-xs leading-snug text-[#2F3332]/70 dark:text-[#E6E7E7]/70">
@@ -92,16 +95,11 @@ export default function AnnouncementTrigger() {
               <button
                 type="button"
                 onClick={dismissTipForSession}
-                className="absolute right-1.5 top-1.5 rounded-full p-1 text-[#2F3332]/50 transition-colors hover:bg-black/5 hover:text-[#1C1F1E] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0097b2] dark:text-[#E6E7E7]/60 dark:hover:bg-white/10 dark:hover:text-[#FCFAEF]"
+                className="absolute right-1.5 top-1.5 inline-flex h-8 w-8 items-center justify-center rounded-md text-[#2F3332]/50 transition-colors hover:bg-[#eeba2b]/25 hover:text-[#1C1F1E] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] dark:text-[#E6E7E7]/60 dark:hover:bg-[#0F4C5C] dark:hover:text-[#FCFAEF]"
                 aria-label="Dismiss update tip"
               >
                 <X className="h-3.5 w-3.5" aria-hidden="true" />
               </button>
-              {/* Bubble tail pointing at the bell */}
-              <span
-                className="absolute -bottom-1.5 right-6 h-3 w-3 rotate-45 bg-[#FCFAEF] ring-1 ring-black/5 dark:bg-[#2F3332] dark:ring-white/10"
-                aria-hidden="true"
-              />
             </div>
           </motion.div>
         )}
@@ -114,9 +112,9 @@ export default function AnnouncementTrigger() {
         aria-label={label}
         className={cn(
           "relative flex h-14 w-14 items-center justify-center rounded-full",
-          "bg-[#0097b2] text-[#FCFAEF] shadow-lg",
-          "transition-transform duration-200 hover:scale-105 hover:bg-[#005A55]",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0097b2] focus-visible:ring-offset-2",
+          "bg-[#0097b2] text-[#FCFAEF] shadow-sm",
+          "transition-colors duration-200 hover:bg-[#eeba2b] hover:text-[#1C1F1E]",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] focus-visible:ring-offset-2",
         )}
       >
         <Bell className="h-6 w-6 shrink-0" aria-hidden="true" />

--- a/src/components/contact/ContactForm.tsx
+++ b/src/components/contact/ContactForm.tsx
@@ -8,12 +8,21 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  editorialFieldClassName,
+  editorialFormShellClassName,
+  editorialLabelClassName,
+  editorialPrimaryButtonClassName,
+  editorialSelectTriggerClassName,
+  editorialTextareaClassName,
+} from "@/components/shared/editorialFormStyles";
 import { CONTACT } from "@/config/contact";
 import {
   CONTACT_NETWORK_ERROR_MESSAGE,
   getContactErrorMessage,
 } from "@/lib/contact-errors";
 import { getContactIntent } from "@/lib/contact-intents";
+import { cn } from "@/lib/utils";
 
 function ContactFormContent() {
   const searchParams = useSearchParams();
@@ -97,7 +106,7 @@ function ContactFormContent() {
       <div
         role="status"
         aria-live="polite"
-        className="border border-[#0097b2]/30 bg-white p-8 text-center dark:bg-[#1C1F1E]"
+        className={cn(editorialFormShellClassName, "border-[#0097b2]/30 text-center")}
       >
         <CheckCircle
           className="mx-auto mb-4 h-12 w-12 text-[#0097b2] dark:text-[#66C4DC]"
@@ -112,7 +121,7 @@ function ContactFormContent() {
         </p>
         <Button
           onClick={() => setIsSubmitted(false)}
-          className="min-h-12 bg-[#0097b2] text-[#FCFAEF] hover:bg-[#eeba2b] hover:text-[#1C1F1E]"
+          className={editorialPrimaryButtonClassName}
         >
           Send Another Message
         </Button>
@@ -123,14 +132,15 @@ function ContactFormContent() {
   return (
     <form
       onSubmit={handleSubmit}
-      className="border border-[#1C1F1E]/10 bg-white p-6 dark:border-[#FCFAEF]/15 dark:bg-[#1C1F1E] md:p-8"
+      className={editorialFormShellClassName}
       noValidate={false}
     >
-      <div className="mb-6">
-        <h3 className="mb-2 font-heading text-2xl font-bold leading-tight text-[#1C1F1E] dark:text-[#FCFAEF]">
+      <div className="mb-8">
+        <p className={editorialLabelClassName}>Contact</p>
+        <h3 className="mt-3 mb-2 font-heading text-2xl font-bold leading-tight text-[#1C1F1E] dark:text-[#FCFAEF] sm:text-3xl">
           Get in Touch
         </h3>
-        <p className="text-[#2F3332] dark:text-[#E6E7E7]">
+        <p className="max-w-xl text-base leading-relaxed text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
           Have questions about partnerships or want to learn more? We&apos;d love to hear from you.
         </p>
       </div>
@@ -158,9 +168,9 @@ function ContactFormContent() {
         </div>
       ) : null}
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
-        <div>
-          <Label htmlFor="name" className="text-[#1C1F1E] dark:text-[#FCFAEF]">
+      <div className="mb-6 grid grid-cols-1 gap-6 md:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="name" className={editorialLabelClassName}>
             Full Name *
           </Label>
           <Input
@@ -170,13 +180,13 @@ function ContactFormContent() {
             required
             value={formData.name}
             onChange={handleChange}
-            className="mt-2 border-[#0097b2] focus:border-[#eeba2b] dark:border-[#66C4DC] dark:focus:border-[#F5C94D]"
+            className={editorialFieldClassName}
             placeholder="Enter your full name"
           />
         </div>
 
-        <div>
-          <Label htmlFor="email" className="text-[#1C1F1E] dark:text-[#FCFAEF]">
+        <div className="space-y-2">
+          <Label htmlFor="email" className={editorialLabelClassName}>
             Email Address *
           </Label>
           <Input
@@ -186,15 +196,15 @@ function ContactFormContent() {
             required
             value={formData.email}
             onChange={handleChange}
-            className="mt-2 border-[#0097b2] focus:border-[#eeba2b] dark:border-[#66C4DC] dark:focus:border-[#F5C94D]"
+            className={editorialFieldClassName}
             placeholder="Enter your email address"
           />
         </div>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
-        <div>
-          <Label htmlFor="phone" className="text-[#1C1F1E] dark:text-[#FCFAEF]">
+      <div className="mb-6 grid grid-cols-1 gap-6 md:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="phone" className={editorialLabelClassName}>
             Phone Number
           </Label>
           <Input
@@ -203,31 +213,42 @@ function ContactFormContent() {
             type="tel"
             value={formData.phone}
             onChange={handleChange}
-            className="mt-2 border-[#0097b2] focus:border-[#eeba2b] dark:border-[#66C4DC] dark:focus:border-[#F5C94D]"
+            className={editorialFieldClassName}
             placeholder="Enter your phone number"
           />
         </div>
 
-        <div>
-          <Label htmlFor="partnershipType" className="text-[#1C1F1E] dark:text-[#FCFAEF]">
+        <div className="space-y-2">
+          <Label htmlFor="partnershipType" className={editorialLabelClassName}>
             Partnership Type
           </Label>
           <Select value={formData.partnershipType} onValueChange={handleSelectChange}>
-            <SelectTrigger id="partnershipType" className="mt-2 h-12 min-h-12 w-full cursor-pointer border-[#0097b2] bg-[#FCFAEF] focus:border-[#eeba2b] hover:bg-white dark:border-[#66C4DC] dark:bg-[#1C1F1E] dark:focus:border-[#F5C94D] dark:hover:bg-[#1C1F1E]">
-              <SelectValue placeholder="Select partnership type" className="text-[#1C1F1E] dark:text-[#FCFAEF]" />
+            <SelectTrigger
+              id="partnershipType"
+              className={cn(editorialSelectTriggerClassName, "cursor-pointer")}
+            >
+              <SelectValue placeholder="Select partnership type" />
             </SelectTrigger>
-            <SelectContent className="bg-[#FCFAEF] dark:bg-[#1C1F1E] text-[#1C1F1E] dark:text-[#FCFAEF]">
-              <SelectItem value="Monetary Sponsorship" className="cursor-pointer">Monetary Sponsorship</SelectItem>
-              <SelectItem value="Host Community Engagement Programs" className="cursor-pointer">Host Community Engagement Programs</SelectItem>
-              <SelectItem value="Strategic Partnerships" className="cursor-pointer">Strategic Partnerships</SelectItem>
-              <SelectItem value="General Inquiry" className="cursor-pointer">General Inquiry</SelectItem>
+            <SelectContent className="border-[#0097b2]/30 bg-[#FCFAEF] text-[#1C1F1E] dark:border-[#66C4DC]/40 dark:bg-[#1C1F1E] dark:text-[#FCFAEF]">
+              <SelectItem value="Monetary Sponsorship" className="cursor-pointer focus:bg-[#0097b2]/10">
+                Monetary Sponsorship
+              </SelectItem>
+              <SelectItem value="Host Community Engagement Programs" className="cursor-pointer focus:bg-[#0097b2]/10">
+                Host Community Engagement Programs
+              </SelectItem>
+              <SelectItem value="Strategic Partnerships" className="cursor-pointer focus:bg-[#0097b2]/10">
+                Strategic Partnerships
+              </SelectItem>
+              <SelectItem value="General Inquiry" className="cursor-pointer focus:bg-[#0097b2]/10">
+                General Inquiry
+              </SelectItem>
             </SelectContent>
           </Select>
         </div>
       </div>
 
-      <div className="mb-6">
-        <Label htmlFor="subject" className="text-[#1C1F1E] dark:text-[#FCFAEF]">
+      <div className="mb-6 space-y-2">
+        <Label htmlFor="subject" className={editorialLabelClassName}>
           Subject *
         </Label>
         <Input
@@ -237,13 +258,13 @@ function ContactFormContent() {
           required
           value={formData.subject}
           onChange={handleChange}
-          className="mt-2 border-[#0097b2] focus:border-[#eeba2b] dark:border-[#66C4DC] dark:focus:border-[#F5C94D]"
+          className={editorialFieldClassName}
           placeholder="Enter subject"
         />
       </div>
 
-      <div className="mb-8">
-        <Label htmlFor="message" className="text-[#1C1F1E] dark:text-[#FCFAEF]">
+      <div className="mb-8 space-y-2">
+        <Label htmlFor="message" className={editorialLabelClassName}>
           Message *
         </Label>
         <Textarea
@@ -253,7 +274,7 @@ function ContactFormContent() {
           value={formData.message}
           onChange={handleChange}
           rows={6}
-          className="mt-2 border-[#0097b2] focus:border-[#eeba2b] dark:border-[#66C4DC] dark:focus:border-[#F5C94D] resize-none"
+          className={cn(editorialTextareaClassName, "resize-none")}
           placeholder="Tell us about your partnership interest or inquiry..."
         />
       </div>
@@ -274,19 +295,19 @@ function ContactFormContent() {
       <Button
         type="submit"
         disabled={isSubmitting}
-        className="min-h-12 w-full rounded-md bg-[#0097b2] px-6 py-3 text-base text-[#FCFAEF] hover:bg-[#eeba2b] hover:text-[#1C1F1E] disabled:cursor-not-allowed disabled:opacity-50 sm:text-lg"
+        className={cn(editorialPrimaryButtonClassName, "w-full sm:w-full")}
       >
         {isSubmitting ? (
           <span className="flex items-center">
             <span
-              className="mr-2 h-5 w-5 animate-spin rounded-full border-2 border-[#FCFAEF] border-t-transparent"
+              className="mr-2 h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent"
               aria-hidden="true"
             />
             Sending...
           </span>
         ) : (
           <span className="flex items-center">
-            <Send size={20} className="mr-2" aria-hidden="true" />
+            <Send size={18} className="mr-2" aria-hidden="true" />
             Send Message
           </span>
         )}
@@ -348,16 +369,14 @@ export default function ContactForm() {
   return (
     <Suspense
       fallback={
-        <div className="border border-[#1C1F1E]/10 bg-white p-8 dark:border-[#FCFAEF]/15 dark:bg-[#1C1F1E]">
-          <div className="text-center">
-            <div
-              className="mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-2 border-[#0097b2] border-t-transparent"
-              aria-hidden="true"
-            />
-            <p className="text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
-              Loading contact form...
-            </p>
-          </div>
+        <div className={cn(editorialFormShellClassName, "text-center")}>
+          <div
+            className="mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-2 border-[#0097b2] border-t-transparent"
+            aria-hidden="true"
+          />
+          <p className="text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
+            Loading contact form...
+          </p>
         </div>
       }
     >

--- a/src/components/donate/AmountSelector.tsx
+++ b/src/components/donate/AmountSelector.tsx
@@ -1,6 +1,10 @@
 "use client";
 
 import { donationAmountOptions } from "@/data/donation";
+import {
+  editorialFieldClassName,
+  editorialLabelClassName,
+} from "@/components/shared/editorialFormStyles";
 import { cn } from "@/lib/utils";
 import { Input } from "@/components/ui/input";
 
@@ -19,50 +23,60 @@ export default function AmountSelector({
 }: AmountSelectorProps) {
   return (
     <div className="space-y-4">
-      <p className="text-sm font-medium text-[#2F3332] dark:text-[#E6E7E7]">Select your amount</p>
+      <p className={editorialLabelClassName}>Select your amount</p>
       <div className="grid grid-cols-2 gap-3 md:grid-cols-3">
         {donationAmountOptions.map((option) => (
           <button
             key={option.value}
             type="button"
+            aria-pressed={selectedPreset === option.value}
             onClick={() => onSelectPreset(option.value)}
             className={cn(
-              "rounded-xl border-2 px-4 py-3 text-left transition",
+              "rounded-md border-2 bg-white px-4 py-3 text-left transition-[border-color,background-color] duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] focus-visible:ring-offset-2 dark:bg-[#121514]",
               selectedPreset === option.value
-                ? "border-lapis bg-lapis/10"
-                : "border-[#E6E7E7] hover:border-lapis/60 dark:border-[#4F5554]",
+                ? "border-[#eeba2b] bg-[#FCFAEF] ring-1 ring-[#eeba2b]/35 dark:bg-[#1C1F1E]"
+                : "border-[#1C1F1E]/12 hover:border-[#0097b2]/55 dark:border-[#FCFAEF]/20",
             )}
           >
-            <p className="text-lg font-bold text-[#1C1F1E] dark:text-[#FCFAEF]">{option.label}</p>
-            <p className="text-xs text-[#2F3332]/80 dark:text-[#E6E7E7]/80">{option.impact}</p>
+            <p className="font-heading text-lg font-bold text-[#1C1F1E] dark:text-[#FCFAEF]">
+              {option.label}
+            </p>
+            <p className="text-xs text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
+              {option.impact}
+            </p>
           </button>
         ))}
 
         <button
           type="button"
+          aria-pressed={selectedPreset === "custom"}
           onClick={() => onSelectPreset("custom")}
           className={cn(
-            "rounded-xl border-2 px-4 py-3 text-left transition",
+            "rounded-md border-2 bg-white px-4 py-3 text-left transition-[border-color,background-color] duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] focus-visible:ring-offset-2 dark:bg-[#121514]",
             selectedPreset === "custom"
-              ? "border-lapis bg-lapis/10"
-              : "border-[#E6E7E7] hover:border-lapis/60 dark:border-[#4F5554]",
+              ? "border-[#eeba2b] bg-[#FCFAEF] ring-1 ring-[#eeba2b]/35 dark:bg-[#1C1F1E]"
+              : "border-[#1C1F1E]/12 hover:border-[#0097b2]/55 dark:border-[#FCFAEF]/20",
           )}
         >
-          <p className="text-lg font-bold text-[#1C1F1E] dark:text-[#FCFAEF]">Custom</p>
-          <p className="text-xs text-[#2F3332]/80 dark:text-[#E6E7E7]/80">Enter your own amount</p>
+          <p className="font-heading text-lg font-bold text-[#1C1F1E] dark:text-[#FCFAEF]">
+            Custom
+          </p>
+          <p className="text-xs text-[#2F3332]/80 dark:text-[#E6E7E7]/80">
+            Enter your own amount
+          </p>
         </button>
       </div>
 
-      {selectedPreset === "custom" && (
+      {selectedPreset === "custom" ? (
         <Input
           type="number"
           min={1}
           value={value > 0 ? String(value) : ""}
           onChange={(event) => onCustomChange(event.target.value)}
           placeholder="Enter custom amount"
-          className="h-11 border-[#0097b2] bg-white dark:bg-[#1C1F1E]"
+          className={editorialFieldClassName}
         />
-      )}
+      ) : null}
     </div>
   );
 }

--- a/src/components/donate/DonatePageContent.tsx
+++ b/src/components/donate/DonatePageContent.tsx
@@ -19,6 +19,10 @@ import {
   EditorialHeading,
   EditorialLead,
 } from "@/components/shared/EditorialPrimitives";
+import {
+  editorialFieldClassName,
+  editorialLabelClassName,
+} from "@/components/shared/editorialFormStyles";
 import { cn } from "@/lib/utils";
 
 const partnerAmounts = [
@@ -117,14 +121,14 @@ function AmountButton({
       aria-pressed={selected}
       onClick={onClick}
       className={cn(
-        "min-h-14 rounded-md border-2 p-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] focus-visible:ring-offset-2 md:p-4",
+        "min-h-14 rounded-md border-2 bg-white p-3 text-left shadow-[0_1px_0_rgba(28,31,30,0.03)] transition-[border-color,background-color,box-shadow] duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#eeba2b] focus-visible:ring-offset-2 md:p-4 dark:bg-[#121514] dark:shadow-none",
         selected
-          ? "border-[#eeba2b] bg-[#FCFAEF] dark:bg-[#121514]"
-          : "border-[#1C1F1E]/15 hover:border-[#0097b2]/50 dark:border-[#FCFAEF]/20",
+          ? "border-[#eeba2b] bg-[#FCFAEF] ring-1 ring-[#eeba2b]/35 dark:bg-[#1C1F1E]"
+          : "border-[#1C1F1E]/12 hover:border-[#0097b2]/55 hover:bg-[#FCFAEF]/80 dark:border-[#FCFAEF]/20 dark:hover:bg-[#1C1F1E]",
       )}
     >
       <div className="flex items-start justify-between gap-2">
-        <div className="text-lg font-bold text-[#1C1F1E] dark:text-[#FCFAEF] md:text-xl">
+        <div className="font-heading text-lg font-bold text-[#1C1F1E] dark:text-[#FCFAEF] md:text-xl">
           {label}
         </div>
         {selected ? (
@@ -364,10 +368,10 @@ export default function DonatePageContent() {
                 </div>
 
                 {selectedPartnerAmount === "custom" ? (
-                  <div className="mt-6 sm:mt-8">
+                  <div className="mt-6 space-y-2 sm:mt-8">
                     <Label
                       htmlFor="custom-partner-amount"
-                      className="mb-2 block text-sm text-[#1C1F1E] dark:text-[#FCFAEF] sm:text-base"
+                      className={editorialLabelClassName}
                     >
                       Enter your monthly amount
                     </Label>
@@ -377,7 +381,7 @@ export default function DonatePageContent() {
                       placeholder="Enter amount"
                       value={customPartnerAmount}
                       onChange={(e) => setCustomPartnerAmount(e.target.value)}
-                      className="h-12 border-[#0097b2] bg-[#FCFAEF] text-base focus:border-[#eeba2b] dark:border-[#66C4DC] dark:bg-[#121514] dark:focus:border-[#F5C94D] sm:text-lg"
+                      className={cn(editorialFieldClassName, "md:text-lg")}
                     />
                   </div>
                 ) : null}
@@ -450,10 +454,10 @@ export default function DonatePageContent() {
                 </div>
 
                 {selectedOneTimeAmount === "custom" ? (
-                  <div className="mt-6 sm:mt-8">
+                  <div className="mt-6 space-y-2 sm:mt-8">
                     <Label
                       htmlFor="custom-one-time-amount"
-                      className="mb-2 block text-sm text-[#1C1F1E] dark:text-[#FCFAEF] sm:text-base"
+                      className={editorialLabelClassName}
                     >
                       Enter your gift amount
                     </Label>
@@ -463,7 +467,7 @@ export default function DonatePageContent() {
                       placeholder="Enter amount"
                       value={customOneTimeAmount}
                       onChange={(e) => setCustomOneTimeAmount(e.target.value)}
-                      className="h-12 border-[#0097b2] bg-[#FCFAEF] text-base focus:border-[#eeba2b] dark:border-[#66C4DC] dark:bg-[#121514] dark:focus:border-[#F5C94D] sm:text-lg"
+                      className={cn(editorialFieldClassName, "md:text-lg")}
                     />
                   </div>
                 ) : null}

--- a/src/components/donate/DonationFollowUpForm.tsx
+++ b/src/components/donate/DonationFollowUpForm.tsx
@@ -4,6 +4,11 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { CheckCircle2, Loader2, Mail } from "lucide-react";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
+import {
+  editorialFieldClassName,
+  editorialLabelClassName,
+  editorialPrimaryButtonClassName,
+} from "@/components/shared/editorialFormStyles";
 import { Button } from "@/components/ui/button";
 import {
   Form,
@@ -19,6 +24,7 @@ import {
   donationFollowUpSchema,
   type DonationFollowUpInput,
 } from "@/lib/donation-follow-up";
+import { cn } from "@/lib/utils";
 
 type DonationFollowUpFormProps = {
   flow: "partner" | "oneTime";
@@ -96,13 +102,14 @@ export default function DonationFollowUpForm({
   }
 
   return (
-    <div className="rounded-md border border-[#2F3332]/12 bg-white p-4 sm:p-5 dark:border-[#FCFAEF]/15 dark:bg-[#1C1F1E]/35">
-      <div className="mb-4 flex items-start gap-3">
-        <div className="flex h-10 w-10 shrink-0 items-center justify-center border border-[#0097b2]/30 text-[#0097b2] dark:border-[#66C4DC]/40 dark:text-[#66C4DC]">
+    <div className="rounded-md border border-[#0097b2]/25 bg-[#FCFAEF]/70 p-5 sm:p-6 dark:border-[#66C4DC]/30 dark:bg-[#121514]/80">
+      <div className="mb-5 flex items-start gap-3">
+        <div className="flex h-11 w-11 shrink-0 items-center justify-center border border-[#0097b2]/35 bg-white text-[#0097b2] dark:border-[#66C4DC]/40 dark:bg-[#1C1F1E] dark:text-[#66C4DC]">
           <Mail aria-hidden="true" className="h-5 w-5" />
         </div>
         <div>
-          <h3 className="text-base font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
+          <p className={editorialLabelClassName}>Follow-up</p>
+          <h3 className="mt-2 font-heading text-lg font-semibold text-[#1C1F1E] dark:text-[#FCFAEF]">
             Let us thank you
           </h3>
           <p className="mt-1 text-sm leading-relaxed text-[#2F3332]/75 dark:text-[#E6E7E7]/75">
@@ -116,22 +123,24 @@ export default function DonationFollowUpForm({
         <form
           noValidate
           onSubmit={form.handleSubmit(onSubmit)}
-          className="space-y-4"
+          className="space-y-5"
         >
-          <div className="grid gap-4 sm:grid-cols-2">
+          <div className="grid gap-5 sm:grid-cols-2">
             <FormField
               control={form.control}
               name="name"
               render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Full name</FormLabel>
+                <FormItem className="space-y-2">
+                  <FormLabel className={editorialLabelClassName}>
+                    Full name
+                  </FormLabel>
                   <FormControl>
                     <Input
                       {...field}
                       autoComplete="name"
                       placeholder="Your full name"
                       disabled={form.formState.isSubmitting}
-                      className="h-11 bg-[#FCFAEF] dark:bg-[#2F3332]"
+                      className={editorialFieldClassName}
                     />
                   </FormControl>
                   <FormMessage role="alert" />
@@ -142,8 +151,10 @@ export default function DonationFollowUpForm({
               control={form.control}
               name="email"
               render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Email address</FormLabel>
+                <FormItem className="space-y-2">
+                  <FormLabel className={editorialLabelClassName}>
+                    Email address
+                  </FormLabel>
                   <FormControl>
                     <Input
                       {...field}
@@ -152,7 +163,7 @@ export default function DonationFollowUpForm({
                       autoComplete="email"
                       placeholder="you@example.com"
                       disabled={form.formState.isSubmitting}
-                      className="h-11 bg-[#FCFAEF] dark:bg-[#2F3332]"
+                      className={editorialFieldClassName}
                     />
                   </FormControl>
                   <FormMessage role="alert" />
@@ -193,7 +204,7 @@ export default function DonationFollowUpForm({
             type="submit"
             size="lg"
             disabled={form.formState.isSubmitting}
-            className="h-12 min-h-12 w-full rounded-md bg-[#0097b2] py-3 text-[#FCFAEF] shadow-none hover:bg-[#007f96] focus-visible:ring-[#F5C94D] sm:w-auto"
+            className={cn(editorialPrimaryButtonClassName, "w-full sm:w-auto")}
           >
             {form.formState.isSubmitting ? (
               <>

--- a/src/components/donate/DonationPaymentMethods.tsx
+++ b/src/components/donate/DonationPaymentMethods.tsx
@@ -11,6 +11,7 @@ import {
   SiZelle,
 } from "react-icons/si";
 import DonationFollowUpForm from "@/components/donate/DonationFollowUpForm";
+import { editorialAmberButtonClassName } from "@/components/shared/editorialFormStyles";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -220,7 +221,7 @@ export default function DonationPaymentMethods({
       <Button
         type="button"
         size="lg"
-        className="h-12 min-h-12 w-full rounded-md bg-[#0097b2] py-3 text-[#FCFAEF] shadow-none hover:bg-[#007f96] focus-visible:ring-[#F5C94D]"
+        className={cn(editorialAmberButtonClassName, "w-full")}
         aria-expanded={showInstructions}
         aria-controls={instructionsId}
         onClick={() => setShowInstructions((current) => !current)}

--- a/src/components/get-involved/GetInvolvedFAQ.tsx
+++ b/src/components/get-involved/GetInvolvedFAQ.tsx
@@ -14,9 +14,7 @@ import { cn } from "@/lib/utils";
 
 export default function GetInvolvedFAQ() {
   const baseId = useId();
-  const [openId, setOpenId] = useState<string | null>(
-    getInvolvedFaqs[0]?.id ?? null,
-  );
+  const [openId, setOpenId] = useState<string | null>(null);
 
   return (
     <EditorialBand
@@ -50,7 +48,9 @@ export default function GetInvolvedFAQ() {
                 <button
                   id={buttonId}
                   type="button"
-                  onClick={() => setOpenId(isOpen ? null : faq.id)}
+                  onClick={() =>
+                    setOpenId((current) => (current === faq.id ? null : faq.id))
+                  }
                   className="flex min-h-14 w-full items-center justify-between gap-4 px-5 py-4 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[#eeba2b] sm:px-6 sm:py-5"
                   aria-expanded={isOpen}
                   aria-controls={panelId}
@@ -60,7 +60,7 @@ export default function GetInvolvedFAQ() {
                   </span>
                   <ChevronDown
                     className={cn(
-                      "h-5 w-5 shrink-0 text-[#0097b2] transition-transform duration-200 motion-reduce:transition-none dark:text-[#66C4DC]",
+                      "h-5 w-5 shrink-0 text-[#0097b2] transition-transform duration-300 ease-out motion-reduce:transition-none dark:text-[#66C4DC]",
                       isOpen && "rotate-180",
                     )}
                     aria-hidden="true"
@@ -68,16 +68,30 @@ export default function GetInvolvedFAQ() {
                 </button>
               </h3>
 
+              {/*
+                CSS grid 0fr→1fr animates height without measuring content,
+                which avoids the layout flicker that instant show/hide caused.
+              */}
               <div
                 id={panelId}
                 role="region"
                 aria-labelledby={buttonId}
-                hidden={!isOpen}
-                className={cn(!isOpen && "hidden")}
+                inert={!isOpen ? true : undefined}
+                className={cn(
+                  "grid transition-[grid-template-rows] duration-300 ease-[cubic-bezier(0.25,0.4,0.25,1)] motion-reduce:transition-none",
+                  isOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+                )}
               >
-                <p className="border-t border-[#1C1F1E]/10 px-5 py-5 text-base leading-relaxed text-[#2F3332]/80 dark:border-[#FCFAEF]/12 dark:text-[#E6E7E7]/75 sm:px-6 sm:pb-6">
-                  {faq.answer}
-                </p>
+                <div className="min-h-0 overflow-hidden">
+                  <p
+                    className={cn(
+                      "border-t border-[#1C1F1E]/10 px-5 py-5 text-base leading-relaxed text-[#2F3332]/80 transition-opacity duration-300 ease-out motion-reduce:transition-none dark:border-[#FCFAEF]/12 dark:text-[#E6E7E7]/75 sm:px-6 sm:pb-6",
+                      isOpen ? "opacity-100" : "opacity-0",
+                    )}
+                  >
+                    {faq.answer}
+                  </p>
+                </div>
               </div>
             </div>
           );

--- a/src/components/shared/editorialFormStyles.ts
+++ b/src/components/shared/editorialFormStyles.ts
@@ -1,0 +1,50 @@
+import { cn } from "@/lib/utils";
+
+/** Shared field chrome for conversion-family forms (contact + donate). */
+export const editorialFieldClassName = cn(
+  "h-12 min-h-12 w-full rounded-md border border-[#0097b2]/45 bg-[#FCFAEF] px-4 font-body text-base text-[#1C1F1E] shadow-none",
+  "placeholder:text-[#2F3332]/45",
+  "transition-[border-color,box-shadow,background-color] duration-200 ease-out",
+  "hover:border-[#0097b2]/75 hover:bg-white",
+  "focus-visible:border-[#eeba2b] focus-visible:bg-white focus-visible:ring-2 focus-visible:ring-[#eeba2b]/45 focus-visible:ring-offset-2",
+  "disabled:cursor-not-allowed disabled:opacity-60",
+  "dark:border-[#66C4DC]/45 dark:bg-[#121514] dark:text-[#FCFAEF] dark:placeholder:text-[#E6E7E7]/45",
+  "dark:hover:border-[#66C4DC]/75 dark:hover:bg-[#1C1F1E]",
+  "dark:focus-visible:border-[#F5C94D] dark:focus-visible:bg-[#1C1F1E] dark:focus-visible:ring-[#F5C94D]/40",
+);
+
+export const editorialTextareaClassName = cn(
+  editorialFieldClassName,
+  "h-auto min-h-[10rem] resize-y py-3 leading-relaxed",
+);
+
+export const editorialLabelClassName = cn(
+  "font-subheading text-xs font-bold uppercase tracking-[0.14em] text-[#0F4C5C]",
+  "dark:text-[#66C4DC]",
+);
+
+export const editorialSelectTriggerClassName = cn(
+  editorialFieldClassName,
+  "justify-between gap-2 data-[placeholder]:text-[#2F3332]/45 dark:data-[placeholder]:text-[#E6E7E7]/45",
+);
+
+export const editorialPrimaryButtonClassName = cn(
+  "h-12 min-h-12 w-full rounded-md bg-[#0097b2] px-6 py-3 font-subheading text-sm font-semibold text-[#FCFAEF] shadow-none",
+  "hover:bg-[#eeba2b] hover:text-[#1C1F1E]",
+  "focus-visible:ring-2 focus-visible:ring-[#eeba2b] focus-visible:ring-offset-2",
+  "disabled:cursor-not-allowed disabled:opacity-55",
+  "sm:w-auto md:text-base",
+);
+
+export const editorialAmberButtonClassName = cn(
+  "h-12 min-h-12 w-full rounded-md bg-[#eeba2b] px-6 py-3 font-subheading text-sm font-semibold text-[#1C1F1E] shadow-none",
+  "hover:bg-[#1C1F1E] hover:text-[#FCFAEF]",
+  "focus-visible:ring-2 focus-visible:ring-[#eeba2b] focus-visible:ring-offset-2",
+  "disabled:cursor-not-allowed disabled:opacity-55",
+  "sm:w-auto md:text-base",
+);
+
+export const editorialFormShellClassName = cn(
+  "border border-[#1C1F1E]/10 bg-white p-6 shadow-[0_1px_0_rgba(28,31,30,0.04)] sm:p-8",
+  "dark:border-[#FCFAEF]/15 dark:bg-[#1C1F1E] dark:shadow-none",
+);


### PR DESCRIPTION
## Summary
- Land shared `editorialFormStyles` chrome across contact/donate conversion forms, with FAQ accordion animation and hardened conversion e2e assertions
- Restyle the bell Announcement modal and tip to match editorial dialog language (cream panels, eyebrow tags, `EditorialButton` CTAs) without changing carousel, dismiss storage, or e2e contracts

## Test plan
- [x] Open announcements via bell FAB, tip bubble, and first-visit auto-open (light + dark)
- [x] Confirm dismiss writes `akomapa-announcements-dismissed` and suppresses auto-open
- [x] Spot-check contact + donate form field/button chrome and FAQ open/close animation
- [x] `npx playwright test e2e/news-detail.spec.ts -g "Announcement modal"`
- [x] `npx playwright test e2e/conversion-family-editorial.spec.ts`

