### PR TITLE
docs(perf): confirm ImageKit as primary optimizer for CDN images (#99)

### DIFF
--- a/docs/performance/README.md
+++ b/docs/performance/README.md
@@ -3,6 +3,12 @@
 This directory captures the before/after measurements for the comprehensive QA,
 performance, and stability pass.
 
+## Image optimization (#99)
+
+See [`image-optimization.md`](./image-optimization.md) for the confirmed
+ImageKit-vs-Next strategy (ImageKit primary for CDN assets; Next for local /
+other remotes).
+
 ## Issue #86 — homepage critical path (2026-07-24)
 
 See [`lighthouse-issue-86.md`](./lighthouse-issue-86.md) for the homepage

--- a/docs/performance/image-optimization.md
+++ b/docs/performance/image-optimization.md
@@ -1,0 +1,43 @@
+# Image optimization strategy (#99)
+
+## Decision
+
+| Asset class | Primary optimizer | Mechanism |
+| --- | --- | --- |
+| ImageKit CDN paths (relative, e.g. `/highlights/…`) | **ImageKit** | Custom `imageKitLoader` on `@/components/common/Image` |
+| Absolute `*.imagekit.io` URLs | **ImageKit** | Same custom loader (applies/replaces `tr=w-,q-`) |
+| Local / `public/` and non-ImageKit remotes (e.g. YouTube thumbs) | **Next `/_next/image`** | Default `next/image` loader |
+
+ImageKit is the primary optimizer for CDN assets. A custom `next/image` loader
+makes Next emit `src` / `srcSet` pointing at ImageKit URLs; the browser fetches
+those URLs directly. Next does **not** re-proxy them through `/_next/image`, so
+there is no double optimization for the ImageKit path.
+
+Do **not** set blanket `unoptimized` on the shared Image wrapper — that would
+disable Next optimization for any non-ImageKit usage of `next/image` patterns
+we rely on elsewhere (local logos, etc.).
+
+## Code pointers
+
+- [`src/components/common/Image.tsx`](../../src/components/common/Image.tsx) — loader selection via `isImageKitSrc`
+- [`src/lib/imagekit.ts`](../../src/lib/imagekit.ts) — `getImageKitUrl`, `imageKitLoader`
+- [`next.config.ts`](../../next.config.ts) — `images.remotePatterns` allowlist (ImageKit + YouTube)
+
+Local `public/` assets should use `next/image` directly, not the common Image
+wrapper (relative paths on the wrapper are treated as ImageKit CDN paths).
+
+## LCP heroes
+
+Homepage and marketing LCP images that use `@/components/common/Image` with
+`priority` and `sizes` rely on ImageKit `tr=w-,q-` for byte size. Keep those
+props accurate so the loader requests an appropriate width.
+
+## How to verify
+
+1. `npm run build && npm run start`
+2. Open `/` (or another page with ImageKit heroes) in DevTools → Network → Img
+3. Confirm ImageKit assets request `https://ik.imagekit.io/...?tr=q-*,w-*` (not `/_next/image?...`)
+4. Confirm local logos (e.g. brand marks from `public/`) request `/_next/image?...`
+
+Collaborator validation (2026-07-05) already observed direct ImageKit URLs for
+homepage CDN assets and `/_next/image` for local logos.

--- a/next.config.ts
+++ b/next.config.ts
@@ -94,8 +94,11 @@ const nextConfig: NextConfig = {
   },
   images: {
     qualities: [75, 85, 100],
-    // Configure ImageKit as a remote pattern for Next.js Image optimization
-    // This enables future use of Next.js Image component with ImageKit URLs
+    // ImageKit CDN assets are optimized via the custom imageKitLoader on
+    // @/components/common/Image (browser fetches ik.imagekit.io directly).
+    // remotePatterns keep ImageKit/YouTube allowlisted if the default
+    // /_next/image optimizer is used; local/public assets use Next optimization.
+    // See docs/performance/image-optimization.md.
     remotePatterns: [
       {
         protocol: 'https',

--- a/src/components/common/Image.tsx
+++ b/src/components/common/Image.tsx
@@ -2,7 +2,7 @@
 
 import NextImage from "next/image";
 import type { ComponentProps } from "react";
-import { imageKitLoader } from "@/lib/imagekit";
+import { imageKitLoader, isImageKitSrc } from "@/lib/imagekit";
 
 type Props = Omit<ComponentProps<typeof NextImage>, "src" | "loader"> & {
   src: string;
@@ -11,9 +11,14 @@ type Props = Omit<ComponentProps<typeof NextImage>, "src" | "loader"> & {
 };
 
 /**
- * ImageKit-backed image using `next/image` with a custom loader for ImageKit
- * paths. Absolute remote URLs use Next.js' default optimizer so responsive
- * width parameters are retained.
+ * App image wrapper with a split optimization strategy:
+ *
+ * - **ImageKit CDN** (relative paths, or absolute `*.imagekit.io` URLs): custom
+ *   `imageKitLoader` — browser fetches ImageKit directly with `tr=w-,q-`.
+ * - **Local / other remotes**: Next.js default `/_next/image` optimizer.
+ *
+ * Do not pass local `public/` paths here; use `next/image` directly for those.
+ * See `docs/performance/image-optimization.md`.
  */
 export default function Image({
   src,
@@ -34,8 +39,7 @@ export default function Image({
   const resolvedWidth = minWidth ?? width;
   const resolvedHeight = minHeight ?? height;
   const resolvedSizes = fill ? (sizes ?? "100vw") : sizes;
-  const isAbsoluteRemoteUrl =
-    src.startsWith("https://") || src.startsWith("http://");
+  const useImageKitLoader = isImageKitSrc(src);
 
   const resolvedLoading =
     loading !== undefined
@@ -47,7 +51,7 @@ export default function Image({
   return (
     <NextImage
       {...rest}
-      loader={isAbsoluteRemoteUrl ? undefined : imageKitLoader}
+      loader={useImageKitLoader ? imageKitLoader : undefined}
       src={src}
       alt={alt}
       width={fill ? undefined : resolvedWidth}

--- a/src/lib/__tests__/imagekit.test.ts
+++ b/src/lib/__tests__/imagekit.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getImageKitUrl,
+  imageKitLoader,
+  isImageKitSrc,
+} from "@/lib/imagekit";
+
+describe("isImageKitSrc", () => {
+  it("treats relative paths as ImageKit CDN paths", () => {
+    expect(isImageKitSrc("/highlights/photo.jpg")).toBe(true);
+    expect(isImageKitSrc("gallery/image.webp")).toBe(true);
+  });
+
+  it("detects absolute ImageKit hosts", () => {
+    expect(
+      isImageKitSrc("https://ik.imagekit.io/akomapa/highlights/photo.jpg"),
+    ).toBe(true);
+    expect(
+      isImageKitSrc("https://cdn.imagekit.io/akomapa/photo.jpg"),
+    ).toBe(true);
+  });
+
+  it("rejects non-ImageKit absolute URLs", () => {
+    expect(
+      isImageKitSrc("https://img.youtube.com/vi/abc/maxresdefault.jpg"),
+    ).toBe(false);
+    expect(isImageKitSrc("https://example.com/photo.jpg")).toBe(false);
+  });
+});
+
+describe("getImageKitUrl / imageKitLoader", () => {
+  const endpoint = "https://ik.imagekit.io/akomapa";
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("builds relative ImageKit URLs with tr= width and quality", () => {
+    vi.stubEnv("NEXT_PUBLIC_IMAGEKIT_URL_ENDPOINT", endpoint);
+
+    expect(
+      getImageKitUrl("/highlights/photo.jpg", { width: 800, quality: 75 }),
+    ).toBe(`${endpoint}/highlights/photo.jpg?tr=q-75,w-800`);
+
+    expect(
+      imageKitLoader({ src: "/highlights/photo.jpg", width: 1200, quality: 85 }),
+    ).toBe(`${endpoint}/highlights/photo.jpg?tr=q-85,w-1200`);
+  });
+
+  it("applies loader transforms to absolute ImageKit URLs", () => {
+    const src = "https://ik.imagekit.io/akomapa/hero.jpg?tr=q-50,w-100";
+
+    expect(imageKitLoader({ src, width: 3840, quality: 75 })).toBe(
+      "https://ik.imagekit.io/akomapa/hero.jpg?tr=q-75%2Cw-3840",
+    );
+  });
+
+  it("passes non-ImageKit absolute URLs through unchanged", () => {
+    const src = "https://img.youtube.com/vi/abc/maxresdefault.jpg";
+    expect(getImageKitUrl(src, { width: 640, quality: 75 })).toBe(src);
+  });
+});

--- a/src/lib/imagekit.ts
+++ b/src/lib/imagekit.ts
@@ -1,6 +1,10 @@
 /**
- * ImageKit URL generation utility
- * Generates optimized ImageKit URLs with transformations for better caching
+ * ImageKit URL generation utility.
+ * Generates ImageKit CDN URLs with `tr=` transformations for responsive sizing.
+ *
+ * Strategy (see docs/performance/image-optimization.md): ImageKit is the primary
+ * optimizer for CDN assets. The custom `next/image` loader returns ImageKit URLs
+ * that the browser fetches directly — Next does not re-proxy them through `/_next/image`.
  */
 
 interface ImageKitTransformations {
@@ -11,62 +15,100 @@ interface ImageKitTransformations {
   minHeight?: number;
 }
 
+function isImageKitHostname(hostname: string): boolean {
+  return hostname === "imagekit.io" || hostname.endsWith(".imagekit.io");
+}
+
+/**
+ * Whether `src` should use the ImageKit custom loader.
+ * Relative paths are treated as ImageKit CDN paths (app convention for
+ * `@/components/common/Image`). Absolute URLs use ImageKit only when hosted
+ * on `*.imagekit.io`.
+ */
+export function isImageKitSrc(src: string): boolean {
+  if (!src.startsWith("http://") && !src.startsWith("https://")) {
+    return true;
+  }
+
+  try {
+    return isImageKitHostname(new URL(src).hostname);
+  } catch {
+    return false;
+  }
+}
+
+function buildTransformParams(
+  transformations?: ImageKitTransformations,
+): string[] {
+  if (!transformations) return [];
+
+  const transformParams: string[] = [];
+  const width = transformations.minWidth || transformations.width;
+  const height = transformations.minHeight || transformations.height;
+
+  if (transformations.quality !== undefined) {
+    transformParams.push(`q-${transformations.quality}`);
+  }
+  if (width !== undefined) {
+    transformParams.push(`w-${width}`);
+  }
+  if (height !== undefined) {
+    transformParams.push(`h-${height}`);
+  }
+
+  return transformParams;
+}
+
 /**
  * Generates an ImageKit URL with optional transformations
- * @param path - The image path in ImageKit (e.g., "/gallery/image.jpg")
+ * @param path - The image path in ImageKit (e.g., "/gallery/image.jpg") or a full ImageKit URL
  * @param transformations - Optional transformation parameters
  * @returns The complete ImageKit URL
  */
 export function getImageKitUrl(
   path: string,
-  transformations?: ImageKitTransformations
+  transformations?: ImageKitTransformations,
 ): string {
-  // If path is already a full URL (http/https), return it as-is
-  // This handles cases where images might come from other sources
-  if (path.startsWith('http://') || path.startsWith('https://')) {
-    return path;
+  const transformParams = buildTransformParams(transformations);
+
+  if (path.startsWith("http://") || path.startsWith("https://")) {
+    // Non-ImageKit remotes: pass through unchanged.
+    if (!isImageKitSrc(path)) {
+      return path;
+    }
+
+    // Absolute ImageKit URLs: apply/replace `tr=` so loader width/quality stick.
+    try {
+      const url = new URL(path);
+      if (transformParams.length > 0) {
+        url.searchParams.set("tr", transformParams.join(","));
+      }
+      return url.href;
+    } catch {
+      return path;
+    }
   }
 
   const urlEndpoint = process.env.NEXT_PUBLIC_IMAGEKIT_URL_ENDPOINT;
-  
+
   if (!urlEndpoint) {
-    console.warn('NEXT_PUBLIC_IMAGEKIT_URL_ENDPOINT is not set');
+    console.warn("NEXT_PUBLIC_IMAGEKIT_URL_ENDPOINT is not set");
     return path;
   }
 
   // Remove leading slash from path if present (ImageKit handles it)
-  const cleanPath = path.startsWith('/') ? path.slice(1) : path;
+  const cleanPath = path.startsWith("/") ? path.slice(1) : path;
 
-  // Build transformation query string
-  const transformParams: string[] = [];
-
-  if (transformations) {
-    // Use minWidth/minHeight if provided, otherwise use width/height
-    const width = transformations.minWidth || transformations.width;
-    const height = transformations.minHeight || transformations.height;
-    
-    if (transformations.quality !== undefined) {
-      transformParams.push(`q-${transformations.quality}`);
-    }
-    if (width !== undefined) {
-      transformParams.push(`w-${width}`);
-    }
-    if (height !== undefined) {
-      transformParams.push(`h-${height}`);
-    }
-  }
-
-  // Construct URL
   // Ensure urlEndpoint doesn't have trailing slash
-  const baseUrl = urlEndpoint.endsWith('/') 
-    ? urlEndpoint.slice(0, -1) 
+  const baseUrl = urlEndpoint.endsWith("/")
+    ? urlEndpoint.slice(0, -1)
     : urlEndpoint;
-  
+
   // ImageKit URL format: {urlEndpoint}/{path}?tr={transformations}
   const imageUrl = `${baseUrl}/${cleanPath}`;
-  
+
   if (transformParams.length > 0) {
-    return `${imageUrl}?tr=${transformParams.join(',')}`;
+    return `${imageUrl}?tr=${transformParams.join(",")}`;
   }
 
   return imageUrl;
@@ -82,14 +124,14 @@ export function getImageKitUrl(
 export function getImageKitSrcSet(
   path: string,
   sizes: number[],
-  transformations?: Omit<ImageKitTransformations, 'width' | 'minWidth'>
+  transformations?: Omit<ImageKitTransformations, "width" | "minWidth">,
 ): string {
   return sizes
     .map((width) => {
       const url = getImageKitUrl(path, { ...transformations, width });
       return `${url} ${width}w`;
     })
-    .join(', ');
+    .join(", ");
 }
 
 /** Parameters passed by `next/image` to a custom loader (see Next.js Image docs). */
@@ -100,10 +142,12 @@ export type ImageKitLoaderParams = {
 };
 
 /**
- * `next/image` loader for ImageKit asset paths (e.g. `/highlights/photo.jpg`).
- * Applies `tr=w-` and `tr=q-` so ImageKit serves appropriately sized bytes; `src` may be a full HTTPS URL (passed through by `getImageKitUrl`).
+ * `next/image` loader for ImageKit asset paths (e.g. `/highlights/photo.jpg`)
+ * and absolute `*.imagekit.io` URLs.
  *
- * **Optimization chain:** With the default Next.js Image pipeline, the URL returned here is fetched and may be further optimized by Next (`remotePatterns` must allow the host). To rely on ImageKit transformations only, render `next/image` with `unoptimized` (not used by our wrapper).
+ * Applies `tr=w-` and `tr=q-` so ImageKit serves appropriately sized bytes.
+ * With a custom loader, Next emits these URLs directly on `<img>` — the browser
+ * fetches ImageKit; Next does not re-optimize through `/_next/image`.
  */
 export function imageKitLoader({
   src,
@@ -113,4 +157,3 @@ export function imageKitLoader({
   const q = quality ?? 75;
   return getImageKitUrl(src, { width, quality: q });
 }
-


### PR DESCRIPTION
## Summary
- Closes [#99](https://github.com/akomapahealth/akomapa-health/issues/99): confirm ImageKit as the primary optimizer for CDN assets; Next `/_next/image` remains for local/`public` and non-ImageKit remotes.
- Harden `@/components/common/Image` so absolute `*.imagekit.io` URLs use `imageKitLoader` (and get `tr=w-,q-`) instead of falling through to Next’s default optimizer.
- Correct outdated comments that implied Next re-optimizes custom-loader URLs; document the strategy in `docs/performance/image-optimization.md`.
- Add unit tests for `isImageKitSrc`, relative URL building, and absolute ImageKit transform application.

## Context
Collaborator validation (2026-07-05) already showed homepage ImageKit assets as direct `ik.imagekit.io?...tr=` URLs, not `/_next/image`. This PR locks that strategy in code + docs and closes the investigation.

## Test plan
- [x] `npx vitest run src/lib/__tests__/imagekit.test.ts`
- [x] `npm run build && npm run start` → Network on `/`: ImageKit heroes hit `ik.imagekit.io` with `tr=`; local logos hit `/_next/image`
- [x] Spot-check a page using `@/components/common/Image` with `priority` still receives sensible widths via `sizes`