### PR TITLE
fix(impact): English basemap labels and single-world Leaflet map

### DIFF
--- a/src/components/impact/ImpactMap.tsx
+++ b/src/components/impact/ImpactMap.tsx
@@ -96,15 +96,7 @@ export default function ImpactMap() {
           <ImpactMapCanvas />
         </div>
         <p className="mx-auto mt-2 max-w-5xl text-right text-[11px] leading-snug text-[#2F3332]/55 dark:text-[#E6E7E7]/55">
-          Map tiles ©{" "}
-          <a
-            href="https://www.esri.com/"
-            className="underline-offset-2 hover:underline"
-            target="_blank"
-            rel="noreferrer"
-          >
-            Esri
-          </a>
+          Map tiles © Esri
         </p>
       </FadeIn>
 

--- a/src/components/impact/ImpactMap.tsx
+++ b/src/components/impact/ImpactMap.tsx
@@ -95,6 +95,17 @@ export default function ImpactMap() {
         >
           <ImpactMapCanvas />
         </div>
+        <p className="mx-auto mt-2 max-w-5xl text-right text-[11px] leading-snug text-[#2F3332]/55 dark:text-[#E6E7E7]/55">
+          Map tiles ©{" "}
+          <a
+            href="https://www.esri.com/"
+            className="underline-offset-2 hover:underline"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Esri
+          </a>
+        </p>
       </FadeIn>
 
       <FadeIn direction="up" delay={0.1}>

--- a/src/components/impact/ImpactMapCanvas.tsx
+++ b/src/components/impact/ImpactMapCanvas.tsx
@@ -14,6 +14,15 @@ import { mapLocations } from "@/data/impact";
 import "leaflet/dist/leaflet.css";
 import "./impact-map.css";
 
+/**
+ * Basemap with English / romanized place names.
+ * Standard OSM raster tiles bake in local-language labels; Leaflet cannot override that.
+ * Esri World Street Map serves English-leaning labels without an API key.
+ * Note Esri's path order is z/y/x (not z/x/y).
+ */
+const ENGLISH_BASEMAP_URL =
+  "https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}";
+
 const typeLabels: Record<MapLocation["type"], string> = {
   "active-hub": "Active hub",
   "planned-hub": "Planned hub",
@@ -117,19 +126,29 @@ export default function ImpactMapCanvas() {
   );
 
   const center: [number, number] = [20, -40];
+  // One world only — Leaflet wraps tiles horizontally by default.
+  const worldBounds: [[number, number], [number, number]] = [
+    [-85, -180],
+    [85, 180],
+  ];
 
   return (
     <MapContainer
       center={center}
       zoom={2}
+      minZoom={2}
+      maxBounds={worldBounds}
+      maxBoundsViscosity={1}
+      attributionControl={false}
       scrollWheelZoom={false}
       className="h-full w-full"
       data-testid="impact-map-canvas"
       aria-label="Interactive map of Akomapa hub and partner locations"
     >
       <TileLayer
-        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
-        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        url={ENGLISH_BASEMAP_URL}
+        noWrap
+        bounds={worldBounds}
       />
       <FitAllLocations locations={mapLocations} />
       <ScrollWheelOnEngage />


### PR DESCRIPTION
## Summary
- Follow-up to the Leaflet Impact map from #190 (closes the flicker work in #177 by replacing the static SVG with Leaflet).
- Switch the basemap from OpenStreetMap raster tiles to Esri World Street Map so place names render in English / romanized labels (OSM tiles bake in local-language text; Leaflet has no language setting).
- Disable horizontal world wrapping (`noWrap` + `maxBounds`) so continents are not repeated while panning.
- Remove the in-map attribution bar and show a compact Esri credit under the map panel.

## Context
- **Issue:** [#177](https://github.com/akomapahealth/akomapa-health/issues/177) — map marker flicker (addressed by Leaflet in #190; this PR hardens the shipped map).
- **Prior PR:** [#190](https://github.com/akomapahealth/akomapa-health/pull/190) — `feat(impact): Leaflet map + compact mobile popups (#177)` (merged to `dev`).

## Test plan
- [x] Open `/impact` and confirm basemap place names read in English (especially West Africa / global view)
- [x] Pan horizontally and confirm Africa / other continents do not repeat
- [x] Confirm the shaded Leaflet attribution bar is gone and a small “Map tiles © Esri” credit appears under the map
- [x] Click hub markers; popups and “View hub” links still work on desktop and mobile
- [x] Spot-check that existing impact-map e2e contracts still pass