### PR TITLE
fix(team): mobile hero strip and directory card reveal

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -32,7 +32,12 @@ jobs:
         run: npm ci
 
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps
+        run: |
+          if timeout 8m npx playwright install --with-deps; then
+            exit 0
+          fi
+          echo "Playwright OS dependency install timed out or failed; installing browsers only"
+          npx playwright install
 
       - name: ESLint
         run: npm run lint

--- a/e2e/about-family-editorial.spec.ts
+++ b/e2e/about-family-editorial.spec.ts
@@ -96,6 +96,18 @@ for (const viewport of viewports) {
           element.querySelectorAll<HTMLElement>("[data-team-node-portrait]"),
         );
 
+        const portraitInClip = (portrait: HTMLElement) => {
+          const portraitBox = portrait.getBoundingClientRect();
+          return (
+            portraitBox.width > 0 &&
+            portraitBox.height > 0 &&
+            portraitBox.left >= box.left - 1 &&
+            portraitBox.right <= box.right + 1 &&
+            portraitBox.top >= box.top - 1 &&
+            portraitBox.bottom <= box.bottom + 1
+          );
+        };
+
         const overlapsCopy = Boolean(
           copy &&
             box.left < copy.right &&
@@ -106,20 +118,11 @@ for (const viewport of viewports) {
 
         return {
           copyWidth: copy?.width ?? 0,
-          contained:
-            box.left >= -1 &&
-            box.right <= window.innerWidth + 1 &&
-            portraits.every((portrait) => {
-              const portraitBox = portrait.getBoundingClientRect();
-              return (
-                portraitBox.width > 0 &&
-                portraitBox.height > 0 &&
-                portraitBox.left >= box.left - 1 &&
-                portraitBox.right <= box.right + 1 &&
-                portraitBox.top >= box.top - 1 &&
-                portraitBox.bottom <= box.bottom + 1
-              );
-            }),
+          networkInViewport:
+            box.left >= -1 && box.right <= window.innerWidth + 1,
+          allPortraitsInNetwork: portraits.every(portraitInClip),
+          visiblePortraitCount: portraits.filter(portraitInClip).length,
+          canScroll: element.scrollWidth > element.clientWidth + 1,
           minimumPortraitSize: Math.min(
             ...portraits.map(
               (portrait) => portrait.getBoundingClientRect().width,
@@ -127,12 +130,45 @@ for (const viewport of viewports) {
           ),
           networkWidth: box.width,
           overlapsCopy,
+          portraitCount: portraits.length,
         };
       });
-      expect(networkLayout).toMatchObject({
-        contained: true,
-        overlapsCopy: false,
-      });
+      expect(networkLayout.portraitCount).toBe(22);
+      expect(networkLayout.networkInViewport).toBe(true);
+      expect(networkLayout.overlapsCopy).toBe(false);
+
+      if (viewport.width < 1024) {
+        expect(networkLayout.visiblePortraitCount).toBeGreaterThanOrEqual(1);
+        expect(networkLayout.canScroll).toBe(true);
+
+        await network.evaluate((element) => {
+          element.scrollTo({ left: element.scrollWidth });
+        });
+
+        const lastPortraitIntersectsClip = await network.evaluate(
+          (element) => {
+            const box = element.getBoundingClientRect();
+            const portraits = element.querySelectorAll<HTMLElement>(
+              "[data-team-node-portrait]",
+            );
+            const last = portraits[portraits.length - 1];
+            if (!last) {
+              return false;
+            }
+            const portraitBox = last.getBoundingClientRect();
+            return (
+              portraitBox.left < box.right + 1 &&
+              portraitBox.right > box.left - 1 &&
+              portraitBox.top < box.bottom + 1 &&
+              portraitBox.bottom > box.top - 1
+            );
+          },
+        );
+        expect(lastPortraitIntersectsClip).toBe(true);
+      } else {
+        expect(networkLayout.allPortraitsInNetwork).toBe(true);
+      }
+
       if (viewport.width >= 1536) {
         expect(networkLayout.networkWidth).toBeGreaterThan(
           networkLayout.copyWidth,

--- a/e2e/about-family-editorial.spec.ts
+++ b/e2e/about-family-editorial.spec.ts
@@ -90,7 +90,7 @@ for (const viewport of viewports) {
 
       const networkLayout = await network.evaluate((element) => {
         const box = element.getBoundingClientRect();
-        const grid = element.parentElement;
+        const grid = element.closest("[data-team-hero]");
         const copy = grid?.firstElementChild?.getBoundingClientRect();
         const portraits = Array.from(
           element.querySelectorAll<HTMLElement>("[data-team-node-portrait]"),
@@ -140,6 +140,7 @@ for (const viewport of viewports) {
       if (viewport.width < 1024) {
         expect(networkLayout.visiblePortraitCount).toBeGreaterThanOrEqual(1);
         expect(networkLayout.canScroll).toBe(true);
+        await expect(page.locator("[data-team-node-scroll-hint]")).toBeVisible();
 
         await network.evaluate((element) => {
           element.scrollTo({ left: element.scrollWidth });
@@ -167,6 +168,7 @@ for (const viewport of viewports) {
         expect(lastPortraitIntersectsClip).toBe(true);
       } else {
         expect(networkLayout.allPortraitsInNetwork).toBe(true);
+        await expect(page.locator("[data-team-node-scroll-hint]")).toBeHidden();
       }
 
       if (viewport.width >= 1536) {

--- a/e2e/team-directory.spec.ts
+++ b/e2e/team-directory.spec.ts
@@ -101,6 +101,47 @@ test.describe("team directory hierarchy", () => {
     }
   });
 
+  test("reveals the first card in each directory on a phone-width viewport", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto("/about/team", { waitUntil: "domcontentloaded" });
+
+    const samples = [
+      ["executive", executiveTeamMembers[0].name],
+      ["member", nonExecutiveTeamMembers[0].name],
+      ["advisor", advisoryBoardMembers[0].name],
+    ] as const;
+
+    for (const [category, name] of samples) {
+      const card = page.locator(
+        `[data-team-section="${category}"] [data-team-member="${name}"]`,
+      );
+      await card.scrollIntoViewIfNeeded();
+      await expect
+        .poll(
+          () =>
+            card.evaluate((element) => {
+              for (
+                let node: Element | null = element;
+                node && !node.hasAttribute("data-team-section");
+                node = node.parentElement
+              ) {
+                const opacity = Number(getComputedStyle(node).opacity);
+                if (opacity < 0.99) {
+                  return opacity;
+                }
+              }
+
+              return 1;
+            }),
+          { timeout: 15_000 },
+        )
+        .toBe(1);
+      await expect(card.getByRole("button", { name: "Read bio" })).toBeVisible();
+    }
+  });
+
   test("has no horizontal overflow at mobile, tablet, and desktop widths", async ({
     page,
   }) => {

--- a/src/components/about/TeamPageContent.tsx
+++ b/src/components/about/TeamPageContent.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from "react";
 import Breadcrumb from "@/components/layout/Breadcrumb";
 import Image from "@/components/common/Image";
 import TeamMemberDialog from "@/components/about/TeamMemberDialog";
@@ -79,6 +80,9 @@ const heroRows: Array<{ offset: string; faces: string[] }> = [
   },
 ];
 
+const heroConnectorClassName =
+  "h-px w-3 shrink-0 border-t border-dotted border-[#FCFAEF]/40 sm:w-5 lg:w-6 xl:w-9 2xl:w-12";
+
 const heroStats = [
   { value: "12", label: "Executive Leads" },
   { value: "6", label: "Academic Partners" },
@@ -158,37 +162,41 @@ export default function TeamPageContent() {
           <div
             data-team-node-network
             aria-hidden="true"
-            className="mx-auto flex w-full max-w-md flex-col gap-2 overflow-hidden border-y border-[#FCFAEF]/20 py-5 sm:gap-3 sm:py-7 lg:col-span-7 lg:max-w-none lg:gap-3 lg:border-y-0 lg:border-l lg:py-4 lg:pl-6 xl:gap-4 xl:pl-8 2xl:gap-5 2xl:pl-10"
+            className="mx-auto flex min-w-0 w-full flex-row flex-nowrap items-center gap-1.5 overflow-x-auto overflow-y-hidden overscroll-x-contain border-y border-[#FCFAEF]/20 py-5 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden sm:gap-2 sm:py-7 lg:col-span-7 lg:max-w-none lg:flex-col lg:gap-3 lg:overflow-hidden lg:border-y-0 lg:border-l lg:py-4 lg:pl-6 xl:gap-4 xl:pl-8 2xl:gap-5 2xl:pl-10"
           >
             {heroRows.map((row, rowIndex) => (
-              <div
-                key={`row-${rowIndex}`}
-                className={`flex min-w-0 items-center justify-end gap-1.5 sm:gap-2 ${row.offset}`}
-              >
-                {row.faces.map((face, faceIndex) => (
-                  <div
-                    key={`${face}-${faceIndex}`}
-                    className="flex min-w-0 items-center gap-1.5 sm:gap-2"
-                  >
+              <Fragment key={`row-${rowIndex}`}>
+                <div
+                  className={`flex shrink-0 items-center justify-start gap-1.5 sm:gap-2 lg:min-w-0 lg:w-full lg:justify-end ${row.offset}`}
+                >
+                  {row.faces.map((face, faceIndex) => (
                     <div
-                      data-team-node-portrait
-                      className="relative size-7 shrink-0 overflow-hidden rounded-full border border-[#FCFAEF]/35 bg-[#0F4C5C] sm:size-9 lg:size-10 xl:size-12 2xl:size-16"
+                      key={`${face}-${faceIndex}`}
+                      className="flex shrink-0 items-center gap-1.5 sm:gap-2"
                     >
-                      <Image
-                        src={face}
-                        alt=""
-                        width={64}
-                        height={64}
-                        className="h-full w-full object-cover object-center"
-                        sizes="(max-width: 639px) 28px, (max-width: 1023px) 36px, (max-width: 1279px) 40px, (max-width: 1535px) 48px, 64px"
-                      />
+                      <div
+                        data-team-node-portrait
+                        className="relative size-12 shrink-0 overflow-hidden rounded-full border border-[#FCFAEF]/35 bg-[#0F4C5C] sm:size-14 lg:size-10 xl:size-12 2xl:size-16"
+                      >
+                        <Image
+                          src={face}
+                          alt=""
+                          width={64}
+                          height={64}
+                          className="h-full w-full object-cover object-center"
+                          sizes="(max-width: 639px) 48px, (max-width: 1023px) 56px, (max-width: 1279px) 40px, (max-width: 1535px) 48px, 64px"
+                        />
+                      </div>
+                      {faceIndex !== row.faces.length - 1 ? (
+                        <span className={heroConnectorClassName} />
+                      ) : null}
                     </div>
-                    {faceIndex !== row.faces.length - 1 ? (
-                      <span className="h-px w-3 shrink-0 border-t border-dotted border-[#FCFAEF]/40 sm:w-5 lg:w-6 xl:w-9 2xl:w-12" />
-                    ) : null}
-                  </div>
-                ))}
-              </div>
+                  ))}
+                </div>
+                {rowIndex !== heroRows.length - 1 ? (
+                  <span className={`${heroConnectorClassName} lg:hidden`} />
+                ) : null}
+              </Fragment>
             ))}
           </div>
         </div>

--- a/src/components/about/TeamPageContent.tsx
+++ b/src/components/about/TeamPageContent.tsx
@@ -101,7 +101,10 @@ export default function TeamPageContent() {
         aria-labelledby="team-hero-heading"
         className="border-b border-[#FCFAEF]/20 bg-[#0F4C5C]"
       >
-        <div className="grid gap-12 lg:grid-cols-12 lg:items-center lg:gap-6 xl:gap-8 2xl:gap-12">
+        <div
+          data-team-hero
+          className="grid gap-12 lg:grid-cols-12 lg:items-center lg:gap-6 xl:gap-8 2xl:gap-12"
+        >
           <div className="lg:col-span-5">
             <EditorialEyebrow tone="light">
               A team of young leaders for young people
@@ -159,45 +162,52 @@ export default function TeamPageContent() {
             </div>
           </div>
 
-          <div
-            data-team-node-network
-            aria-hidden="true"
-            className="mx-auto flex min-w-0 w-full flex-row flex-nowrap items-center gap-1.5 overflow-x-auto overflow-y-hidden overscroll-x-contain border-y border-[#FCFAEF]/20 py-5 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden sm:gap-2 sm:py-7 lg:col-span-7 lg:max-w-none lg:flex-col lg:gap-3 lg:overflow-hidden lg:border-y-0 lg:border-l lg:py-4 lg:pl-6 xl:gap-4 xl:pl-8 2xl:gap-5 2xl:pl-10"
-          >
-            {heroRows.map((row, rowIndex) => (
-              <Fragment key={`row-${rowIndex}`}>
-                <div
-                  className={`flex shrink-0 items-center justify-start gap-1.5 sm:gap-2 lg:min-w-0 lg:w-full lg:justify-end ${row.offset}`}
-                >
-                  {row.faces.map((face, faceIndex) => (
-                    <div
-                      key={`${face}-${faceIndex}`}
-                      className="flex shrink-0 items-center gap-1.5 sm:gap-2"
-                    >
+          <div className="relative mx-auto min-w-0 w-full lg:col-span-7">
+            <div
+              data-team-node-network
+              aria-hidden="true"
+              className="flex min-w-0 w-full flex-row flex-nowrap items-center gap-1.5 overflow-x-auto overflow-y-hidden overscroll-x-contain border-y border-[#FCFAEF]/20 py-5 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden sm:gap-2 sm:py-7 lg:flex-col lg:gap-3 lg:overflow-hidden lg:border-y-0 lg:border-l lg:py-4 lg:pl-6 xl:gap-4 xl:pl-8 2xl:gap-5 2xl:pl-10"
+            >
+              {heroRows.map((row, rowIndex) => (
+                <Fragment key={`row-${rowIndex}`}>
+                  <div
+                    className={`flex shrink-0 items-center justify-start gap-1.5 sm:gap-2 lg:min-w-0 lg:w-full lg:justify-end ${row.offset}`}
+                  >
+                    {row.faces.map((face, faceIndex) => (
                       <div
-                        data-team-node-portrait
-                        className="relative size-12 shrink-0 overflow-hidden rounded-full border border-[#FCFAEF]/35 bg-[#0F4C5C] sm:size-14 lg:size-10 xl:size-12 2xl:size-16"
+                        key={`${face}-${faceIndex}`}
+                        className="flex shrink-0 items-center gap-1.5 sm:gap-2"
                       >
-                        <Image
-                          src={face}
-                          alt=""
-                          width={64}
-                          height={64}
-                          className="h-full w-full object-cover object-center"
-                          sizes="(max-width: 639px) 48px, (max-width: 1023px) 56px, (max-width: 1279px) 40px, (max-width: 1535px) 48px, 64px"
-                        />
+                        <div
+                          data-team-node-portrait
+                          className="relative size-12 shrink-0 overflow-hidden rounded-full border border-[#FCFAEF]/35 bg-[#0F4C5C] sm:size-14 lg:size-10 xl:size-12 2xl:size-16"
+                        >
+                          <Image
+                            src={face}
+                            alt=""
+                            width={64}
+                            height={64}
+                            className="h-full w-full object-cover object-center"
+                            sizes="(max-width: 639px) 48px, (max-width: 1023px) 56px, (max-width: 1279px) 40px, (max-width: 1535px) 48px, 64px"
+                          />
+                        </div>
+                        {faceIndex !== row.faces.length - 1 ? (
+                          <span className={heroConnectorClassName} />
+                        ) : null}
                       </div>
-                      {faceIndex !== row.faces.length - 1 ? (
-                        <span className={heroConnectorClassName} />
-                      ) : null}
-                    </div>
-                  ))}
-                </div>
-                {rowIndex !== heroRows.length - 1 ? (
-                  <span className={`${heroConnectorClassName} lg:hidden`} />
-                ) : null}
-              </Fragment>
-            ))}
+                    ))}
+                  </div>
+                  {rowIndex !== heroRows.length - 1 ? (
+                    <span className={`${heroConnectorClassName} lg:hidden`} />
+                  ) : null}
+                </Fragment>
+              ))}
+            </div>
+            <span
+              data-team-node-scroll-hint
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-y-0 right-0 z-10 w-9 bg-gradient-to-l from-[#0F4C5C] via-[#0F4C5C]/50 to-transparent sm:w-11 lg:hidden"
+            />
           </div>
         </div>
       </EditorialBand>

--- a/src/components/about/__tests__/TeamPageContent.test.tsx
+++ b/src/components/about/__tests__/TeamPageContent.test.tsx
@@ -17,8 +17,13 @@ describe("TeamPageContent", () => {
       "min-w-0",
       "overflow-x-auto",
       "lg:flex-col",
-      "lg:col-span-7",
     );
+    expect(
+      container.querySelector("[data-team-node-network]")?.parentElement,
+    ).toHaveClass("lg:col-span-7");
+    expect(
+      container.querySelector("[data-team-node-scroll-hint]"),
+    ).toHaveClass("pointer-events-none", "lg:hidden");
     expect(screen.getByText("Executive Team")).toBeInTheDocument();
     expect(screen.getByText("Team Members")).toBeInTheDocument();
     expect(screen.getByText("Advisory Board")).toBeInTheDocument();

--- a/src/components/about/__tests__/TeamPageContent.test.tsx
+++ b/src/components/about/__tests__/TeamPageContent.test.tsx
@@ -14,6 +14,9 @@ describe("TeamPageContent", () => {
       container.querySelector("[data-team-node-network]"),
     ).toHaveAttribute("aria-hidden", "true");
     expect(container.querySelector("[data-team-node-network]")).toHaveClass(
+      "min-w-0",
+      "overflow-x-auto",
+      "lg:flex-col",
       "lg:col-span-7",
     );
     expect(screen.getByText("Executive Team")).toBeInTheDocument();

--- a/src/components/animations/FadeIn.tsx
+++ b/src/components/animations/FadeIn.tsx
@@ -4,6 +4,7 @@ import { motion, type Variants } from "framer-motion";
 import { ReactNode } from "react";
 import {
   defaultScrollViewport,
+  defaultStaggerScrollViewport,
   fadeUpStaggerContainerVariants,
   fadeUpStaggerItemVariants,
   fadeUpVariants,
@@ -75,7 +76,7 @@ export function FadeInStagger({
   className = "",
   staggerDelay = motionDurations.staggerContainer,
   once = true,
-  amount = defaultScrollViewport.amount,
+  amount = defaultStaggerScrollViewport.amount,
 }: FadeInStaggerProps) {
   const containerVariants: Variants =
     fadeUpStaggerContainerVariants(staggerDelay);

--- a/src/components/animations/index.ts
+++ b/src/components/animations/index.ts
@@ -7,4 +7,5 @@ export {
   motionDurations,
   MOTION_EASE,
   defaultScrollViewport,
+  defaultStaggerScrollViewport,
 } from "@/lib/motion/tokens";

--- a/src/lib/motion/__tests__/tokens.test.ts
+++ b/src/lib/motion/__tests__/tokens.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  defaultScrollViewport,
+  defaultStaggerScrollViewport,
+  fadeUpStaggerContainerVariants,
+} from "@/lib/motion/tokens";
+
+describe("scroll-reveal viewport tokens", () => {
+  it("keeps short FadeIn sections on a 20% threshold", () => {
+    expect(defaultScrollViewport).toEqual({ once: true, amount: 0.2 });
+  });
+
+  it("lets tall FadeInStagger grids reveal on any intersection", () => {
+    expect(defaultStaggerScrollViewport).toEqual({
+      once: true,
+      amount: "some",
+    });
+  });
+
+  it("does not hide the stagger container itself", () => {
+    const variants = fadeUpStaggerContainerVariants(0.1);
+
+    expect(variants.hidden).toEqual({});
+    expect(variants.visible).toMatchObject({
+      transition: { staggerChildren: 0.1 },
+    });
+    expect(variants.hidden).not.toHaveProperty("opacity");
+    expect(variants.visible).not.toHaveProperty("opacity");
+  });
+});

--- a/src/lib/motion/tokens.ts
+++ b/src/lib/motion/tokens.ts
@@ -34,6 +34,12 @@ export const defaultScrollViewport = {
   amount: 0.2,
 } as const;
 
+/** Tall stagger grids never reach 20% visibility on mobile; any intersection must trigger. */
+export const defaultStaggerScrollViewport = {
+  once: true,
+  amount: "some",
+} as const;
+
 export type FadeUpOptions = {
   direction?: FadeDirection;
   duration?: number;
@@ -71,9 +77,8 @@ export function fadeUpStaggerContainerVariants(
   staggerDelay: number = motionDurations.staggerContainer
 ): Variants {
   return {
-    hidden: { opacity: 0 },
+    hidden: {},
     visible: {
-      opacity: 1,
       transition: {
         staggerChildren: staggerDelay,
       },


### PR DESCRIPTION
## Summary
- Related to [#218](https://github.com/akomapahealth/akomapa-health/issues/218): below `lg`, the 22-portrait hero network is a contained, left-aligned, horizontally scrollable strip with larger faces and dotted connectors. The 7-row staircase is unchanged at `lg+`.
- Restores the directory fade-in fix on this branch: `FadeInStagger` uses `amount: "some"` and no longer starts the stagger container at `opacity: 0`, so Executive / Team Members / Advisory cards reveal on phone-width viewports.
- Overlaps [PR #219](https://github.com/akomapahealth/akomapa-health/pull/219) on the animation tokens. Merge either first; the leftover animation hunks should then be empty or trivial.

## Test plan
- [x] Open `/about/team` at ~375px and ~768px: hero faces scroll inside the band (no page scrollbar); first cards in each directory are visible, not blank.
- [x] Open `/about/team` at `lg` and above: staircase layout and portrait sizes match current desktop.
- [x] Run `npx playwright test e2e/team-directory.spec.ts e2e/about-family-editorial.spec.ts --project=chromium` (or rely on CI).