### PR TITLE
fix(animations): reveal team directory cards on mobile

### DIFF
--- a/e2e/team-directory.spec.ts
+++ b/e2e/team-directory.spec.ts
@@ -101,6 +101,47 @@ test.describe("team directory hierarchy", () => {
     }
   });
 
+  test("reveals the first card in each directory on a phone-width viewport", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto("/about/team", { waitUntil: "domcontentloaded" });
+
+    const samples = [
+      ["executive", executiveTeamMembers[0].name],
+      ["member", nonExecutiveTeamMembers[0].name],
+      ["advisor", advisoryBoardMembers[0].name],
+    ] as const;
+
+    for (const [category, name] of samples) {
+      const card = page.locator(
+        `[data-team-section="${category}"] [data-team-member="${name}"]`,
+      );
+      await card.scrollIntoViewIfNeeded();
+      await expect
+        .poll(
+          () =>
+            card.evaluate((element) => {
+              for (
+                let node: Element | null = element;
+                node && !node.hasAttribute("data-team-section");
+                node = node.parentElement
+              ) {
+                const opacity = Number(getComputedStyle(node).opacity);
+                if (opacity < 0.99) {
+                  return opacity;
+                }
+              }
+
+              return 1;
+            }),
+          { timeout: 15_000 },
+        )
+        .toBe(1);
+      await expect(card.getByRole("button", { name: "Read bio" })).toBeVisible();
+    }
+  });
+
   test("has no horizontal overflow at mobile, tablet, and desktop widths", async ({
     page,
   }) => {

--- a/src/components/animations/FadeIn.tsx
+++ b/src/components/animations/FadeIn.tsx
@@ -4,6 +4,7 @@ import { motion, type Variants } from "framer-motion";
 import { ReactNode } from "react";
 import {
   defaultScrollViewport,
+  defaultStaggerScrollViewport,
   fadeUpStaggerContainerVariants,
   fadeUpStaggerItemVariants,
   fadeUpVariants,
@@ -75,7 +76,7 @@ export function FadeInStagger({
   className = "",
   staggerDelay = motionDurations.staggerContainer,
   once = true,
-  amount = defaultScrollViewport.amount,
+  amount = defaultStaggerScrollViewport.amount,
 }: FadeInStaggerProps) {
   const containerVariants: Variants =
     fadeUpStaggerContainerVariants(staggerDelay);

--- a/src/components/animations/index.ts
+++ b/src/components/animations/index.ts
@@ -7,4 +7,5 @@ export {
   motionDurations,
   MOTION_EASE,
   defaultScrollViewport,
+  defaultStaggerScrollViewport,
 } from "@/lib/motion/tokens";

--- a/src/lib/motion/__tests__/tokens.test.ts
+++ b/src/lib/motion/__tests__/tokens.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  defaultScrollViewport,
+  defaultStaggerScrollViewport,
+  fadeUpStaggerContainerVariants,
+} from "@/lib/motion/tokens";
+
+describe("scroll-reveal viewport tokens", () => {
+  it("keeps short FadeIn sections on a 20% threshold", () => {
+    expect(defaultScrollViewport).toEqual({ once: true, amount: 0.2 });
+  });
+
+  it("lets tall FadeInStagger grids reveal on any intersection", () => {
+    expect(defaultStaggerScrollViewport).toEqual({
+      once: true,
+      amount: "some",
+    });
+  });
+
+  it("does not hide the stagger container itself", () => {
+    const variants = fadeUpStaggerContainerVariants(0.1);
+
+    expect(variants.hidden).toEqual({});
+    expect(variants.visible).toMatchObject({
+      transition: { staggerChildren: 0.1 },
+    });
+    expect(variants.hidden).not.toHaveProperty("opacity");
+    expect(variants.visible).not.toHaveProperty("opacity");
+  });
+});

--- a/src/lib/motion/tokens.ts
+++ b/src/lib/motion/tokens.ts
@@ -34,6 +34,12 @@ export const defaultScrollViewport = {
   amount: 0.2,
 } as const;
 
+/** Tall stagger grids never reach 20% visibility on mobile; any intersection must trigger. */
+export const defaultStaggerScrollViewport = {
+  once: true,
+  amount: "some",
+} as const;
+
 export type FadeUpOptions = {
   direction?: FadeDirection;
   duration?: number;
@@ -71,9 +77,8 @@ export function fadeUpStaggerContainerVariants(
   staggerDelay: number = motionDurations.staggerContainer
 ): Variants {
   return {
-    hidden: { opacity: 0 },
+    hidden: {},
     visible: {
-      opacity: 1,
       transition: {
         staggerChildren: staggerDelay,
       },


### PR DESCRIPTION
## Summary
- Fixes [#218](https://github.com/akomapahealth/akomapa-health/issues/218): Executive / Team Members / Advisory grids on `/about/team` stayed at `opacity: 0` on phone-width viewports because `FadeInStagger` required 20% of a tall grid in view and hid the whole container until then.
- `FadeInStagger` now uses `amount: "some"` and no longer starts the stagger container at `opacity: 0`, so the first cards can reveal as soon as any part of the grid intersects the viewport.
- Adds a phone-width Playwright check that the first card in each directory section is fully opaque, plus unit coverage for the stagger viewport token.

## Test plan
- [x] Open `/about/team` at ~375px width and confirm Executive, Team Members, and Advisory cards are visible (not a blank page).
- [x] Confirm the first cards still fade in as you scroll, without waiting for 20% of the grid.
- [x] Spot-check desktop `/about/team` so stagger animation still looks the same.
- [x] Run `npx playwright test e2e/team-directory.spec.ts` (or rely on CI) for the new opacity regression.